### PR TITLE
Refactor color tokens for improved WCAG AA contrast compliance

### DIFF
--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -95,7 +95,7 @@ export default function BookPage() {
 
       {/* Hero */}
       <section className="relative flex max-w-7xl rounded-b-3xl my-2 md:my-4 mx-auto flex-col items-center justify-center pt-20 md:pt-24 pb-6 md:pb-8 overflow-hidden px-4 md:px-8 bg-gradient-to-t from-[rgba(107,45,62,0.50)] via-[rgba(240,224,214,0.70)] to-[rgba(250,246,241,1)]">
-        <p className="relative z-20 text-[11px] uppercase tracking-[0.25em] text-charcoal/60 mb-4">
+        <p className="relative z-20 text-[11px] uppercase tracking-[0.25em] text-muted-strong mb-4">
           The first step
         </p>
         <h1 className="relative z-20 max-w-4xl text-center font-serif text-3xl md:text-5xl lg:text-6xl font-semibold tracking-tight text-charcoal">
@@ -117,7 +117,7 @@ export default function BookPage() {
           ].map((chip) => (
             <span
               key={chip}
-              className="inline-flex items-center rounded-full border border-warm-border bg-white/70 px-3 py-1.5 text-xs text-charcoal/70"
+              className="inline-flex items-center rounded-full border border-wine/30 bg-white px-3 py-1.5 text-xs text-wine"
             >
               {chip}
             </span>
@@ -241,7 +241,7 @@ export default function BookPage() {
       {/* Soft exit: Noell Support fallback */}
       <section className="px-4 pb-20">
         <div className="max-w-3xl mx-auto rounded-[22px] border border-warm-border bg-cream-dark p-8 text-center">
-          <p className="text-[11px] uppercase tracking-[0.2em] text-lilac-dark mb-3 inline-flex items-center gap-2">
+          <p className="text-[11px] uppercase tracking-[0.2em] text-muted-strong mb-3 inline-flex items-center gap-2">
             <span className="w-1.5 h-1.5 rounded-full bg-lilac-dark" />
             Not ready to book?
           </p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,6 +24,12 @@
   --color-warm-gray: #78716C;
   --color-warm-border: #E7DFD6;
 
+  /* Readable-gray tokens for muted text on cream backgrounds (WCAG AA). */
+  --color-muted-strong: #5A4A50;
+  --color-muted-medium: #6E5E64;
+  /* For reassurance copy on dark wine backgrounds (passes 4.5:1 on wine). */
+  --color-on-dark-soft: rgba(255, 255, 255, 0.82);
+
   /* Fonts: three registers, display, body, system */
   --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
   --font-mono: "Courier New", ui-monospace, "Cascadia Mono", "Segoe UI Mono", monospace;

--- a/src/app/noell-support/page.tsx
+++ b/src/app/noell-support/page.tsx
@@ -190,7 +190,7 @@ export default function NoellSupportPage() {
       <section id="capabilities" className="py-20 md:py-28 px-4">
         <div className="max-w-7xl mx-auto">
           <div className="text-center mb-14 max-w-3xl mx-auto">
-            <p className="text-[11px] uppercase tracking-[0.25em] text-lilac-dark mb-4">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-muted-strong mb-4">
               What Noell Support does
             </p>
             <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">

--- a/src/components/agent-chat-widget.tsx
+++ b/src/components/agent-chat-widget.tsx
@@ -352,7 +352,7 @@ export function AgentChatWidget(props: AgentChatWidgetProps) {
                   <IconSend size={15} />
                 </button>
               </div>
-              <p className="text-xs text-neutral-400 mt-2 px-1">
+              <p className="text-xs text-[#555555] mt-2 px-1">
                 By chatting, you agree to our{" "}
                 <a href="/privacy" target="_blank" rel="noopener" className="underline">Privacy Policy</a>
                 {" "}and{" "}

--- a/src/components/booking-embed.tsx
+++ b/src/components/booking-embed.tsx
@@ -35,8 +35,8 @@ export function BookingEmbed() {
           className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-cream text-charcoal px-6 text-center"
         >
           <div className="flex items-center gap-2 mb-5">
-            <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
-            <span className="font-mono text-[10px] uppercase tracking-[0.28em] text-charcoal/60">
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-[#2E7D5B] animate-pulse" />
+            <span className="font-mono text-[10px] uppercase tracking-[0.28em] text-muted-strong">
               noell front desk / scheduler
             </span>
           </div>
@@ -46,7 +46,7 @@ export function BookingEmbed() {
             <LoadingDots />
           </p>
 
-          <p className="mt-5 font-mono text-[11px] uppercase tracking-widest text-charcoal/40">
+          <p className="mt-5 font-mono text-[11px] uppercase tracking-widest text-muted-strong">
             holding your spot while we fetch the calendar
           </p>
 
@@ -90,8 +90,8 @@ function BookingFallback() {
     <div className="rounded-2xl border border-warm-border bg-gradient-to-b from-cream to-white p-8 md:p-12">
       <div className="max-w-lg mx-auto text-center">
         <div className="inline-flex items-center gap-2 mb-5">
-          <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-500" />
-          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-wine">
+          <span className="inline-block w-1.5 h-1.5 rounded-full bg-[#2E7D5B]" />
+          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-muted-strong">
             direct booking / by hand
           </p>
         </div>
@@ -125,10 +125,10 @@ function BookingFallback() {
           </Link>
         </div>
 
-        <p className="mt-8 font-mono text-[10px] uppercase tracking-widest text-charcoal/40">
+        <p className="mt-8 font-mono text-[10px] uppercase tracking-widest text-muted-strong">
           why no instant calendar?
         </p>
-        <p className="mt-2 text-xs text-charcoal/50 leading-relaxed max-w-md mx-auto">
+        <p className="mt-2 text-xs text-muted-medium leading-relaxed max-w-md mx-auto">
           Audits are booked by hand right now. It keeps the quality bar high.
           Instant self-serve returns when capacity allows.
         </p>

--- a/src/components/cta.tsx
+++ b/src/components/cta.tsx
@@ -84,7 +84,7 @@ export default function CTA({
             </Button>
           </div>
 
-          <p className="mt-8 text-xs text-white/50">{trustLine}</p>
+          <p className="mt-8 text-xs text-on-dark-soft">{trustLine}</p>
         </div>
       </motion.div>
     </section>

--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -39,7 +39,7 @@ export function Features({
   return (
     <div className="w-full py-20 relative">
       <div className="text-center mb-12 px-4">
-        <p className="text-[11px] uppercase tracking-[0.25em] text-charcoal/50 mb-4">
+        <p className="text-[11px] uppercase tracking-[0.25em] text-muted-strong mb-4">
           {eyebrow}
         </p>
         <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal mb-4 max-w-3xl mx-auto">

--- a/src/components/features3.tsx
+++ b/src/components/features3.tsx
@@ -71,6 +71,8 @@ export function Features3({
   accent?: "wine" | "lilac";
 }) {
   const accentText = accent === "wine" ? "text-wine" : "text-lilac-dark";
+  // Eyebrow needs extra contrast on cream; lilac-dark fails AA, so use muted-strong for the lilac variant.
+  const eyebrowColor = accent === "wine" ? "text-wine" : "text-muted-strong";
   const accentBg = accent === "wine" ? "bg-wine/10" : "bg-lilac-dark/10";
   const accentGrad =
     accent === "wine"
@@ -84,7 +86,7 @@ export function Features3({
           <p
             className={cn(
               "text-[11px] uppercase tracking-[0.25em] mb-4",
-              accentText
+              eyebrowColor
             )}
           >
             {eyebrow}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -49,7 +49,7 @@ export function Footer() {
 
           <div className="grid grid-cols-2 md:grid-cols-4 gap-8 md:gap-12">
             <div className="space-y-5">
-              <h3 className="text-[11px] uppercase tracking-widest text-charcoal/40">
+              <h3 className="text-[11px] uppercase tracking-widest text-muted-strong">
                 Pages
               </h3>
               <ul className="space-y-3">
@@ -67,7 +67,7 @@ export function Footer() {
             </div>
 
             <div className="space-y-5">
-              <h3 className="text-[11px] uppercase tracking-widest text-charcoal/40">
+              <h3 className="text-[11px] uppercase tracking-widest text-muted-strong">
                 The Noell system
               </h3>
               <ul className="space-y-3">
@@ -85,7 +85,7 @@ export function Footer() {
             </div>
 
             <div className="space-y-5">
-              <h3 className="text-[11px] uppercase tracking-widest text-charcoal/40">
+              <h3 className="text-[11px] uppercase tracking-widest text-muted-strong">
                 Verticals
               </h3>
               <ul className="space-y-3">
@@ -103,7 +103,7 @@ export function Footer() {
             </div>
 
             <div className="space-y-5">
-              <h3 className="text-[11px] uppercase tracking-widest text-charcoal/40">
+              <h3 className="text-[11px] uppercase tracking-widest text-muted-strong">
                 Legal
               </h3>
               <ul className="space-y-3">
@@ -123,11 +123,11 @@ export function Footer() {
         </div>
 
         <div className="flex flex-col md:flex-row justify-between items-center pt-12 mt-12 border-t border-warm-border gap-3">
-          <p className="text-xs text-charcoal/50">
+          <p className="text-xs text-muted-strong">
             &copy; {new Date().getFullYear()} Ops by Noell. Quiet operations for
             service businesses.
           </p>
-          <p className="text-xs text-charcoal/40">
+          <p className="text-xs text-muted-strong">
             Built for service businesses. Managed end-to-end.
           </p>
         </div>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -53,7 +53,9 @@ export function Hero({
 
   const accentGradient = {
     wine: "bg-gradient-to-b from-[rgba(139,77,94,1)] to-[rgba(107,45,62,1)]",
-    lilac: "bg-gradient-to-b from-[rgba(196,181,206,1)] to-[rgba(139,111,156,1)]",
+    // Lilac variant uses Wine for the italic accent so it passes AA on the
+    // blush/lilac hero gradient (the pale-lilac color fails ~1.5:1).
+    lilac: "bg-gradient-to-b from-[rgba(139,77,94,1)] to-[rgba(107,45,62,1)]",
     sage: "bg-gradient-to-b from-[rgba(122,156,121,1)] to-[rgba(79,107,78,1)]",
   };
 
@@ -69,7 +71,7 @@ export function Hero({
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, delay: 0.1 }}
-        className="relative z-20 text-[11px] uppercase tracking-[0.25em] text-charcoal/60 mb-6"
+        className="relative z-20 text-[11px] uppercase tracking-[0.25em] text-muted-strong mb-6"
       >
         {eyebrow}
       </motion.p>
@@ -165,7 +167,7 @@ export function Hero({
       </motion.div>
 
       {priceSignal && (
-        <div className="relative z-20 -mt-4 mb-6 text-center text-xs text-charcoal/60">
+        <div className="relative z-20 -mt-4 mb-6 text-center text-xs text-muted-strong">
           {priceSignal}
         </div>
       )}

--- a/src/components/logos-cloud.tsx
+++ b/src/components/logos-cloud.tsx
@@ -68,7 +68,7 @@ export function LogoCloud() {
         <div className="text-center mb-12 max-w-2xl mx-auto">
           <div className="inline-flex items-center gap-2 mb-4">
             <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-500" />
-            <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-charcoal/60">
+            <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-muted-strong">
               who this is for
             </p>
           </div>

--- a/src/components/noell-support-chat.tsx
+++ b/src/components/noell-support-chat.tsx
@@ -391,7 +391,7 @@ export function NoellSupportChat() {
                   <IconSend size={15} />
                 </button>
               </div>
-              <p className="text-[9px] text-charcoal/40 mt-2 text-center">
+              <p className="text-[9px] text-[#555555] mt-2 text-center">
                 Noell Support handles new-prospect intake. First response,
                 qualification, routing, and human handoff.
               </p>

--- a/src/components/roi-calculator.tsx
+++ b/src/components/roi-calculator.tsx
@@ -51,7 +51,7 @@ export function ROICalculator() {
       </div>
       <div className="border-t border-warm-border pt-6 space-y-3">
         <div>
-          <div className="text-xs uppercase tracking-widest text-charcoal/60">
+          <div className="text-xs uppercase tracking-widest text-muted-strong">
             Monthly recoverable revenue
           </div>
           <div className="font-serif text-3xl md:text-4xl text-charcoal mt-1">
@@ -65,7 +65,7 @@ export function ROICalculator() {
           Growth ($797/mo) pays for itself in {formatPayback(paybackMonthsGrowth)}.
         </div>
       </div>
-      <div className="text-xs text-charcoal/50 mt-6 leading-relaxed">
+      <div className="text-xs text-muted-medium mt-6 leading-relaxed">
         Conservative model. Assumes 40% recovery rate on missed calls. Your
         actual recovery depends on call volume, timing, and offer.
       </div>

--- a/src/components/testimonials.tsx
+++ b/src/components/testimonials.tsx
@@ -49,7 +49,7 @@ export function Testimonials({
               </div>
               <div>
                 <p className="text-sm font-medium text-charcoal">Santa E.</p>
-                <p className="text-xs text-charcoal/50">
+                <p className="text-xs text-muted-medium">
                   Massage therapist · Laguna Niguel, CA
                 </p>
               </div>


### PR DESCRIPTION
## Summary
This PR introduces new semantic color tokens for muted text and updates component usage to improve WCAG AA contrast compliance across the site. The changes replace arbitrary opacity-based colors (e.g., `text-charcoal/60`) with dedicated, readable-gray tokens that maintain sufficient contrast on cream backgrounds.

## Key Changes

- **New CSS color tokens** (`src/app/globals.css`):
  - `--color-muted-strong`: #5A4A50 (primary muted text, passes AA on cream)
  - `--color-muted-medium`: #6E5E64 (secondary muted text)
  - `--color-on-dark-soft`: rgba(255, 255, 255, 0.82) (soft white on dark backgrounds)

- **Status indicator color update**:
  - Changed green-500 to custom green (#2E7D5B) for better visual consistency

- **Component-wide text color migrations**:
  - Replaced `text-charcoal/60`, `text-charcoal/50`, `text-charcoal/40` with semantic tokens
  - Updated footer, hero, booking embed, features, and other components
  - Applied to eyebrows, labels, secondary copy, and metadata text

- **Accessibility fixes**:
  - Hero lilac variant now uses wine gradient for italic accent (pale-lilac fails ~1.5:1 contrast)
  - Features3 lilac eyebrow uses `text-muted-strong` instead of `text-lilac-dark` (fails AA)
  - Chat widget disclaimer text changed to #555555 for better readability

- **Booking page chip styling**:
  - Updated border and text colors for better visual hierarchy

## Implementation Details
The refactor maintains visual consistency while ensuring all text meets WCAG AA standards (4.5:1 for normal text, 3:1 for large text). Semantic token names make future maintenance and color adjustments more straightforward.

https://claude.ai/code/session_01RpJt7n9CWCZb6DU6ZSqzDu