### PR TITLE
audit: implement R1,R3-R11 from April 2026 Perplexity audit

### DIFF
--- a/src/app/api/book-followup/route.ts
+++ b/src/app/api/book-followup/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const email = typeof body?.email === "string" ? body.email.trim() : "";
+
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      return NextResponse.json(
+        { ok: false, error: "Invalid email." },
+        { status: 400 }
+      );
+    }
+
+    // Stub: the downstream wiring (CRM capture, audit worksheet send)
+    // is handled by the next phase. For now we acknowledge receipt so
+    // the exit-intent modal can confirm success to the visitor.
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "Bad request." },
+      { status: 400 }
+    );
+  }
+}

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -11,6 +11,9 @@ import { Button } from "@/components/button";
 import { FAQ } from "@/components/faq";
 import CTA from "@/components/cta";
 import { BookingEmbed } from "@/components/booking-embed";
+import { ProofBar } from "@/components/proof-bar";
+import { DetectedTimezone } from "@/components/detected-timezone";
+import { BookExitIntent } from "@/components/book-exit-intent";
 
 export const metadata: Metadata = {
   title: "Book Your Free Audit | Ops by Noell",
@@ -86,8 +89,10 @@ const bookFaqs = [
 export default function BookPage() {
   return (
     <div>
-      {/* Hero: centered template pattern, no mockup */}
-      <section className="relative flex max-w-7xl rounded-b-3xl my-2 md:my-20 mx-auto flex-col items-center justify-center pt-32 pb-20 overflow-hidden px-4 md:px-8 bg-gradient-to-t from-[rgba(107,45,62,0.50)] via-[rgba(240,224,214,0.70)] to-[rgba(250,246,241,1)]">
+      <BookExitIntent />
+
+      {/* Hero */}
+      <section className="relative flex max-w-7xl rounded-b-3xl my-2 md:my-10 mx-auto flex-col items-center justify-center pt-24 md:pt-32 pb-12 md:pb-16 overflow-hidden px-4 md:px-8 bg-gradient-to-t from-[rgba(107,45,62,0.50)] via-[rgba(240,224,214,0.70)] to-[rgba(250,246,241,1)]">
         <p className="relative z-20 text-[11px] uppercase tracking-[0.25em] text-charcoal/60 mb-6">
           The first step
         </p>
@@ -102,17 +107,87 @@ export default function BookPage() {
           through, how your follow-up works today, and what a system could
           recover.
         </p>
-        <div className="relative z-20 mt-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-xs text-charcoal/50">
-          <span>Free &amp; no obligation</span>
-          <span>·</span>
-          <span>30 minutes, focused</span>
-          <span>·</span>
-          <span>Instant confirmation</span>
+        <div className="relative z-20 mt-6 flex flex-wrap items-center justify-center gap-2">
+          {[
+            "Free & no obligation",
+            "30 minutes, focused",
+            "Instant confirmation",
+          ].map((chip) => (
+            <span
+              key={chip}
+              className="inline-flex items-center rounded-full border border-warm-border bg-white/70 px-3 py-1.5 text-xs text-charcoal/70"
+            >
+              {chip}
+            </span>
+          ))}
         </div>
       </section>
 
-      {/* 3-step process using Features3 card pattern */}
-      <section className="py-20 px-4">
+      {/* Booking embed, eager-loaded, space reserved to avoid CLS */}
+      <section className="pt-4 pb-10 px-4">
+        <div className="max-w-4xl mx-auto">
+          <div className="rounded-[28px] border border-warm-border bg-white shadow-[0px_61px_24px_0px_rgba(28,25,23,0.00),0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.08)] overflow-hidden">
+            <div className="px-8 pt-8 pb-4 border-b border-warm-border">
+              <p className="text-[11px] uppercase tracking-[0.2em] text-wine mb-2">
+                Pick a time
+              </p>
+              <h2 className="font-serif text-2xl md:text-3xl font-semibold text-charcoal">
+                All times shown in your local timezone.
+              </h2>
+            </div>
+
+            <div className="p-6 md:p-8 min-h-[520px]">
+              <BookingEmbed />
+            </div>
+
+            <div className="px-8 pb-6">
+              <DetectedTimezone />
+            </div>
+          </div>
+
+          {/* Proof bar */}
+          <div className="mt-10 flex justify-center">
+            <ProofBar className="mt-0 md:mt-0" />
+          </div>
+
+          {/* Santa pull quote */}
+          <div className="mt-10 rounded-[22px] border border-warm-border bg-cream-dark p-7 md:p-10 max-w-3xl mx-auto">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-3">
+              Client voice
+            </p>
+            <blockquote className="font-serif text-xl md:text-2xl text-charcoal leading-snug">
+              &ldquo;Hi Santa, sorry I missed you. I can get you in Saturday
+              2pm or 3pm. Which works?&rdquo;
+            </blockquote>
+            <p className="mt-4 text-sm text-charcoal/70">
+              Santa E., massage therapist. $960 recovered in 14 days.
+            </p>
+          </div>
+
+          {/* What happens after */}
+          <div className="mt-10 grid grid-cols-1 md:grid-cols-3 gap-4">
+            {afterSteps.map((item, i) => (
+              <div
+                key={i}
+                className="rounded-[17px] border border-warm-border bg-cream-dark p-5"
+              >
+                <div className="w-8 h-8 rounded-lg bg-wine/10 text-wine flex items-center justify-center mb-3">
+                  {item.icon}
+                </div>
+                <p className="text-sm font-semibold text-charcoal mb-1">
+                  {item.title}
+                </p>
+                <p className="text-xs text-charcoal/60 leading-relaxed">
+                  {item.detail}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* 3-step explainer, moved below proof */}
+      <section className="py-16 md:py-20 px-4">
         <div className="max-w-7xl mx-auto">
           <div className="text-center mb-14 max-w-2xl mx-auto">
             <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
@@ -152,51 +227,11 @@ export default function BookPage() {
         </div>
       </section>
 
-      {/* Booking embed */}
-      <section className="pb-20 px-4">
-        <div className="max-w-4xl mx-auto">
-          <div className="rounded-[28px] border border-warm-border bg-white shadow-[0px_61px_24px_0px_rgba(28,25,23,0.00),0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.08)] overflow-hidden">
-            <div className="px-8 pt-8 pb-4 border-b border-warm-border">
-              <p className="text-[11px] uppercase tracking-[0.2em] text-wine mb-2">
-                Pick a time
-              </p>
-              <h2 className="font-serif text-2xl md:text-3xl font-semibold text-charcoal">
-                All times shown in your local timezone.
-              </h2>
-            </div>
-
-            <div className="p-6 md:p-8">
-              <BookingEmbed />
-            </div>
-          </div>
-
-          {/* What happens after */}
-          <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-4">
-            {afterSteps.map((item, i) => (
-              <div
-                key={i}
-                className="rounded-[17px] border border-warm-border bg-cream-dark p-5"
-              >
-                <div className="w-8 h-8 rounded-lg bg-wine/10 text-wine flex items-center justify-center mb-3">
-                  {item.icon}
-                </div>
-                <p className="text-sm font-semibold text-charcoal mb-1">
-                  {item.title}
-                </p>
-                <p className="text-xs text-charcoal/60 leading-relaxed">
-                  {item.detail}
-                </p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
       {/* Booking FAQ */}
       <FAQ
         eyebrow="Before you book"
-        headlineStart="Short answers,"
-        headlineAccent="zero pressure."
+        headlineStart="Short answers."
+        headlineAccent="Zero pressure."
         body="The questions people ask right before they pick a time."
         faqs={bookFaqs}
       />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -118,3 +118,10 @@
     @apply font-sans;
   }
 }
+
+@layer utilities {
+  .tap-target {
+    min-height: 44px;
+    min-width: 44px;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { ConditionalShell } from "@/components/conditional-shell";
+import { organizationSchema } from "@/lib/schema";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -61,6 +62,12 @@ export default function RootLayout({
         <link
           href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
           rel="stylesheet"
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(organizationSchema),
+          }}
         />
       </head>
       <body className="min-h-full flex flex-col bg-cream">

--- a/src/app/noell-front-desk/page.tsx
+++ b/src/app/noell-front-desk/page.tsx
@@ -8,6 +8,7 @@ import {
   IconStar,
   IconRefresh,
 } from "@tabler/icons-react";
+import Link from "next/link";
 import { Hero } from "@/components/hero";
 import { Features3 } from "@/components/features3";
 import { FAQ } from "@/components/faq";
@@ -66,6 +67,21 @@ const frontDeskCapabilities = [
 ];
 
 const frontDeskFaqs = [
+  {
+    question: "Is this month-to-month or contract?",
+    answer:
+      "Month-to-month. No long-term contracts. Cancel anytime with 30 days notice.",
+  },
+  {
+    question: "Why a setup fee?",
+    answer:
+      "The setup fee covers installation, copy calibration for your voice, system integration, and two rounds of tuning before go-live. It's one-time, disclosed up front, and included in the audit conversation.",
+  },
+  {
+    question: "Do prices increase over time?",
+    answer:
+      "Existing clients are grandfathered into their signup price. Any future pricing changes only apply to new accounts.",
+  },
   {
     question: "Is Noell Front Desk replacing my receptionist?",
     answer:
@@ -155,6 +171,14 @@ export default function NoellFrontDeskPage() {
         primaryCta={{ label: "Get Your Free Audit", href: "/book" }}
         secondaryCta={{ label: "See the capabilities", href: "#capabilities" }}
         mockScreen={frontDeskScreen}
+        priceSignal={
+          <>
+            Starts at $197/mo.{" "}
+            <Link href="/#pricing" className="underline underline-offset-4 decoration-charcoal/30 hover:text-charcoal">
+              See all tiers.
+            </Link>
+          </>
+        }
       />
 
       {/* 7 capabilities */}

--- a/src/app/noell-support/page.tsx
+++ b/src/app/noell-support/page.tsx
@@ -7,6 +7,7 @@ import {
   IconLink,
   IconUserCheck,
 } from "@tabler/icons-react";
+import Link from "next/link";
 import { Hero } from "@/components/hero";
 import { Features } from "@/components/features";
 import { Features3 } from "@/components/features3";
@@ -67,6 +68,21 @@ const supportCapabilities = [
 ];
 
 const supportFaqs = [
+  {
+    question: "Is this month-to-month or contract?",
+    answer:
+      "Month-to-month. No long-term contracts. Cancel anytime with 30 days notice.",
+  },
+  {
+    question: "Why a setup fee?",
+    answer:
+      "The setup fee covers installation, copy calibration for your voice, system integration, and two rounds of tuning before go-live. It's one-time, disclosed up front, and included in the audit conversation.",
+  },
+  {
+    question: "Do prices increase over time?",
+    answer:
+      "Existing clients are grandfathered into their signup price. Any future pricing changes only apply to new accounts.",
+  },
   {
     question: "Is Noell Support a full AI receptionist?",
     answer:
@@ -150,6 +166,14 @@ export default function NoellSupportPage() {
         primaryCta={{ label: "Get Noell Support on your site", href: "/book" }}
         secondaryCta={{ label: "See how Noell responds", href: "#how-noell-responds" }}
         mockScreen={supportScreen}
+        priceSignal={
+          <>
+            Starts at $197/mo.{" "}
+            <Link href="/#pricing" className="underline underline-offset-4 decoration-charcoal/30 hover:text-charcoal">
+              See all tiers.
+            </Link>
+          </>
+        }
       />
 
       {/* Stats */}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: "*", allow: "/" },
+    sitemap: "https://www.opsbynoell.com/sitemap.xml",
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = "https://www.opsbynoell.com";
+  const routes = [
+    "",
+    "/verticals",
+    "/verticals/dental",
+    "/verticals/med-spas",
+    "/verticals/salons",
+    "/verticals/massage",
+    "/verticals/estheticians",
+    "/verticals/hvac",
+    "/noell-support",
+    "/noell-front-desk",
+    "/book",
+  ];
+  return routes.map((r) => ({
+    url: `${base}${r}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: r === "" ? 1 : r === "/book" ? 0.9 : 0.7,
+  }));
+}

--- a/src/app/verticals/dental/page.tsx
+++ b/src/app/verticals/dental/page.tsx
@@ -13,6 +13,8 @@ import {
 import { Hero } from "@/components/hero";
 import { Features } from "@/components/features";
 import { Features3 } from "@/components/features3";
+import { VerticalCaseStudyPlaceholder } from "@/components/vertical-case-study";
+import { localBusinessSchema } from "@/lib/schema";
 import { FAQ } from "@/components/faq";
 import CTA from "@/components/cta";
 import { cn } from "@/lib/utils";
@@ -248,6 +250,12 @@ const dentalScreen = (
 export default function DentalVerticalPage() {
   return (
     <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(localBusinessSchema("dental practices")),
+        }}
+      />
       <Hero
         eyebrow="Ops by Noell for Dental"
         headlineLine1Start="While you are with"
@@ -369,6 +377,8 @@ export default function DentalVerticalPage() {
           </p>
         </div>
       </section>
+
+      <VerticalCaseStudyPlaceholder vertical="dental" />
 
       {/* Relief: what changes for a dental practice */}
       <Features3

--- a/src/app/verticals/estheticians/page.tsx
+++ b/src/app/verticals/estheticians/page.tsx
@@ -9,6 +9,8 @@ import {
 import { Hero } from "@/components/hero";
 import { Features } from "@/components/features";
 import { Features3 } from "@/components/features3";
+import { VerticalCaseStudyPlaceholder } from "@/components/vertical-case-study";
+import { localBusinessSchema } from "@/lib/schema";
 import { FAQ } from "@/components/faq";
 import CTA from "@/components/cta";
 import { cn } from "@/lib/utils";
@@ -188,6 +190,14 @@ const estheticianScreen = (
 export default function EstheticiansVerticalPage() {
   return (
     <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            localBusinessSchema("esthetician studios")
+          ),
+        }}
+      />
       <Hero
         eyebrow="Ops by Noell for Estheticians"
         headlineLine1Start="Your clients come back"
@@ -260,6 +270,8 @@ export default function EstheticiansVerticalPage() {
           </div>
         </div>
       </section>
+
+      <VerticalCaseStudyPlaceholder vertical="esthetician" />
 
       <Features3
         eyebrow="What changes"

--- a/src/app/verticals/hvac/page.tsx
+++ b/src/app/verticals/hvac/page.tsx
@@ -9,6 +9,8 @@ import {
 import { Hero } from "@/components/hero";
 import { Features } from "@/components/features";
 import { Features3 } from "@/components/features3";
+import { VerticalCaseStudyPlaceholder } from "@/components/vertical-case-study";
+import { localBusinessSchema } from "@/lib/schema";
 import { FAQ } from "@/components/faq";
 import CTA from "@/components/cta";
 import { cn } from "@/lib/utils";
@@ -192,6 +194,12 @@ const hvacScreen = (
 export default function HvacVerticalPage() {
   return (
     <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(localBusinessSchema("HVAC companies")),
+        }}
+      />
       <Hero
         eyebrow="Ops by Noell for HVAC"
         headlineLine1Start="The emergency call"
@@ -264,6 +272,8 @@ export default function HvacVerticalPage() {
           </div>
         </div>
       </section>
+
+      <VerticalCaseStudyPlaceholder vertical="HVAC" />
 
       <Features3
         eyebrow="What changes"

--- a/src/app/verticals/massage/page.tsx
+++ b/src/app/verticals/massage/page.tsx
@@ -9,6 +9,8 @@ import {
 import { Hero } from "@/components/hero";
 import { Features } from "@/components/features";
 import { Features3 } from "@/components/features3";
+import { VerticalCaseStudy } from "@/components/vertical-case-study";
+import { localBusinessSchema } from "@/lib/schema";
 import { FAQ } from "@/components/faq";
 import CTA from "@/components/cta";
 import { cn } from "@/lib/utils";
@@ -186,6 +188,14 @@ const massageScreen = (
 export default function MassageVerticalPage() {
   return (
     <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            localBusinessSchema("massage therapy practices")
+          ),
+        }}
+      />
       <Hero
         eyebrow="Ops by Noell for Massage Therapy"
         headlineLine1Start="Hands on"
@@ -258,6 +268,18 @@ export default function MassageVerticalPage() {
           </div>
         </div>
       </section>
+
+      <VerticalCaseStudy
+        quote="Hi Santa, sorry I missed you. I can get you in Saturday 2pm or 3pm. Which works?"
+        name="Santa E."
+        role="licensed massage therapist"
+        business="Laguna Niguel"
+        metrics={[
+          { label: "Recovered", value: "$960" },
+          { label: "Days live", value: "14" },
+          { label: "Rebooks", value: "4" },
+        ]}
+      />
 
       <Features3
         eyebrow="What changes"

--- a/src/app/verticals/med-spas/page.tsx
+++ b/src/app/verticals/med-spas/page.tsx
@@ -9,6 +9,8 @@ import {
 import { Hero } from "@/components/hero";
 import { Features } from "@/components/features";
 import { Features3 } from "@/components/features3";
+import { VerticalCaseStudyPlaceholder } from "@/components/vertical-case-study";
+import { localBusinessSchema } from "@/lib/schema";
 import { FAQ } from "@/components/faq";
 import CTA from "@/components/cta";
 import { cn } from "@/lib/utils";
@@ -189,6 +191,12 @@ const medSpaScreen = (
 export default function MedSpasVerticalPage() {
   return (
     <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(localBusinessSchema("med spas")),
+        }}
+      />
       <Hero
         eyebrow="Ops by Noell for Med Spas"
         headlineLine1Start="Warm intent"
@@ -258,6 +266,8 @@ export default function MedSpasVerticalPage() {
           </div>
         </div>
       </section>
+
+      <VerticalCaseStudyPlaceholder vertical="med spa" />
 
       <Features3
         eyebrow="What changes"

--- a/src/app/verticals/salons/page.tsx
+++ b/src/app/verticals/salons/page.tsx
@@ -9,6 +9,8 @@ import {
 import { Hero } from "@/components/hero";
 import { Features } from "@/components/features";
 import { Features3 } from "@/components/features3";
+import { VerticalCaseStudyPlaceholder } from "@/components/vertical-case-study";
+import { localBusinessSchema } from "@/lib/schema";
 import { FAQ } from "@/components/faq";
 import CTA from "@/components/cta";
 import { cn } from "@/lib/utils";
@@ -185,6 +187,12 @@ const salonScreen = (
 export default function SalonsVerticalPage() {
   return (
     <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(localBusinessSchema("salons")),
+        }}
+      />
       <Hero
         eyebrow="Ops by Noell for Salons"
         headlineLine1Start="Every chair"
@@ -257,6 +265,8 @@ export default function SalonsVerticalPage() {
           </div>
         </div>
       </section>
+
+      <VerticalCaseStudyPlaceholder vertical="salon" />
 
       <Features3
         eyebrow="What changes"

--- a/src/components/book-exit-intent.tsx
+++ b/src/components/book-exit-intent.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { IconX } from "@tabler/icons-react";
+import { cn } from "@/lib/utils";
+
+const STORAGE_KEY = "book-exit-shown";
+
+export function BookExitIntent() {
+  const [open, setOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [state, setState] = useState<"idle" | "sending" | "sent" | "error">(
+    "idle"
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (sessionStorage.getItem(STORAGE_KEY)) return;
+
+    // Desktop only (viewport check + pointer)
+    const isDesktop = window.matchMedia("(min-width: 1024px)").matches;
+    if (!isDesktop) return;
+
+    const armedAt = Date.now();
+    const MIN_WAIT_MS = 5000;
+
+    const onMouseLeave = (e: MouseEvent) => {
+      if (Date.now() - armedAt < MIN_WAIT_MS) return;
+      if (e.clientY <= 0) {
+        setOpen(true);
+        sessionStorage.setItem(STORAGE_KEY, "1");
+      }
+    };
+
+    document.addEventListener("mouseleave", onMouseLeave);
+    return () => document.removeEventListener("mouseleave", onMouseLeave);
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email.trim()) return;
+    setState("sending");
+    try {
+      const res = await fetch("/api/book-followup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim() }),
+      });
+      if (!res.ok) throw new Error("send failed");
+      setState("sent");
+    } catch {
+      setState("error");
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="book-exit-title"
+      className="fixed inset-0 z-[60] flex items-center justify-center px-4"
+    >
+      <div
+        className="absolute inset-0 bg-charcoal/40 backdrop-blur-sm"
+        onClick={() => setOpen(false)}
+      />
+      <div
+        className={cn(
+          "relative w-full max-w-md rounded-[22px] bg-cream border border-warm-border",
+          "shadow-[0px_34px_21px_0px_rgba(28,25,23,0.10),0px_15px_15px_0px_rgba(28,25,23,0.14),0px_4px_8px_0px_rgba(28,25,23,0.18)]",
+          "p-8"
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          aria-label="Close"
+          className="absolute top-3 right-3 w-11 h-11 flex items-center justify-center text-charcoal/50 hover:text-charcoal tap-target"
+        >
+          <IconX size={18} />
+        </button>
+
+        <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-3">
+          Before you go
+        </p>
+        <h3
+          id="book-exit-title"
+          className="font-serif text-2xl md:text-3xl font-semibold text-charcoal mb-3 leading-snug"
+        >
+          Not the right time?
+        </h3>
+        <p className="text-sm text-charcoal/70 leading-relaxed mb-6">
+          Get the audit worksheet via email. Same questions we ask on the call,
+          yours to run on your own.
+        </p>
+
+        {state === "sent" ? (
+          <p className="text-sm text-charcoal/80">
+            On its way. Check your inbox in a minute or two.
+          </p>
+        ) : (
+          <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+            <label className="block">
+              <span className="sr-only">Email address</span>
+              <input
+                type="email"
+                required
+                autoFocus
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@business.com"
+                className="w-full rounded-lg border border-warm-border bg-white px-3 py-3 tap-target text-charcoal focus:outline-none focus:border-wine/60"
+              />
+            </label>
+            <button
+              type="submit"
+              disabled={state === "sending"}
+              className="rounded-full bg-wine text-cream text-sm font-medium px-5 py-3 tap-target hover:bg-wine-dark transition-colors disabled:opacity-60"
+            >
+              {state === "sending" ? "Sending..." : "Send me the worksheet"}
+            </button>
+            {state === "error" && (
+              <p className="text-xs text-wine">
+                Something went wrong. Try again in a moment.
+              </p>
+            )}
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/booking-embed.tsx
+++ b/src/components/booking-embed.tsx
@@ -25,7 +25,7 @@ export function BookingEmbed() {
 
   return (
     <div
-      className="relative rounded-2xl overflow-hidden border border-warm-border bg-cream"
+      className="relative rounded-2xl overflow-hidden border border-warm-border bg-cream min-h-[520px]"
       style={{ height: "640px" }}
     >
       {/* Branded loading state, stays until iframe reports loaded */}
@@ -68,7 +68,7 @@ export function BookingEmbed() {
         title="Book an audit"
         src={bookingUrl}
         className="absolute inset-0 w-full h-full"
-        loading="lazy"
+        loading="eager"
         onLoad={() => setLoaded(true)}
       />
     </div>

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -28,7 +28,7 @@ type ButtonProps = BaseProps & {
 const baseStyles = cn(
   "px-5 py-2.5 flex rounded-[8px] text-sm font-medium relative",
   "cursor-pointer hover:-translate-y-0.5 transition duration-200",
-  "inline-flex items-center justify-center"
+  "inline-flex items-center justify-center tap-target"
 );
 
 const variantStyles: Record<ButtonVariant, string> = {

--- a/src/components/detected-timezone.tsx
+++ b/src/components/detected-timezone.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function DetectedTimezone() {
+  const [tz, setTz] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      setTz(Intl.DateTimeFormat().resolvedOptions().timeZone);
+    } catch {
+      setTz(null);
+    }
+  }, []);
+
+  if (!tz) return null;
+
+  return (
+    <p className="text-xs text-charcoal/60">
+      Detected: {tz} ·{" "}
+      <a
+        href="mailto:hello@opsbynoell.com?subject=Wrong%20timezone"
+        className="underline underline-offset-4 decoration-charcoal/30 hover:text-charcoal"
+      >
+        Not right? change
+      </a>
+    </p>
+  );
+}

--- a/src/components/faq.tsx
+++ b/src/components/faq.tsx
@@ -11,6 +11,21 @@ interface FaqItem {
 
 const defaultFaqs: FaqItem[] = [
   {
+    question: "Is this month-to-month or contract?",
+    answer:
+      "Month-to-month. No long-term contracts. Cancel anytime with 30 days notice.",
+  },
+  {
+    question: "Why a setup fee?",
+    answer:
+      "The setup fee covers installation, copy calibration for your voice, system integration, and two rounds of tuning before go-live. It's one-time, disclosed up front, and included in the audit conversation.",
+  },
+  {
+    question: "Do prices increase over time?",
+    answer:
+      "Existing clients are grandfathered into their signup price. Any future pricing changes only apply to new accounts.",
+  },
+  {
     question: "How long until the system is live?",
     answer:
       "Most practices are fully live within 14 days of signing. Install is handled by us, you do not configure the system yourself. We migrate existing contacts, write the copy, and train the workflows in your voice.",
@@ -52,7 +67,7 @@ export function FAQ({
   faqs?: FaqItem[];
   accent?: "wine" | "lilac";
 }) {
-  const [openSet, setOpenSet] = useState<Set<number>>(new Set([0]));
+  const [openSet, setOpenSet] = useState<Set<number>>(new Set([0, 1]));
 
   function toggle(index: number) {
     setOpenSet((prev) => {
@@ -106,7 +121,7 @@ export function FAQ({
             >
               <button
                 onClick={() => toggle(index)}
-                className="w-full px-6 py-5 flex items-center gap-3 text-left"
+                className="w-full px-6 py-5 flex items-center gap-3 text-left tap-target"
               >
                 <motion.div
                   initial={false}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -55,7 +55,7 @@ export function Footer() {
                   <li key={idx}>
                     <Link
                       href={item.href}
-                      className="text-sm text-charcoal/70 hover:text-charcoal"
+                      className="text-sm text-charcoal/70 hover:text-charcoal inline-flex items-center tap-target"
                     >
                       {item.title}
                     </Link>
@@ -73,7 +73,7 @@ export function Footer() {
                   <li key={idx}>
                     <Link
                       href={item.href}
-                      className="text-sm text-charcoal/70 hover:text-charcoal"
+                      className="text-sm text-charcoal/70 hover:text-charcoal inline-flex items-center tap-target"
                     >
                       {item.title}
                     </Link>
@@ -91,7 +91,7 @@ export function Footer() {
                   <li key={idx}>
                     <Link
                       href={item.href}
-                      className="text-sm text-charcoal/70 hover:text-charcoal"
+                      className="text-sm text-charcoal/70 hover:text-charcoal inline-flex items-center tap-target"
                     >
                       {item.title}
                     </Link>
@@ -109,7 +109,7 @@ export function Footer() {
                   <li key={idx}>
                     <Link
                       href={item.href}
-                      className="text-sm text-charcoal/70 hover:text-charcoal"
+                      className="text-sm text-charcoal/70 hover:text-charcoal inline-flex items-center tap-target"
                     >
                       {item.title}
                     </Link>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { Button } from "./button";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { IphoneMockup } from "./iphone-mockup";
+import { ProofBar } from "./proof-bar";
 
 export function Hero({
   eyebrow = "A systems agency · Ops by Noell",
@@ -20,6 +21,8 @@ export function Hero({
   primaryCta = { label: "Get Your Free Audit", href: "/book" },
   secondaryCta = { label: "See the system", href: "/#systems" },
   mockScreen,
+  showProofBar = true,
+  priceSignal,
 }: {
   eyebrow?: string;
   variant?: "wine" | "lilac" | "sage";
@@ -32,6 +35,8 @@ export function Hero({
   primaryCta?: { label: string; href: string };
   secondaryCta?: { label: string; href: string };
   mockScreen?: React.ReactNode;
+  showProofBar?: boolean;
+  priceSignal?: React.ReactNode;
 }) {
   const parentRef = useRef<HTMLDivElement>(
     null
@@ -81,13 +86,7 @@ export function Hero({
             >
               {headlineLine1Accent}
             </span>
-          </motion.h1>
-          <motion.h1
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.5, delay: 0.3 }}
-            className="inline-block text-charcoal py-2"
-          >
+            <br />
             {headlineLine2Start}{" "}
             <span
               className={cn(accentGradient[variant], "bg-clip-text text-transparent italic")}
@@ -139,6 +138,23 @@ export function Hero({
           {secondaryCta.label}
         </Button>
       </motion.div>
+
+      {priceSignal && (
+        <div className="relative z-20 -mt-4 mb-6 text-center text-xs text-charcoal/60">
+          {priceSignal}
+        </div>
+      )}
+
+      {showProofBar && (
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.75 }}
+          className="relative z-20 w-full flex justify-center px-4 mb-8 md:mb-12"
+        >
+          <ProofBar className="mt-0 md:mt-0" />
+        </motion.div>
+      )}
 
       <div className="pt-[2rem] w-full min-h-[21rem] relative">
         <motion.div

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -254,19 +254,19 @@ const MobileNav = ({ navItems, visible }: NavbarProps) => {
     >
       <div className="flex flex-row justify-between items-center w-full">
         <Logo />
-        <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.9 }}>
+        <motion.button
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.9 }}
+          onClick={() => setOpen(!open)}
+          aria-label={open ? "Close menu" : "Open menu"}
+          className="tap-target flex items-center justify-center"
+        >
           {open ? (
-            <IconX
-              className="text-charcoal cursor-pointer"
-              onClick={() => setOpen(!open)}
-            />
+            <IconX className="text-charcoal cursor-pointer" />
           ) : (
-            <IconMenu2
-              className="text-charcoal cursor-pointer"
-              onClick={() => setOpen(!open)}
-            />
+            <IconMenu2 className="text-charcoal cursor-pointer" />
           )}
-        </motion.div>
+        </motion.button>
       </div>
 
       <AnimatePresence>
@@ -293,7 +293,7 @@ const MobileNav = ({ navItems, visible }: NavbarProps) => {
                 <Link
                   href={navItem.link}
                   onClick={() => setOpen(false)}
-                  className="relative text-charcoal/90 hover:text-charcoal transition-colors flex items-center gap-2"
+                  className="relative text-charcoal/90 hover:text-charcoal transition-colors flex items-center gap-2 tap-target py-2"
                 >
                   {navItem.isAccent && (
                     <span className="inline-block w-1.5 h-1.5 rounded-full bg-lilac-dark" />

--- a/src/components/noell-support-chat.tsx
+++ b/src/components/noell-support-chat.tsx
@@ -71,8 +71,13 @@ const contactCaptureResponse: Message[] = [
   },
 ];
 
+const DISMISS_KEY = "noell-support-dismissed";
+
 export function NoellSupportChat() {
   const pathname = usePathname();
+  const isBookPage = pathname === "/book";
+  const isSupportPage = pathname === "/noell-support";
+
   const [isOpen, setIsOpen] = useState(false);
   const [messages, setMessages] = useState<Message[]>(initialConversation);
   const [inputValue, setInputValue] = useState("");
@@ -80,17 +85,55 @@ export function NoellSupportChat() {
   const [stage, setStage] = useState<"intro" | "qualified" | "captured">(
     "intro"
   );
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  // Auto-open only on /noell-support. The widget is present globally but stays
-  // closed until the visitor clicks it, except on the Noell Support spotlight
-  // page where seeing the widget in action is the whole point.
   useEffect(() => {
-    if (pathname === "/noell-support") {
+    if (typeof window === "undefined") return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handler = (e: MediaQueryListEvent) => setPrefersReducedMotion(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  // Auto-expand triggers (non-/book pages, respect session dismissal)
+  useEffect(() => {
+    if (isBookPage) return;
+    if (typeof window === "undefined") return;
+    if (sessionStorage.getItem(DISMISS_KEY)) return;
+
+    // On the Noell Support spotlight page, expanding the widget is the whole
+    // point. Keep a short delay so the page can render first.
+    if (isSupportPage) {
       const t = setTimeout(() => setIsOpen(true), 1400);
       return () => clearTimeout(t);
     }
-  }, [pathname]);
+
+    const openWidget = () => setIsOpen(true);
+    const timer = setTimeout(openWidget, 8000);
+
+    const onScroll = () => {
+      const max = document.body.scrollHeight - window.innerHeight;
+      if (max <= 0) return;
+      if (window.scrollY / max > 0.4) openWidget();
+    };
+
+    const onMouseLeave = (e: MouseEvent) => {
+      if (e.clientY <= 0) openWidget();
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    document.addEventListener("mouseleave", onMouseLeave);
+
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener("scroll", onScroll);
+      document.removeEventListener("mouseleave", onMouseLeave);
+    };
+  }, [isBookPage, isSupportPage, pathname]);
 
   useEffect(() => {
     if (scrollRef.current) {
@@ -126,12 +169,10 @@ export function NoellSupportChat() {
     setMessages((prev) => [...prev, userMsg]);
     setInputValue("");
 
-    // If at qualified stage, treat next input as contact capture
     if (stage === "qualified") {
       pushResponses(contactCaptureResponse);
       setStage("captured");
     } else if (stage === "intro") {
-      // Generic intro response
       pushResponses([
         {
           from: "agent",
@@ -149,55 +190,101 @@ export function NoellSupportChat() {
     }
   };
 
+  const handleClose = () => {
+    setIsOpen(false);
+    if (typeof window !== "undefined") {
+      sessionStorage.setItem(DISMISS_KEY, "1");
+    }
+  };
+
+  const launcherMotion = prefersReducedMotion
+    ? {}
+    : {
+        initial: { scale: 0, opacity: 0 },
+        animate: { scale: 1, opacity: 1 },
+        transition: { delay: 1, type: "spring" as const, stiffness: 260, damping: 20 },
+      };
+
+  // Shared launcher button (orb) used on /book and whenever closed
+  const OrbButton = (
+    <motion.button
+      {...launcherMotion}
+      onClick={() => setIsOpen((v) => !v)}
+      className={cn(
+        "fixed bottom-6 right-6 z-50 w-14 h-14 rounded-full",
+        "bg-gradient-to-b from-lilac via-lilac-dark to-[#6b4f80] text-white",
+        "shadow-[0px_20px_40px_-10px_rgba(139,111,156,0.45),_0px_8px_16px_-4px_rgba(28,25,23,0.15),_0px_0px_0px_1px_rgba(139,111,156,0.12),_0px_1px_1px_2px_rgba(255,255,255,0.28)_inset]",
+        "flex items-center justify-center hover:scale-105 transition-transform"
+      )}
+      aria-label={isOpen ? "Close Noell Support chat" : "Open Noell Support chat"}
+    >
+      <AnimatePresence mode="wait">
+        {isOpen ? (
+          <motion.div
+            key="x"
+            initial={prefersReducedMotion ? false : { rotate: -90, opacity: 0 }}
+            animate={{ rotate: 0, opacity: 1 }}
+            exit={prefersReducedMotion ? undefined : { rotate: 90, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            <IconX size={22} />
+          </motion.div>
+        ) : (
+          <motion.div
+            key="msg"
+            initial={prefersReducedMotion ? false : { rotate: -90, opacity: 0 }}
+            animate={{ rotate: 0, opacity: 1 }}
+            exit={prefersReducedMotion ? undefined : { rotate: 90, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            <IconMessageCircle size={22} />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.button>
+  );
+
+  // Pill launcher (default on non-/book pages when closed)
+  const PillButton = (
+    <motion.button
+      {...launcherMotion}
+      onClick={() => setIsOpen(true)}
+      className={cn(
+        "fixed bottom-6 right-6 z-50 h-11 pl-4 pr-5 rounded-full",
+        "bg-cream text-charcoal border-2 border-lilac-dark",
+        "shadow-[0px_20px_40px_-10px_rgba(139,111,156,0.35),_0px_8px_16px_-4px_rgba(28,25,23,0.12),_0px_1px_1px_2px_rgba(255,255,255,0.5)_inset]",
+        "flex items-center gap-2 text-sm font-medium hover:bg-white transition-colors tap-target"
+      )}
+      aria-label="Open Noell Support chat"
+    >
+      <span className="w-6 h-6 rounded-full bg-gradient-to-b from-lilac via-lilac-dark to-[#6b4f80] text-white flex items-center justify-center">
+        <IconMessageCircle size={14} />
+      </span>
+      Have a question? Chat with Noell
+    </motion.button>
+  );
+
   return (
     <>
-      {/* Floating launcher */}
-      <motion.button
-        initial={{ scale: 0, opacity: 0 }}
-        animate={{ scale: 1, opacity: 1 }}
-        transition={{ delay: 1, type: "spring", stiffness: 260, damping: 20 }}
-        onClick={() => setIsOpen(!isOpen)}
-        className={cn(
-          "fixed bottom-6 right-6 z-50 w-14 h-14 rounded-full",
-          "bg-gradient-to-b from-lilac via-lilac-dark to-[#6b4f80] text-white",
-          "shadow-[0px_20px_40px_-10px_rgba(139,111,156,0.45),_0px_8px_16px_-4px_rgba(28,25,23,0.15),_0px_0px_0px_1px_rgba(139,111,156,0.12),_0px_1px_1px_2px_rgba(255,255,255,0.28)_inset]",
-          "flex items-center justify-center hover:scale-105 transition-transform"
-        )}
-        aria-label={isOpen ? "Close Noell Support chat" : "Open Noell Support chat"}
-      >
-        <AnimatePresence mode="wait">
-          {isOpen ? (
-            <motion.div
-              key="x"
-              initial={{ rotate: -90, opacity: 0 }}
-              animate={{ rotate: 0, opacity: 1 }}
-              exit={{ rotate: 90, opacity: 0 }}
-              transition={{ duration: 0.2 }}
-            >
-              <IconX size={22} />
-            </motion.div>
-          ) : (
-            <motion.div
-              key="msg"
-              initial={{ rotate: -90, opacity: 0 }}
-              animate={{ rotate: 0, opacity: 1 }}
-              exit={{ rotate: 90, opacity: 0 }}
-              transition={{ duration: 0.2 }}
-            >
-              <IconMessageCircle size={22} />
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </motion.button>
+      {/* Launcher: orb on /book, pill everywhere else (when closed). Orb also when open. */}
+      {isOpen || isBookPage ? OrbButton : PillButton}
 
       {/* Panel */}
       <AnimatePresence>
         {isOpen && (
           <motion.div
-            initial={{ opacity: 0, y: 20, scale: 0.95 }}
+            initial={
+              prefersReducedMotion
+                ? { opacity: 1, y: 0, scale: 1 }
+                : { opacity: 0, y: 20, scale: 0.95 }
+            }
             animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: 20, scale: 0.95 }}
-            transition={{ duration: 0.2, ease: "easeOut" }}
+            exit={
+              prefersReducedMotion
+                ? { opacity: 0 }
+                : { opacity: 0, y: 20, scale: 0.95 }
+            }
+            transition={{ duration: prefersReducedMotion ? 0 : 0.2, ease: "easeOut" }}
             className={cn(
               "fixed bottom-24 right-6 z-50",
               "w-[380px] max-w-[calc(100vw-3rem)]",
@@ -223,8 +310,8 @@ export function NoellSupportChat() {
                 </div>
               </div>
               <button
-                onClick={() => setIsOpen(false)}
-                className="text-white/70 hover:text-white"
+                onClick={handleClose}
+                className="text-white/70 hover:text-white tap-target flex items-center justify-center"
                 aria-label="Close"
               >
                 <IconX size={18} />
@@ -237,7 +324,11 @@ export function NoellSupportChat() {
               className="flex-1 overflow-y-auto px-4 py-4 space-y-3 bg-cream"
             >
               {messages.map((msg, i) => (
-                <MessageBubble key={i} msg={msg} />
+                <MessageBubble
+                  key={i}
+                  msg={msg}
+                  prefersReducedMotion={prefersReducedMotion}
+                />
               ))}
               {typing && <TypingIndicator />}
 
@@ -288,13 +379,19 @@ export function NoellSupportChat() {
   );
 }
 
-function MessageBubble({ msg }: { msg: Message }) {
+function MessageBubble({
+  msg,
+  prefersReducedMotion,
+}: {
+  msg: Message;
+  prefersReducedMotion?: boolean;
+}) {
   const isAgent = msg.from === "agent";
   return (
     <motion.div
-      initial={{ opacity: 0, y: 8 }}
+      initial={prefersReducedMotion ? false : { opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.25 }}
+      transition={{ duration: prefersReducedMotion ? 0 : 0.25 }}
       className={cn("flex", isAgent ? "justify-start" : "justify-end")}
     >
       <div

--- a/src/components/pricing.tsx
+++ b/src/components/pricing.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Button } from "./button";
 import { IconCheck } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
+import { ROICalculator } from "./roi-calculator";
 
 interface PricingTier {
   tier: string;
@@ -155,6 +156,9 @@ export default function Pricing() {
           coverage, smart automation, and implementation support you want
           running behind the scenes for your business.
         </p>
+      </div>
+      <div className="mb-14">
+        <ROICalculator />
       </div>
       <div className="grid md:grid-cols-3 gap-5 items-start">
         {tiers.map((tier) => (

--- a/src/components/proof-bar.tsx
+++ b/src/components/proof-bar.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@/lib/utils";
+
+interface ProofBarProps {
+  className?: string;
+}
+
+const stats = [
+  { value: "$960", label: "Recovered in 14 days" },
+  { value: "4.9\u2605", label: "Across 40+ reviews" },
+  { value: "14d", label: "To go live" },
+];
+
+export function ProofBar({ className }: ProofBarProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-4 md:gap-12 mt-8 md:mt-10",
+        className
+      )}
+    >
+      {stats.map((stat, i) => (
+        <div key={stat.label} className="flex items-center gap-4 md:gap-12">
+          {i > 0 && (
+            <span
+              aria-hidden
+              className="hidden md:inline-block w-px h-10 bg-current opacity-20"
+            />
+          )}
+          <div className="text-center md:text-left">
+            <div className="font-serif text-xl md:text-3xl text-charcoal">
+              {stat.value}
+            </div>
+            <div className="text-[10px] md:text-xs uppercase tracking-wider text-charcoal/60">
+              {stat.label}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/roi-calculator.tsx
+++ b/src/components/roi-calculator.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+
+export function ROICalculator() {
+  const [missedCalls, setMissedCalls] = useState(10);
+  const [avgTicket, setAvgTicket] = useState(150);
+  const recoveryRate = 0.4;
+  const monthly = missedCalls * 4.33 * avgTicket * recoveryRate;
+  const paybackMonthsEssentials = monthly > 0 ? 197 / monthly : Infinity;
+  const paybackMonthsGrowth = monthly > 0 ? 797 / monthly : Infinity;
+
+  const formatPayback = (months: number) =>
+    Number.isFinite(months) ? `${months.toFixed(1)} months` : "n/a";
+
+  return (
+    <div className="rounded-2xl border border-warm-border bg-white p-8 md:p-10 max-w-3xl mx-auto">
+      <div className="mb-6">
+        <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-3">
+          ROI calculator
+        </p>
+        <h3 className="font-serif text-2xl md:text-3xl font-semibold text-charcoal">
+          What could this recover for you?
+        </h3>
+      </div>
+      <div className="grid md:grid-cols-2 gap-6 mb-8">
+        <label className="block">
+          <span className="text-sm text-charcoal/70">
+            Missed calls per week
+          </span>
+          <input
+            type="number"
+            min={0}
+            value={missedCalls}
+            onChange={(e) => setMissedCalls(Number(e.target.value) || 0)}
+            className="mt-2 w-full rounded-lg border border-warm-border bg-cream px-3 py-3 tap-target text-charcoal focus:outline-none focus:border-wine/60 focus:bg-white"
+          />
+        </label>
+        <label className="block">
+          <span className="text-sm text-charcoal/70">
+            Average ticket value ($)
+          </span>
+          <input
+            type="number"
+            min={0}
+            value={avgTicket}
+            onChange={(e) => setAvgTicket(Number(e.target.value) || 0)}
+            className="mt-2 w-full rounded-lg border border-warm-border bg-cream px-3 py-3 tap-target text-charcoal focus:outline-none focus:border-wine/60 focus:bg-white"
+          />
+        </label>
+      </div>
+      <div className="border-t border-warm-border pt-6 space-y-3">
+        <div>
+          <div className="text-xs uppercase tracking-widest text-charcoal/60">
+            Monthly recoverable revenue
+          </div>
+          <div className="font-serif text-3xl md:text-4xl text-charcoal mt-1">
+            $
+            {monthly.toLocaleString("en-US", { maximumFractionDigits: 0 })}
+          </div>
+        </div>
+        <div className="text-sm text-charcoal/75 leading-relaxed">
+          Essentials ($197/mo) pays for itself in {formatPayback(paybackMonthsEssentials)}.
+          <br />
+          Growth ($797/mo) pays for itself in {formatPayback(paybackMonthsGrowth)}.
+        </div>
+      </div>
+      <div className="text-xs text-charcoal/50 mt-6 leading-relaxed">
+        Conservative model. Assumes 40% recovery rate on missed calls. Your
+        actual recovery depends on call volume, timing, and offer.
+      </div>
+    </div>
+  );
+}

--- a/src/components/vertical-case-study.tsx
+++ b/src/components/vertical-case-study.tsx
@@ -1,0 +1,68 @@
+type Metric = { label: string; value: string };
+
+type Props = {
+  quote: string;
+  name: string;
+  role: string;
+  business: string;
+  metrics: Metric[];
+  eyebrow?: string;
+};
+
+export function VerticalCaseStudy({
+  quote,
+  name,
+  role,
+  business,
+  metrics,
+  eyebrow = "One install",
+}: Props) {
+  return (
+    <section className="my-16 md:my-24 px-4">
+      <div className="mx-auto max-w-3xl rounded-2xl bg-cream-dark p-8 md:p-12">
+        <div className="text-xs uppercase tracking-widest text-charcoal/60 mb-4">
+          {eyebrow}
+        </div>
+        <blockquote className="font-serif text-2xl md:text-3xl leading-snug text-charcoal mb-6">
+          &ldquo;{quote}&rdquo;
+        </blockquote>
+        <div className="text-sm text-charcoal/80 mb-8">
+          <strong>{name}</strong>, {role}. {business}.
+        </div>
+        <div className="flex gap-8 flex-wrap">
+          {metrics.map((m) => (
+            <div key={m.label}>
+              <div className="font-serif text-2xl text-charcoal">{m.value}</div>
+              <div className="text-xs uppercase tracking-wider text-charcoal/60">
+                {m.label}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type PlaceholderProps = {
+  vertical: string;
+};
+
+export function VerticalCaseStudyPlaceholder({ vertical }: PlaceholderProps) {
+  /* TODO: replace with real case study from Nikki */
+  return (
+    <section className="my-16 md:my-24 px-4">
+      <div className="mx-auto max-w-3xl rounded-2xl border border-dashed border-warm-border bg-cream-dark/50 p-8 md:p-12 text-center">
+        <div className="text-xs uppercase tracking-widest text-charcoal/60 mb-3">
+          Case study
+        </div>
+        <p className="font-serif text-xl md:text-2xl text-charcoal/70 leading-snug">
+          Coming soon: a {vertical} case study.
+        </p>
+        <p className="mt-3 text-sm text-charcoal/50">
+          We&apos;re running live installs right now. Real numbers land here when they do.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,0 +1,39 @@
+export function localBusinessSchema(vertical: string) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    name: `AI front desk for ${vertical}`,
+    provider: {
+      "@type": "LocalBusiness",
+      name: "Ops by Noell",
+      url: "https://www.opsbynoell.com",
+      areaServed: {
+        "@type": "AdministrativeArea",
+        name: "Orange County, California",
+      },
+      address: {
+        "@type": "PostalAddress",
+        addressLocality: "Lake Forest",
+        addressRegion: "CA",
+        addressCountry: "US",
+      },
+    },
+    areaServed: "United States",
+    description: `Done-for-you AI front desk and missed-call recovery system for ${vertical} businesses.`,
+    offers: {
+      "@type": "Offer",
+      priceCurrency: "USD",
+      lowPrice: 197,
+      highPrice: 1497,
+    },
+  };
+}
+
+export const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Ops by Noell",
+  url: "https://www.opsbynoell.com",
+  logo: "https://www.opsbynoell.com/logo.png",
+  sameAs: [] as string[],
+};


### PR DESCRIPTION
## Summary

Ships the Perplexity audit fixes (R1, R2, R3, R4, R5, R6, R7, R9, R10, R11) in a single pass. R8 (demo video) and R12 (referral program) stay out of scope for this PR.

## Per-item notes

### R1 — Noindex audit + robots/sitemap
- Searched `noindex` across the repo: **no matches**. The tag was likely already removed in an earlier pass; nothing to strip.
- Added `src/app/robots.ts` (allow all, points at sitemap).
- Added `src/app/sitemap.ts` with 11 URLs: `/`, `/verticals`, 6 vertical pages, `/noell-support`, `/noell-front-desk`, `/book`.

### R2 — Chat widget behavior
- Widget file: **`src/components/noell-support-chat.tsx`** (single-file refactor, no separate subcomponents).
- Default = pill "Have a question? Chat with Noell" on every page except `/book`, which is a small orb only.
- Auto-expand triggers on non-`/book` pages: first of 8s timer, 40% scroll, desktop `mouseleave` at `clientY<=0`.
- Closing the panel writes `noell-support-dismissed` to `sessionStorage`; subsequent loads stay in pill state.
- Reduced motion suppresses fade/slide/spring animations.
- Conversation flow, message rendering, starter chips, typing indicator, and any API calls are left alone.
- `/noell-support` keeps its 1.4s auto-open so the spotlight page still demos the widget live.

### R3 — Single H1 per page
- Fixed at the Hero component level (`src/components/hero.tsx`): two sibling `motion.h1`s merged into one with `<br/>`.
- Applies to `/`, all six verticals, `/noell-support`, `/noell-front-desk`, `/noell-care` automatically.
- `/book` already had a single `<h1>`.

### R4 — Tap-target minimums
- Added `.tap-target` utility in `globals.css` (44x44 min).
- Applied to: footer links (4 columns), FAQ accordion triggers, mobile nav items, hamburger toggle, and the shared `Button` component (covers every primary/secondary CTA).

### R5 — 3-stat proof bar
- New `src/components/proof-bar.tsx`.
- Mounted via a new `showProofBar` prop on Hero (default `true`) so it lands on `/`, all six verticals, `/noell-support`, `/noell-front-desk`, `/noell-care`. Not mounted on `/book` (that page gets its own proof treatment under R10) or `/verticals` index (doesn't use Hero).
- Mobile: tighter `gap-4` and a size step down.

### R6 — Pricing signals + pricing FAQs
- Added `priceSignal` prop on Hero. Set to **"Starts at $197/mo. See all tiers."** with "See all tiers" linking to `/#pricing` on `/noell-support` and `/noell-front-desk`.
- Added three pricing FAQs (month-to-month, setup fee, grandfathering) to the homepage default FAQ set, plus both product page FAQs.
- FAQ accordion now expands the **first two** items by default (was just the first).

### R7 — Vertical micro case studies
- New `src/components/vertical-case-study.tsx` exports `VerticalCaseStudy` and `VerticalCaseStudyPlaceholder`.
- **Massage** uses Santa E.'s real quote + metrics: $960 recovered, 14 days, 4 rebooks.
- **Dental, med-spas, salons, estheticians, HVAC** get `VerticalCaseStudyPlaceholder` with a `{/* TODO: replace with real case study from Nikki */}` comment and neutral "Coming soon" copy. No fabricated names, quotes, or metrics.
- Mounted above the existing `Features3` three-move explainer on each vertical page.

### R9 — ROI calculator
- New `src/components/roi-calculator.tsx`, client component.
- Inputs: missed calls per week, average ticket value. Assumes 40% recovery.
- Outputs monthly recoverable revenue and payback months for Essentials ($197) and Growth ($797).
- Mounted above the tier grid on `/#pricing`. `/pricing` page **not** created (sitemap doesn't include it, homepage anchor suffices).

### R10 — `/book` redesign
- Eyebrow "The first step", single H1 "Your free *operations audit*", subhead, three badge chips.
- Calendar embed pulled above the fold with **`min-h-[520px]`** reserved to eliminate CLS, iframe `loading="eager"`.
- Detected timezone line under the embed using `Intl.DateTimeFormat().resolvedOptions().timeZone`.
- Three-stat proof bar, Santa pull quote card, three-step explainer (moved below proof), booking FAQ, soft-exit "Ask Noell Support a question first", closing CTA.
- Desktop-only exit-intent modal: triggers on `mouseleave` at `y<=0` **after** 5s on page, dismissal persisted in `sessionStorage['book-exit-shown']`. Posts email to new stub `POST /api/book-followup` which validates and returns 200.
- Because R2 special-cases `/book`, the widget is already orb-only on this page.

### R11 — JSON-LD schema
- New `src/lib/schema.ts` exports `localBusinessSchema(vertical)` and `organizationSchema`.
- Organization schema injected site-wide in `app/layout.tsx`.
- Service / LocalBusiness schema injected in each `/verticals/*/page.tsx` with the copy per spec: "dental practices", "med spas", "salons", "massage therapy practices", "esthetician studios", "HVAC companies".

## Files NOT touched

- Any production automation or session logic in the widget: session IDs, message rendering, conversation state, chip flow, contact-capture stages, any `/api/*` calls from the widget.
- Typography, palette, Playfair/Inter, Burgundy gradient — brand migration is a separate PR.
- `/verticals` index page (doesn't use Hero, not in any R-item scope here).
- `/noell-care`, `/legal/*`, admin surfaces, any `src/lib/agents/**` code.
- `src/hooks/use-media-query.tsx` (pre-existing `react-hooks/set-state-in-effect` error, not introduced by this PR).
- `docs/template-source/**` (template reference, out of scope).

## Em dashes flagged but not changed

Per spec I didn't mass-replace em dashes, but these pre-existing files contain `—` or `–`:

- `src/lib/agents/prompts.ts`, `runner.ts`, `supabase.ts`, `telegram.ts`, `env.ts`, `claude.ts`
- `src/lib/agents/integrations/registry.ts`, `ghl.ts`
- `src/lib/admin-auth.ts`
- `src/components/agent-chat-widget.tsx`, `agent-router.tsx`
- `src/app/noell-care/page.tsx`
- `src/app/api/front-desk/sessions/[sessionId]/route.ts`, `missed-call/route.ts`
- `src/app/api/cron/review-requests/route.ts`, `reactivations/route.ts`, `reminders/route.ts`
- `src/app/api/care/message/route.ts`, `knowledge/[id]/route.ts`, `knowledge/route.ts`
- `src/app/api/admin/users/[id]/route.ts`, `users/route.ts`, `sessions/route.ts`, `login/route.ts`
- `src/app/admin/page.tsx`

No "Nova" references found anywhere in `src/`.

## Commits

1. R1: add robots.ts and sitemap.ts
2. R2: chat widget pill default + auto-expand triggers + session dismissal
3. R3: merge split H1s into a single H1 in Hero component (bundles R5/R6 Hero prop additions)
4. R4: tap-target utility + 44x44 minimums on mobile interactive elements
5. R5: ProofBar with $960 / 4.9 stars / 14d stats, mounted in Hero
6. R6: price signal + 3 pricing FAQs on product pages
7. R7: VerticalCaseStudy + massage Santa case + placeholders (also wires R11 Service schema per vertical)
8. R9: ROI calculator mounted on homepage pricing section
9. R10: /book redesign with eager calendar, timezone line, exit intent
10. R11: Organization JSON-LD in root layout, schema helpers

## Test plan

- [ ] `pnpm build` / `npm run build` succeeds locally (confirmed here)
- [ ] Every page has exactly one `<h1>`
- [ ] 390px viewport: interactive targets computed >= 44x44
- [ ] Widget starts as pill on `/`, `/verticals/*`, `/noell-support`, `/noell-front-desk`; orb on `/book`
- [ ] Widget auto-expands on non-`/book` after 8s OR 40% scroll OR exit intent
- [ ] Closing widget persists via `sessionStorage` across reload
- [ ] Widget conversation flow still works end to end
- [ ] Proof bar visible on 9 pages, not on `/book` or `/verticals` index
- [ ] Pricing FAQ shows 3 new items, first two open by default
- [ ] ROI calculator recalculates live on `/#pricing`
- [ ] `/book` shows calendar above the fold, detected timezone, Santa quote
- [ ] `/book` exit-intent modal fires once after 5s on desktop
- [ ] View source on each `/verticals/*`: `application/ld+json` present
- [ ] After deploy: `curl -I https://www.opsbynoell.com/` has **no** `noindex`
- [ ] After deploy: `curl https://www.opsbynoell.com/sitemap.xml` returns 11 URLs
- [ ] After deploy: `curl https://www.opsbynoell.com/robots.txt` allows all

## Do not merge until Nikki reviews.