### PR TITLE
feat(analytics): Meta Pixel integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,8 @@ GHL_API_KEY=
 # Vercel cron shared secret (any HTTP caller hitting /api/cron/* without
 # the `x-vercel-cron` header must send Authorization: Bearer <CRON_SECRET>)
 CRON_SECRET=
+
+# Meta Pixel (client-side analytics for Facebook / Instagram ads)
+# Pixel lives in the "Nikki Noell" business portfolio.
+# Leave blank in dev to disable pixel firing locally.
+NEXT_PUBLIC_META_PIXEL_ID=792219100378130

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { ConditionalShell } from "@/components/conditional-shell";
+import { MetaPixel } from "@/components/meta-pixel";
 import { organizationSchema } from "@/lib/schema";
 import "./globals.css";
 
@@ -71,6 +72,7 @@ export default function RootLayout({
         />
       </head>
       <body className="min-h-full flex flex-col bg-cream">
+        <MetaPixel />
         <ConditionalShell>{children}</ConditionalShell>
       </body>
     </html>

--- a/src/components/meta-pixel.tsx
+++ b/src/components/meta-pixel.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import Script from "next/script";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect, Suspense } from "react";
+
+/**
+ * Meta Pixel integration for Ops by Noell
+ *
+ * Reads pixel ID from NEXT_PUBLIC_META_PIXEL_ID env var.
+ * Fires PageView on initial load and on every client-side navigation.
+ *
+ * Custom events to fire from other components:
+ *   window.fbq('track', 'Lead')            // when a user submits a form
+ *   window.fbq('track', 'Contact')         // when a user clicks /book or /contact
+ *   window.fbq('track', 'Schedule')        // when a user completes booking
+ */
+
+declare global {
+  interface Window {
+    fbq?: (...args: unknown[]) => void;
+    _fbq?: unknown;
+  }
+}
+
+function MetaPixelPageview({ pixelId }: { pixelId: string }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.fbq) return;
+    window.fbq("track", "PageView");
+    // Intentionally referencing values so effect re-runs on route change
+    void pathname;
+    void searchParams;
+  }, [pathname, searchParams, pixelId]);
+
+  return null;
+}
+
+export function MetaPixel() {
+  const pixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID;
+
+  if (!pixelId) {
+    // Gracefully no-op in dev or if env var is missing.
+    return null;
+  }
+
+  return (
+    <>
+      <Script
+        id="meta-pixel-base"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+!function(f,b,e,v,n,t,s)
+{if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+n.queue=[];t=b.createElement(e);t.async=!0;
+t.src=v;s=b.getElementsByTagName(e)[0];
+s.parentNode.insertBefore(t,s)}(window, document,'script',
+'https://connect.facebook.net/en_US/fbevents.js');
+fbq('init', '${pixelId}');
+fbq('track', 'PageView');
+          `,
+        }}
+      />
+      <noscript>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          height="1"
+          width="1"
+          style={{ display: "none" }}
+          src={`https://www.facebook.com/tr?id=${pixelId}&ev=PageView&noscript=1`}
+          alt=""
+        />
+      </noscript>
+      <Suspense fallback={null}>
+        <MetaPixelPageview pixelId={pixelId} />
+      </Suspense>
+    </>
+  );
+}

--- a/src/lib/meta-pixel-track.ts
+++ b/src/lib/meta-pixel-track.ts
@@ -1,0 +1,55 @@
+/**
+ * Helpers to fire Meta Pixel custom events from anywhere in the app.
+ *
+ * Usage:
+ *   import { trackMetaEvent } from "@/lib/meta-pixel-track";
+ *   trackMetaEvent("Contact");                      // when user clicks /book CTA
+ *   trackMetaEvent("Lead", { content_name: "Contact form" });
+ *
+ * These all no-op safely if the pixel hasn't loaded or is missing.
+ */
+
+type StandardEvent =
+  | "PageView"
+  | "Lead"
+  | "Contact"
+  | "Schedule"
+  | "CompleteRegistration"
+  | "Subscribe"
+  | "ViewContent"
+  | "InitiateCheckout"
+  | "Purchase";
+
+export function trackMetaEvent(
+  eventName: StandardEvent,
+  params?: Record<string, unknown>,
+) {
+  if (typeof window === "undefined") return;
+  if (typeof window.fbq !== "function") return;
+  try {
+    if (params) {
+      window.fbq("track", eventName, params);
+    } else {
+      window.fbq("track", eventName);
+    }
+  } catch {
+    // swallow — pixel should never break the UI
+  }
+}
+
+export function trackMetaCustomEvent(
+  eventName: string,
+  params?: Record<string, unknown>,
+) {
+  if (typeof window === "undefined") return;
+  if (typeof window.fbq !== "function") return;
+  try {
+    if (params) {
+      window.fbq("trackCustom", eventName, params);
+    } else {
+      window.fbq("trackCustom", eventName);
+    }
+  } catch {
+    // swallow
+  }
+}


### PR DESCRIPTION
## What this does

Wires up the Meta Pixel (ID `792219100378130` — the new **Ops by Noell** dataset in the Nikki Noell business portfolio) across the site so visitor data starts collecting today. This is foundation work for ad retargeting + conversion optimization once Meta business verification clears.

## Changes

- **`src/components/meta-pixel.tsx`** — new client component. Injects the Meta base script via `next/script` (`afterInteractive` strategy so it never blocks the first paint), fires `PageView` on load, and re-fires `PageView` on every client-side route change. No-ops cleanly when `NEXT_PUBLIC_META_PIXEL_ID` is missing (dev + preview safety).
- **`src/app/layout.tsx`** — mounts `<MetaPixel />` once inside `<body>`.
- **`src/lib/meta-pixel-track.ts`** — helper exposing `trackMetaEvent` and `trackMetaCustomEvent` so CTAs and form handlers can fire Lead / Contact / Schedule conversions.
- **`.env.example`** — documents `NEXT_PUBLIC_META_PIXEL_ID`.

## Deployment checklist

1. Set `NEXT_PUBLIC_META_PIXEL_ID=792219100378130` in Vercel → Settings → Environment Variables (Production + Preview).
2. Merge this PR. Vercel auto-deploys on `main`.
3. Verify with Meta Pixel Helper extension on opsbynoell.com — should see `PageView` fire.
4. Confirm events in Events Manager (Ops by Noell dataset) within ~20 min.

## Still outstanding (tracked separately)

- Meta business verification for James Noell (pending submission in portfolio)
- Domain verification for opsbynoell.com in Brand Safety
- Wiring `trackMetaEvent('Contact')` into the `/book` and `/contact` CTA buttons (follow-up PR)