### PR TITLE
Homepage trim + pricing move + contrast v2

### DIFF
--- a/src/app/noell-front-desk/page.tsx
+++ b/src/app/noell-front-desk/page.tsx
@@ -174,7 +174,7 @@ export default function NoellFrontDeskPage() {
         priceSignal={
           <>
             Starts at $197/mo.{" "}
-            <Link href="/#pricing" className="underline underline-offset-4 decoration-charcoal/30 hover:text-charcoal">
+            <Link href="/pricing" className="underline underline-offset-4 decoration-charcoal/30 hover:text-charcoal">
               See all tiers.
             </Link>
           </>

--- a/src/app/noell-support/page.tsx
+++ b/src/app/noell-support/page.tsx
@@ -169,7 +169,7 @@ export default function NoellSupportPage() {
         priceSignal={
           <>
             Starts at $197/mo.{" "}
-            <Link href="/#pricing" className="underline underline-offset-4 decoration-charcoal/30 hover:text-charcoal">
+            <Link href="/pricing" className="underline underline-offset-4 decoration-charcoal/30 hover:text-charcoal">
               See all tiers.
             </Link>
           </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,12 @@
 import { Hero } from "@/components/hero";
-import { Features } from "@/components/features";
-import LiveSystemLog from "@/components/live-system-log";
-import { FounderQuote } from "@/components/founder-quote";
-import { Features2 } from "@/components/features2";
-import { LogoCloud } from "@/components/logos-cloud";
 import { Testimonials } from "@/components/testimonials";
 import { Systems } from "@/components/systems";
-import { NoellSupportSpotlight } from "@/components/noell-support-spotlight";
-import { Features3 } from "@/components/features3";
-import Pricing from "@/components/pricing";
-import { FAQ } from "@/components/faq";
 import CTA from "@/components/cta";
 
 export default function Home() {
   return (
     <div>
-      {/* 1. Hero (Recognition) */}
+      {/* 1. Hero */}
       <Hero
         headlineLine1Start="Three agents. One system."
         headlineLine1Accent=""
@@ -25,54 +16,29 @@ export default function Home() {
         body="Noell Support handles website chat 24/7. Noell Front Desk never misses a call, text, or confirmation. Noell Care takes reschedules and service questions. The system runs. You run the business."
         footnote=""
         primaryCta={{
-          label: "Start with a free 30-minute audit",
+          label: "Get Your Free Audit",
           href: "/book",
         }}
         secondaryCta={{
           label: "See how it works",
-          href: "#the-noell-system",
+          href: "#systems",
         }}
       />
 
-      {/* 2. Social proof bar, credibility numbers */}
-      <Features />
-
-      <LiveSystemLog />
-
-      {/* 3. Founder presence */}
-      <FounderQuote />
-
-      {/* 4. Problem, Pain (with 85% stat callout) */}
-      <Features2 />
-
-      {/* 6. Who This Is For, vertical identity cards */}
-      <LogoCloud />
-
-      {/* 7. Case Study, moved up before the Agent Roster */}
-      <Testimonials />
-
-      {/* 8. Agent Roster, three Noell agents as a buddy list */}
+      {/* 2. What We Do — three agents, tight */}
       <Systems />
 
-      {/* 9. Noell Support Spotlight, honest positioning */}
-      <NoellSupportSpotlight />
+      {/* 3. Proof — one strong testimonial */}
+      <Testimonials />
 
-      {/* 10. How It Works, three-step process (Features3 reframed) */}
-      <Features3
-        eyebrow="How it works"
-        headlineStart="Three moves"
-        headlineAccent="that close the gap."
-        body="Not a 40-feature list. Three touchpoints, running quietly, that move the numbers every week."
+      {/* 4. Final CTA band */}
+      <CTA
+        eyebrow="The first step"
+        headlineStart="Start with a"
+        headlineAccent="free 30-minute audit."
+        body="No pitch. No pressure. A clear map of where leads are falling through, whether you work with us or not."
+        trustLine="Free · 30 minutes · Live in 14 days"
       />
-
-      {/* 11. Pricing */}
-      <Pricing />
-
-      {/* 12. FAQ */}
-      <FAQ />
-
-      {/* 13. Dark CTA (Action) */}
-      <CTA />
     </div>
   );
 }

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Pricing from "@/components/pricing";
+import { FAQ } from "@/components/faq";
+import CTA from "@/components/cta";
+
+export const metadata: Metadata = {
+  title: "Pricing | Ops by Noell",
+  description:
+    "Transparent, flat-rate pricing for the Noell system. Essentials at $197/mo, Growth at $797/mo, Custom Ops at $1,497/mo. Each tier includes a one-time setup.",
+};
+
+export default function PricingPage() {
+  return (
+    <div>
+      <section className="relative flex max-w-7xl rounded-b-3xl my-2 md:my-8 mx-auto flex-col items-center justify-center pt-24 md:pt-28 pb-6 px-4 md:px-8 bg-gradient-to-t from-[rgba(107,45,62,0.35)] via-[rgba(240,224,214,0.60)] to-[rgba(250,246,241,1)]">
+        <p className="relative z-20 text-[11px] uppercase tracking-[0.25em] text-muted-strong mb-4">
+          Pricing
+        </p>
+        <h1 className="relative z-20 max-w-4xl text-center font-serif text-3xl md:text-5xl lg:text-6xl font-semibold tracking-tight text-charcoal leading-tight">
+          One system.{" "}
+          <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+            Three ways to run it.
+          </span>
+        </h1>
+        <p className="relative z-20 mt-4 max-w-2xl text-center text-charcoal/75 text-sm md:text-base leading-relaxed">
+          Transparent, flat-rate monthly pricing. No bait pricing, no mystery
+          scope. Your audit is where we confirm the right fit and book the
+          install.
+        </p>
+        <p className="relative z-20 mt-3 text-xs text-muted-medium">
+          Curious what you could recover?{" "}
+          <Link
+            href="/roi"
+            className="underline underline-offset-4 decoration-charcoal/30 hover:text-charcoal"
+          >
+            Run the ROI calculator
+          </Link>
+          .
+        </p>
+      </section>
+
+      <Pricing />
+
+      <FAQ
+        eyebrow="Before you book"
+        headlineStart="Pricing questions,"
+        headlineAccent="answered."
+      />
+
+      <CTA />
+    </div>
+  );
+}

--- a/src/app/roi/page.tsx
+++ b/src/app/roi/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ROICalculator } from "@/components/roi-calculator";
+import CTA from "@/components/cta";
+
+export const metadata: Metadata = {
+  title: "ROI Calculator | Ops by Noell",
+  description:
+    "Estimate what a missed-call recovery system could return for your service business. Enter your missed calls per week and average ticket to see monthly recovery and payback.",
+};
+
+export default function RoiPage() {
+  return (
+    <div>
+      <section className="relative flex max-w-7xl rounded-b-3xl my-2 md:my-8 mx-auto flex-col items-center justify-center pt-24 md:pt-28 pb-6 px-4 md:px-8 bg-gradient-to-t from-[rgba(107,45,62,0.35)] via-[rgba(240,224,214,0.60)] to-[rgba(250,246,241,1)]">
+        <p className="relative z-20 text-[11px] uppercase tracking-[0.25em] text-muted-strong mb-4">
+          ROI calculator
+        </p>
+        <h1 className="relative z-20 max-w-3xl text-center font-serif text-3xl md:text-5xl lg:text-6xl font-semibold tracking-tight text-charcoal leading-tight">
+          What could this{" "}
+          <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+            recover for you?
+          </span>
+        </h1>
+        <p className="relative z-20 mt-4 max-w-xl text-center text-charcoal/75 text-sm md:text-base leading-relaxed">
+          A quick back-of-napkin estimate. Tune the inputs to your shop, see the
+          monthly recovery, and check payback against each tier.
+        </p>
+      </section>
+
+      <section className="py-12 md:py-16 px-4">
+        <ROICalculator />
+      </section>
+
+      <section className="px-4 pb-16 text-center max-w-2xl mx-auto">
+        <p className="text-sm text-muted-medium">
+          Like what you see?{" "}
+          <Link
+            href="/pricing"
+            className="text-wine underline underline-offset-4 decoration-wine/40 hover:decoration-wine"
+          >
+            See all tiers
+          </Link>{" "}
+          or{" "}
+          <Link
+            href="/book"
+            className="text-wine underline underline-offset-4 decoration-wine/40 hover:decoration-wine"
+          >
+            book a free audit
+          </Link>
+          .
+        </p>
+      </section>
+
+      <CTA />
+    </div>
+  );
+}

--- a/src/components/agent-chat-widget.tsx
+++ b/src/components/agent-chat-widget.tsx
@@ -352,7 +352,7 @@ export function AgentChatWidget(props: AgentChatWidgetProps) {
                   <IconSend size={15} />
                 </button>
               </div>
-              <p className="text-xs text-[#555555] mt-2 px-1">
+              <p className="text-xs text-muted-medium mt-2 px-1">
                 By chatting, you agree to our{" "}
                 <a href="/privacy" target="_blank" rel="noopener" className="underline">Privacy Policy</a>
                 {" "}and{" "}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -6,14 +6,15 @@ export function Footer() {
     { title: "Home", href: "/" },
     { title: "Systems", href: "/#systems" },
     { title: "Verticals", href: "/verticals" },
-    { title: "Pricing", href: "/#pricing" },
+    { title: "Pricing", href: "/pricing" },
+    { title: "ROI calculator", href: "/roi" },
     { title: "Book", href: "/book" },
   ];
 
   const products = [
     { title: "Noell Support", href: "/noell-support" },
     { title: "Noell Front Desk", href: "/noell-front-desk" },
-    { title: "Noell Care", href: "/#systems" },
+    { title: "Noell Care", href: "/noell-care" },
     { title: "Book an Audit", href: "/book" },
   ];
 

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -35,7 +35,7 @@ export const Navbar = () => {
     { name: "Home", link: "/" },
     { name: "Systems", link: "/#systems" },
     { name: "Verticals", link: "/verticals" },
-    { name: "Pricing", link: "/#pricing" },
+    { name: "Pricing", link: "/pricing" },
     { name: "Noell Support", link: "/noell-support", isAccent: true },
     { name: "Book", link: "/book" },
   ];

--- a/src/components/noell-support-chat.tsx
+++ b/src/components/noell-support-chat.tsx
@@ -391,7 +391,7 @@ export function NoellSupportChat() {
                   <IconSend size={15} />
                 </button>
               </div>
-              <p className="text-[9px] text-[#555555] mt-2 text-center">
+              <p className="text-[9px] text-muted-medium mt-2 text-center">
                 Noell Support handles new-prospect intake. First response,
                 qualification, routing, and human handoff.
               </p>

--- a/src/components/pricing.tsx
+++ b/src/components/pricing.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Button } from "./button";
 import { IconCheck } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
-import { ROICalculator } from "./roi-calculator";
 
 interface PricingTier {
   tier: string;
@@ -156,9 +155,6 @@ export default function Pricing() {
           coverage, smart automation, and implementation support you want
           running behind the scenes for your business.
         </p>
-      </div>
-      <div className="mb-14">
-        <ROICalculator />
       </div>
       <div className="grid md:grid-cols-3 gap-5 items-start">
         {tiers.map((tier) => (

--- a/src/components/systems.tsx
+++ b/src/components/systems.tsx
@@ -41,7 +41,7 @@ const agents: AgentCard[] = [
     description:
       "Rebooking, service questions, account help, and support for clients already in your system. Keeps your front desk clear for new business.",
     uptime: "status: online / existing clients",
-    href: "/#systems",
+    href: "/noell-care",
     icon: <IconHeartHandshake size={22} />,
   },
 ];


### PR DESCRIPTION
## Summary

Trims homepage from 13 → 4 sections. Moves pricing + ROI calculator off the homepage to dedicated routes. Finishes the 2 contrast misses from PR #12 audit.

## Homepage before → after

**Before:** 13 sections stacked
**After:** Hero → Systems ("What We Do") → Testimonials ("Proof") → CTA → Footer

### Removed from `src/app/page.tsx` (components kept, just not imported on home)

- Features (stat bar) — still used on /noell-support
- LiveSystemLog, FounderQuote, Features2, LogoCloud, NoellSupportSpotlight, Features3, FAQ
- Pricing → moved to `/pricing` (new route)
- ROICalculator (was embedded inside Pricing) → moved to `/roi` (new route)

## Pricing

- `/pricing` now exists — renders full Pricing component + FAQ + CTA
- Navbar and footer "Pricing" link → `/pricing`
- Agent-page priceSignal taglines ("Starts at $197/mo. See all tiers.") on /noell-support and /noell-front-desk updated from `/#pricing` → `/pricing`
- Added ROI calculator link to footer
- Noell Care footer and Systems card links updated to `/noell-care`

## Contrast

- **Fix A** (`/book` DIRECT BOOKING label): already on `text-muted-strong` + `#2E7D5B` dot from PR #12. No change required
- **Fix B** (chat widget disclaimers): `noell-support-chat.tsx:394` and `agent-chat-widget.tsx:355` moved from `text-[#555555]` → `text-muted-medium` (#6E5E64, ~6.1:1 on white). Wording unchanged
- **Spot-check C** (`--on-dark-soft`): `globals.css:31` is `rgba(255,255,255,0.82)` → ~5.3:1 on wine. Passes. No change

## A2P guardrail

`git diff main -- src/app/contact src/app/sms-policy src/app/privacy src/app/terms src/app/cookies src/app/legal` is empty. Frozen files untouched.

## Build

`npm run build` passes clean. Both new routes (`/pricing`, `/roi`) prerendered as static.