### PR TITLE
feat: Twilio SMS swap for opsbynoell (post-A2P)

### DIFF
--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -1,0 +1,23 @@
+# Environment Variables
+
+Vercel-scoped environment variables used by the Ops by Noell marketing site
+and its agent backend. Set each in the Vercel project for the listed scopes
+(Production / Preview / Development) unless a section says otherwise.
+
+The canonical reader for these is `src/lib/agents/env.ts` — any new variable
+should be plumbed through there rather than read from `process.env` directly.
+
+## Twilio (Ops by Noell SMS)
+
+Required in Vercel for the opsbynoell client's SMS to work:
+
+- TWILIO_ACCOUNT_SID — from https://console.twilio.com (Account SID, starts with "AC")
+- TWILIO_AUTH_TOKEN  — from https://console.twilio.com (Auth Token, rotate if leaked)
+- TWILIO_FROM_NUMBER — your purchased A2P-registered number in E.164 format, e.g. "+19499991234"
+
+Scope: Production, Preview, Development.
+
+After setting these, also update in Supabase:
+- `clients.phone` for slug=opsbynoell → set to TWILIO_FROM_NUMBER
+- `clients.locations[0].phone` → same
+- `clients.escalation_rules.qualifiedLead.smsTo` → Nikki's personal cell in E.164

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "twilio:smoke": "tsx scripts/twilio-smoke-test.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/twilio-smoke-test.ts
+++ b/scripts/twilio-smoke-test.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env tsx
+/**
+ * Twilio smoke test — sends one SMS to verify the A2P swap is live.
+ *
+ * Usage:
+ *   TWILIO_ACCOUNT_SID=AC... TWILIO_AUTH_TOKEN=... TWILIO_FROM_NUMBER=+1... \
+ *     npm run twilio:smoke -- +19491234567
+ *
+ * Exits 0 on success (prints the message SID), 1 on failure.
+ */
+
+export {};
+
+const sid = process.env.TWILIO_ACCOUNT_SID;
+const token = process.env.TWILIO_AUTH_TOKEN;
+const from = process.env.TWILIO_FROM_NUMBER;
+const to = process.argv[2];
+
+if (!sid || !token || !from) {
+  console.error("Missing TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, or TWILIO_FROM_NUMBER.");
+  process.exit(1);
+}
+if (!to) {
+  console.error("Usage: tsx scripts/twilio-smoke-test.ts <+E164_TARGET_NUMBER>");
+  process.exit(1);
+}
+
+const body =
+  "Ops by Noell Twilio smoke test — if you received this, the A2P swap is live. STOP to opt out, HELP for help.";
+
+const res = await fetch(
+  `https://api.twilio.com/2010-04-01/Accounts/${sid}/Messages.json`,
+  {
+    method: "POST",
+    headers: {
+      Authorization: "Basic " + Buffer.from(`${sid}:${token}`).toString("base64"),
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({ To: to, From: from, Body: body }),
+  }
+);
+
+if (!res.ok) {
+  console.error(`Twilio send failed: ${res.status} ${await res.text()}`);
+  process.exit(1);
+}
+
+const data = (await res.json()) as { sid: string };
+console.log(`OK — message SID: ${data.sid}`);
+process.exit(0);

--- a/supabase/seeds/opsbynoell_seed.sql
+++ b/supabase/seeds/opsbynoell_seed.sql
@@ -1,0 +1,158 @@
+-- ============================================================
+-- Ops by Noell — clients row (internal support agent)
+-- Target project: clipzfkbzupjctherijz
+-- GHL location ID: Un5H1b2zXJM3agZ56j7c
+-- SMS provider: Twilio (standalone account, post-A2P 10DLC approval)
+--
+-- Run AFTER:
+--   supabase/migrations/0001_agents_schema.sql
+--   supabase/migrations/0002_multi_tenant_admin.sql
+--
+-- PLACEHOLDERS — must be updated before go-live:
+--   PHONE_PLACEHOLDER — replace with the purchased Twilio A2P number
+--                      (E.164, e.g. +19499991234). Used in:
+--                        - clients.phone
+--                        - clients.locations[0].phone
+--                        - clients.escalation_rules.qualifiedLead.smsTo
+--                          (set this one to Nikki's personal cell, NOT
+--                          the Twilio number)
+--
+-- Notes:
+--   - Ops by Noell only runs the Support tier on its own marketing site.
+--     Front Desk and Care are products sold to reseller clients, not used
+--     internally.
+--   - sms_provider='twilio' — SMS sends go through the standalone Twilio
+--     account configured via TWILIO_ACCOUNT_SID / TWILIO_AUTH_TOKEN /
+--     TWILIO_FROM_NUMBER env vars (see docs/ENV_VARS.md).
+--   - sms_config.from is informational only; TwilioSms reads the real
+--     From number from env at send-time.
+-- ============================================================
+
+
+INSERT INTO public.clients (
+  id,
+  brand_name,
+  vertical,
+  phone,
+  email,
+  agents,
+
+  -- Noell Support config
+  support_system_prompt,
+  support_greeting,
+  support_booking_url,
+
+  -- Noell Front Desk config (unused for Ops by Noell)
+  front_desk_system_prompt,
+  calendar_provider,
+  calendar_config,
+  sms_provider,
+  sms_config,
+  missed_call_text_template,
+  review_platform,
+  review_url,
+  reactivation_threshold_days,
+
+  -- Noell Care config (unused for Ops by Noell)
+  care_system_prompt,
+  care_greeting,
+
+  -- Business metadata
+  hours,
+  locations,
+  team,
+  escalation_rules,
+  telegram_chat_id
+)
+VALUES (
+  'opsbynoell',
+  'Ops by Noell',
+  'internal',
+  'PHONE_PLACEHOLDER',
+  'hello@opsbynoell.com',
+  '{"support": true, "frontDesk": false, "care": false}'::jsonb,
+
+  -- Support system prompt (fallback — v2 prompt file not present at seed-write time)
+  'You are the Support agent for Ops by Noell, a small automation agency run by Nikki. Ops by Noell sells three tiers of AI-powered agents to service businesses: Noell Support (website chat + lead capture), Noell Front Desk (24/7 missed-call text-back + booking), and Noell Care (returning-client scheduling and follow-up).
+
+Your job is to (1) greet visitors warmly, (2) answer questions about the three tiers and what each one does, (3) capture the visitor''s name, business, and contact info, and (4) route qualified leads to the contact form at https://www.opsbynoell.com/contact. When a lead is clearly qualified (they run a service business, they''ve described a concrete pain point, and they''ve given contact info), escalate to Nikki via SMS and email using the escalation rules configured on this client.
+
+Be concise, plain-spoken, and grounded. Never invent pricing. If asked about cost, explain that Nikki scopes pricing per-client after a short intake and point them to the contact form. Never provide technical implementation details about other clients'' setups.',
+
+  'Hi — I''m Noell Support. I help with questions about the Noell Support, Front Desk, and Care tiers, and I can route you straight to Nikki. What can I help with?',
+  'https://www.opsbynoell.com/book',
+
+  -- Front Desk: not enabled for Ops by Noell
+  NULL,
+
+  'ghl',
+  '{"locationId": "Un5H1b2zXJM3agZ56j7c"}'::jsonb,
+
+  -- KEY CHANGE: Twilio (standalone account) instead of GHL LC Phone.
+  -- The actual From number is read from TWILIO_FROM_NUMBER env at send-time;
+  -- the JSON below is informational so operators can see the source.
+  'twilio',
+  '{"from": "env:TWILIO_FROM_NUMBER"}'::jsonb,
+
+  NULL,            -- missed_call_text_template (Front Desk not in use)
+  'google',
+  NULL,            -- review_url (not in use yet)
+  NULL,            -- reactivation_threshold_days (Care not in use)
+
+  NULL,            -- care_system_prompt
+  NULL,            -- care_greeting
+
+  '{}'::jsonb,     -- hours (internal agency, no public hours)
+
+  -- Locations: iPostal1 mailing address (NEVER use 14 Quinn Way publicly)
+  '[{
+    "name": "Ops by Noell HQ",
+    "address": "23710 El Toro Road #1086, Lake Forest, CA 92630",
+    "phone": "PHONE_PLACEHOLDER"
+  }]'::jsonb,
+
+  '[{"name": "Nikki", "role": "Founder"}]'::jsonb,
+
+  -- Escalation rules: qualified leads alert Nikki via SMS + email.
+  -- Replace PHONE_PLACEHOLDER with Nikki's personal cell in E.164 post-Twilio setup.
+  '{
+    "qualifiedLead": {
+      "smsTo":   "PHONE_PLACEHOLDER",
+      "emailTo": "hello@opsbynoell.com"
+    }
+  }'::jsonb,
+
+  NULL             -- telegram_chat_id (not in use)
+)
+ON CONFLICT (id) DO UPDATE SET
+  brand_name                  = EXCLUDED.brand_name,
+  vertical                    = EXCLUDED.vertical,
+  phone                       = EXCLUDED.phone,
+  email                       = EXCLUDED.email,
+  agents                      = EXCLUDED.agents,
+  support_system_prompt       = EXCLUDED.support_system_prompt,
+  support_greeting            = EXCLUDED.support_greeting,
+  support_booking_url         = EXCLUDED.support_booking_url,
+  front_desk_system_prompt    = EXCLUDED.front_desk_system_prompt,
+  calendar_provider           = EXCLUDED.calendar_provider,
+  calendar_config             = EXCLUDED.calendar_config,
+  sms_provider                = EXCLUDED.sms_provider,
+  sms_config                  = EXCLUDED.sms_config,
+  missed_call_text_template   = EXCLUDED.missed_call_text_template,
+  review_platform             = EXCLUDED.review_platform,
+  review_url                  = EXCLUDED.review_url,
+  reactivation_threshold_days = EXCLUDED.reactivation_threshold_days,
+  care_system_prompt          = EXCLUDED.care_system_prompt,
+  care_greeting               = EXCLUDED.care_greeting,
+  hours                       = EXCLUDED.hours,
+  locations                   = EXCLUDED.locations,
+  team                        = EXCLUDED.team,
+  escalation_rules            = EXCLUDED.escalation_rules,
+  telegram_chat_id            = EXCLUDED.telegram_chat_id;
+
+
+-- ============================================================
+-- Verify with:
+--   SELECT id, brand_name, sms_provider, sms_config
+--   FROM clients WHERE id = 'opsbynoell';
+-- ============================================================


### PR DESCRIPTION
## Twilio SMS Swap (Post-A2P)

A2P 10DLC campaign approved ✅ — swapping Ops by Noell's SMS provider from GHL LC Phone to a standalone Twilio account for white-label resale.

### Changes
- `supabase/seeds/opsbynoell_seed.sql` — new client seed with `sms_provider='twilio'`
- `docs/ENV_VARS.md` — Twilio env var docs
- `scripts/twilio-smoke-test.ts` — standalone Twilio send test
- `package.json` — `twilio:smoke` script

Note: the existing `TwilioSms` class (`src/lib/agents/integrations/generic.ts`), env helpers (`src/lib/agents/env.ts`), and provider switch (`src/lib/agents/integrations/registry.ts`) were already wired — this PR only adds the client seed, env docs, smoke test, and npm script. No production runtime code changed.

### Before merging
1. Sign up for standalone Twilio account
2. Buy A2P-registered number
3. Link the Twilio Brand/Campaign to the purchased number
4. Set Vercel env vars: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER` (all three scopes: Production, Preview, Development)
5. Run smoke test locally:
   ```
   TWILIO_ACCOUNT_SID=AC... TWILIO_AUTH_TOKEN=... TWILIO_FROM_NUMBER=+1... \
     npm run twilio:smoke -- +1NIKKICELL
   ```
6. Confirm the test SMS arrives on Nikki's cell
7. Apply seed in Supabase: `psql $SUPABASE_URL -f supabase/seeds/opsbynoell_seed.sql` (or paste into SQL editor)
8. Update `clients.phone`, `clients.locations[0].phone`, and `clients.escalation_rules.qualifiedLead.smsTo` — replace `PHONE_PLACEHOLDER` with the real Twilio number on the first two and Nikki's personal cell on the third

### After merging
Full end-to-end Noell Support audit (chat → lead capture → email alert → SMS confirmation → Supabase session row).

### Notes / non-goals
- `GhlSms` integration is untouched — Santa and future reseller clients on GHL LC Phone keep working
- No `twilio` SDK added — the existing `fetch`-based `TwilioSms` class is the pattern
- Seed is not applied automatically; Nikki will run it manually after Twilio env vars are set
- `CLAUDE.md`-mandated branch `claude/twilio-sms-swap-vN3EG` was used instead of the prompt's suggested `claude/twilio-swap-opsbynoell` (session-provided branch takes precedence)
