### PR TITLE
feat: /systems page + pricing clarity + FAQ expansion

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import Pricing from "@/components/pricing";
-import { FAQ } from "@/components/faq";
+import { FAQ, type FaqItem } from "@/components/faq";
 import CTA from "@/components/cta";
 
 export const metadata: Metadata = {
@@ -9,6 +9,117 @@ export const metadata: Metadata = {
   description:
     "Transparent, flat-rate pricing for the Noell system. Essentials at $197/mo, Growth at $797/mo, Custom Ops at $1,497/mo. Each tier includes a one-time setup.",
 };
+
+const pricingFaqs: FaqItem[] = [
+  // Group 1 — Commitment and terms
+  {
+    id: "commitment_month_to_month",
+    group: "commitment",
+    question: "Is this month-to-month or contract?",
+    answer:
+      "Month-to-month. No long-term contracts. Cancel anytime with 30 days notice. Your monthly rate is locked at the price you signed up at for as long as you stay on that tier.",
+  },
+  {
+    id: "commitment_setup_fee",
+    group: "commitment",
+    question: "Why is there a setup fee?",
+    answer:
+      "Setup covers the 14-day install: vertical-specific copy written in your voice, A2P SMS registration (required by federal carriers before any business texting is legal), integration with your existing tools, and the initial automation buildout. It's one-time and non-refundable once provisioning begins. Setup is where the system actually learns your business.",
+  },
+  {
+    id: "commitment_price_increases",
+    group: "commitment",
+    question: "Do prices increase over time?",
+    answer:
+      "No. Your monthly rate is locked at the price you signed up at. If you upgrade tiers, the new rate applies. If you downgrade, the lower rate applies at the start of the next billing month. We don't do introductory pricing games.",
+  },
+  {
+    id: "commitment_upgrade_downgrade",
+    group: "commitment",
+    question: "Can I upgrade or downgrade later?",
+    answer:
+      "Yes. Upgrades are prorated and take effect immediately — the system grows with you. Downgrades take effect at the start of the next billing month so nothing gets orphaned mid-build. If you're on Custom Ops and we're still building your Reactivation Campaigns when you downgrade, we finish what we started on the original tier. No half-built systems.",
+  },
+  {
+    id: "commitment_guarantee",
+    group: "commitment",
+    question: "What if it doesn't work for my business?",
+    answer:
+      "Every install includes a 90-day results check-in. If by day 90 the system hasn't produced measurable lift in at least one of: recovered calls, booked appointments, or captured reviews — we rebuild the core flows at no charge. If the rebuild hasn't moved the numbers by day 120, you can cancel your subscription with no further obligation. The one-time setup fee isn't refundable once provisioning has begun.",
+  },
+  // Group 2 — What you're actually buying
+  {
+    id: "features_tier_difference",
+    group: "features",
+    question: "What's the difference between the three tiers in plain English?",
+    answer:
+      "Essentials ($197/mo) is for solo operators who just need to stop missing calls. It adds A2P-registered texting, auto-reply when you miss a call, appointment confirmation texts, and one review-request sequence. It works alongside your existing booking tool — it doesn't talk to it directly. Think of it as a smart assistant sitting next to your current setup. Growth ($797/mo) is the full front desk system. Everything in Essentials, plus Noell Support AI Chat on your website handling conversations 24/7, no-show recovery sequences, Google review automation, lead pipeline management so nothing falls through the cracks, and a monthly strategy call. Growth also integrates directly with your PMS or booking tool — reading availability, writing confirmed bookings back in. Most practices start here. Custom Ops ($1,497/mo) is for multi-location or reactivation-heavy practices. Everything in Growth, plus reactivation campaigns that win back inactive clients, multi-location sync, a custom reporting dashboard, same-day priority support, and a quarterly business review. If you have unscheduled treatment worth reactivating or more than one location to run, this is the tier.",
+  },
+  {
+    id: "features_a2p_sms",
+    group: "features",
+    question: "What is A2P-registered SMS and why does it matter?",
+    answer:
+      "A2P stands for Application-to-Person. As of 2023, US carriers require every business that sends automated texts to be registered and approved. Unregistered senders get their messages blocked, filtered to spam, or worse — fined. A2P registration is a 2–4 week process involving business verification, campaign approval, and ongoing compliance. We handle it as part of setup. It's the reason your texts actually deliver.",
+  },
+  {
+    id: "features_support_ai_chat",
+    group: "features",
+    question: "What does Noell Support AI Chat (Growth and up) actually do?",
+    answer:
+      "Noell Support is an AI chat agent on your website trained on your specific business — your services, pricing, hours, booking logic, tone. She handles the 80% of website conversations that are predictable: \"Do you take my insurance?\", \"What's the earliest appointment?\", \"How much is a deep tissue?\", \"Can I reschedule?\". She books appointments directly when she has enough information. When a conversation needs a human — refund requests, clinical questions, anything that smells like a complaint — she routes it to your team with the full chat context attached. She is not a generic ChatGPT wrapper.",
+  },
+  {
+    id: "features_no_show_recovery",
+    group: "features",
+    question: "What is no-show recovery (Growth and up)?",
+    answer:
+      "When a client no-shows, most practices just lose the revenue and move on. No-show recovery automatically texts the client within minutes of the miss, offers the next two available slots on your calendar, and rebooks them without anyone at your practice lifting a finger. On average, no-show recovery rebooks 35-45% of misses within 7 days.",
+  },
+  {
+    id: "features_review_automation",
+    group: "features",
+    question: "What is Google review automation (Growth and up)?",
+    answer:
+      "After every appointment, the system texts a review request with a one-tap link to your Google Business profile. Most practices see a 4-8× increase in review volume in the first 90 days. More recent reviews and more 5-star reviews both directly affect how high you rank when someone searches \"dentist near me\" or \"massage near me.\" This is one of the highest-leverage things a practice can do, and nobody does it consistently without automation.",
+  },
+  {
+    id: "features_reactivation",
+    group: "features",
+    question: "What are reactivation campaigns (Custom Ops only)?",
+    answer:
+      "Reactivation campaigns automatically identify and contact inactive clients — typically 6+ months since last visit — with a sequence built around why they probably stopped coming. For dental, that's often unscheduled treatment plans sitting in the PMS; we text a friendly nudge with a direct link to reschedule. For salons, it's clients who drifted after a stylist moved. For massage and spa, it's seasonal drop-offs. Reactivation is usually the highest-ROI automation a practice can run because the leads already know and trust you.",
+  },
+  {
+    id: "features_lead_pipeline",
+    group: "features",
+    question: "What is lead pipeline management (Growth and up)?",
+    answer:
+      "Every lead that comes into your practice — web form, missed call, chat, direct text — gets logged, tagged, and tracked through a visible pipeline: new lead → contacted → booked → consulted → decision. Leads that go cold get automated follow-up, leads that book skip ahead, leads that ghost get categorized so you see what's actually happening. It replaces the sticky-notes-and-texts-with-myself workflow most practices still run on.",
+  },
+  // Group 3 — Install, tools, logistics
+  {
+    id: "logistics_time_to_live",
+    group: "logistics",
+    question: "How long until the system is live?",
+    answer:
+      "14 days from audit-to-live on most installs. A2P registration takes 2–4 weeks on the carrier side but runs in parallel, so your SMS delivery goes live as soon as carriers approve — usually within the first 14 days. Multi-location Custom Ops builds can take up to 21 days. Your audit call confirms the timeline for your specific setup.",
+  },
+  {
+    id: "logistics_replace_booking_tool",
+    group: "logistics",
+    question: "Do I need to replace my current booking tool?",
+    answer:
+      "No. The Noell system layers on top of what you already run — Dentrix, Dentrix Ascend, Eaglesoft, Open Dental, Curve, Denticon for dental; Mindbody, Vagaro, Boulevard, Booker for salons and spas; ServiceTitan, Housecall Pro, Jobber for HVAC. Your team keeps the tool they trained on. We layer the communication and scheduling automation on top. On Essentials, the system works alongside your tool via SMS; on Growth and Custom Ops, it integrates directly (reads availability, writes confirmed bookings back).",
+  },
+  {
+    id: "logistics_managed_meaning",
+    group: "logistics",
+    question: "What does \"managed\" actually mean?",
+    answer:
+      "You never touch the backend. Ongoing copy tweaks, automation adjustments, integration fixes, new review responses, seasonal campaign setup, messaging around holidays and closures — we handle all of it. The Noell team is the admin. You get the monthly report. If something isn't working, you tell us and we fix it. Managed means you don't become an ops person in addition to running your practice.",
+  },
+];
 
 export default function PricingPage() {
   return (
@@ -46,6 +157,8 @@ export default function PricingPage() {
         eyebrow="Before you book"
         headlineStart="Pricing questions,"
         headlineAccent="answered."
+        body="No sales theater. These are the real questions we get before someone books an audit. If yours isn't here, chat with Noell Support — she has the answers too."
+        faqs={pricingFaqs}
       />
 
       <CTA />

--- a/src/app/systems/page.tsx
+++ b/src/app/systems/page.tsx
@@ -1,0 +1,317 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  IconBolt,
+  IconPhoneCall,
+  IconHeartHandshake,
+  IconCompass,
+  IconTool,
+  IconRocket,
+} from "@tabler/icons-react";
+import CTA from "@/components/cta";
+import { cn } from "@/lib/utils";
+import { SystemsPageAnalytics } from "@/components/systems-page-analytics";
+
+export const metadata: Metadata = {
+  title:
+    "The Noell System | One System. Three Agents. Managed End-to-End. | Ops by Noell",
+  description:
+    "The Noell system is a done-for-you front desk, intake, and retention engine for service businesses. Three agents run in the background, layered on top of the tools you already use. Audit, install, live in 14 days.",
+};
+
+type Agent = {
+  title: string;
+  handle: string;
+  eyebrow: string;
+  description: string;
+  status: string;
+  href: string;
+  icon: React.ReactNode;
+};
+
+const agents: Agent[] = [
+  {
+    title: "Noell Support",
+    handle: "@noell_support",
+    eyebrow: "New prospect intake",
+    description:
+      "Website chat, lead qualification, contact capture, and triage to booking or your team.",
+    status: "status: online / 24/7",
+    href: "/noell-support",
+    icon: <IconBolt size={22} />,
+  },
+  {
+    title: "Noell Front Desk",
+    handle: "@noell_frontdesk",
+    eyebrow: "Operations layer",
+    description:
+      "Calls, scheduling, reminders, confirmations, reschedules, review capture, and reactivation.",
+    status: "status: online / runs during hours",
+    href: "/noell-front-desk",
+    icon: <IconPhoneCall size={22} />,
+  },
+  {
+    title: "Noell Care",
+    handle: "@noell_care",
+    eyebrow: "Existing client support",
+    description:
+      "Rebooking, service questions, and account help for existing clients. Keeps the front desk clear for new business.",
+    status: "status: online / existing clients",
+    href: "/noell-care",
+    icon: <IconHeartHandshake size={22} />,
+  },
+];
+
+type ProcessStep = {
+  number: string;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+};
+
+const processSteps: ProcessStep[] = [
+  {
+    number: "01",
+    title: "Audit (Day 0)",
+    description:
+      "Free 30-minute call. We map where leads are falling through, whether you work with us or not.",
+    icon: <IconCompass size={28} />,
+  },
+  {
+    number: "02",
+    title: "Install (Days 1–14)",
+    description:
+      "We write the copy, wire the integrations, register SMS, and train the agents on your business. You approve before go-live.",
+    icon: <IconTool size={28} />,
+  },
+  {
+    number: "03",
+    title: "Live (Day 14+)",
+    description:
+      "The system runs. Monthly report. Ongoing tuning handled by our team. You focus on the business.",
+    icon: <IconRocket size={28} />,
+  },
+];
+
+const marqueeIntegrations = [
+  "Dentrix",
+  "Open Dental",
+  "Mindbody",
+  "Boulevard",
+  "Vagaro",
+  "ServiceTitan",
+  "Housecall Pro",
+];
+
+export default function SystemsPage() {
+  return (
+    <div>
+      <SystemsPageAnalytics />
+
+      {/* Hero */}
+      <section className="relative flex max-w-7xl rounded-b-3xl my-2 md:my-8 mx-auto flex-col items-center justify-center pt-24 md:pt-28 pb-12 md:pb-16 px-4 md:px-8 bg-gradient-to-t from-[rgba(107,45,62,0.35)] via-[rgba(240,224,214,0.60)] to-[rgba(250,246,241,1)]">
+        <div className="relative z-20 flex items-center gap-2 mb-6">
+          <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
+          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-charcoal/60">
+            the noell system / what it is
+          </p>
+        </div>
+        <h1 className="relative z-20 max-w-4xl text-center font-serif text-3xl md:text-5xl lg:text-6xl font-semibold tracking-tight text-charcoal leading-tight">
+          One system. Three agents.{" "}
+          <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+            Managed end-to-end.
+          </span>
+        </h1>
+        <p className="relative z-20 mt-6 max-w-2xl text-center text-charcoal/75 text-base md:text-lg leading-relaxed">
+          The Noell system is a done-for-you front desk, intake, and retention
+          engine for service businesses. Three agents run in the background.
+          You run the business.
+        </p>
+        <div className="relative z-20 mt-10 flex flex-col sm:flex-row gap-3">
+          <Link
+            href="/book"
+            className="inline-flex items-center justify-center h-12 px-7 rounded-full bg-wine text-cream font-medium hover:bg-wine-dark transition-colors"
+          >
+            Get Your Free Audit
+          </Link>
+          <Link
+            href="/noell-support"
+            className="inline-flex items-center justify-center h-12 px-7 rounded-full bg-white/70 border border-warm-border text-charcoal font-medium hover:bg-white transition-colors"
+          >
+            Talk to Noell Support first
+          </Link>
+        </div>
+      </section>
+
+      {/* Three agents card grid */}
+      <section className="w-full py-16 md:py-20 px-4">
+        <div className="max-w-7xl mx-auto">
+          <div className="text-center mb-12 max-w-3xl mx-auto">
+            <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-wine mb-4">
+              the noell system / agent roster
+            </p>
+            <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+              Three agents.{" "}
+              <span className="italic bg-gradient-to-b from-wine to-wine-light bg-clip-text text-transparent">
+                One system.
+              </span>
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {agents.map((agent, index) => (
+              <Link
+                key={agent.handle}
+                href={agent.href}
+                className={cn(
+                  "group relative rounded-[22px] border border-warm-border bg-white",
+                  "p-7 md:p-8 transition-all duration-200",
+                  "shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]",
+                  "hover:-translate-y-1 hover:shadow-[0px_44px_24px_0px_rgba(28,25,23,0.06),0px_18px_18px_0px_rgba(28,25,23,0.08),0px_6px_10px_0px_rgba(28,25,23,0.06)]"
+                )}
+              >
+                <div className="flex items-center justify-between mb-6">
+                  <div className="w-12 h-12 rounded-xl bg-wine/10 text-wine flex items-center justify-center">
+                    {agent.icon}
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
+                    <span className="text-[10px] font-mono text-charcoal/40">
+                      0{index + 1}
+                    </span>
+                  </div>
+                </div>
+                <p className="text-[11px] uppercase tracking-[0.2em] text-wine/70 mb-1">
+                  {agent.eyebrow}
+                </p>
+                <h3 className="font-serif text-2xl font-semibold text-charcoal mb-1">
+                  {agent.title}
+                </h3>
+                <p className="font-mono text-[10px] text-charcoal/40 mb-3">
+                  {agent.handle}
+                </p>
+                <p className="text-sm text-charcoal/80 leading-relaxed">
+                  {agent.description}
+                </p>
+                <div className="mt-6 pt-4 border-t border-warm-border flex items-center justify-between">
+                  <p className="font-mono text-[10px] uppercase tracking-widest text-charcoal/40">
+                    {agent.status}
+                  </p>
+                  <p className="text-xs text-wine font-medium opacity-70 group-hover:opacity-100 transition-opacity">
+                    Learn more &rarr;
+                  </p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* How the install works */}
+      <section className="w-full py-16 md:py-20 px-4">
+        <div className="max-w-6xl mx-auto">
+          <div className="text-center mb-14 max-w-3xl mx-auto">
+            <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-wine mb-4">
+              audit &rarr; install &rarr; live
+            </p>
+            <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+              From a 30-minute call to a live system{" "}
+              <span className="italic bg-gradient-to-b from-wine to-wine-light bg-clip-text text-transparent">
+                in 14 days.
+              </span>
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {processSteps.map((step) => (
+              <div
+                key={step.number}
+                className={cn(
+                  "relative rounded-[22px] border border-warm-border bg-white",
+                  "p-7 md:p-8",
+                  "shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
+                )}
+              >
+                <div className="flex items-center justify-between mb-6">
+                  <div className="w-12 h-12 rounded-xl bg-wine/10 text-wine flex items-center justify-center">
+                    {step.icon}
+                  </div>
+                  <span className="text-[10px] font-mono text-charcoal/30">
+                    {step.number}
+                  </span>
+                </div>
+                <h3 className="font-serif text-xl md:text-2xl font-semibold text-charcoal mb-3 leading-snug">
+                  {step.title}
+                </h3>
+                <p className="text-sm text-charcoal/75 leading-relaxed">
+                  {step.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Integrations band */}
+      <section className="w-full max-w-7xl mx-auto rounded-3xl bg-charcoal px-6 py-20 md:py-24 my-10 md:my-16">
+        <div className="text-center mb-10 max-w-3xl mx-auto">
+          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-blush mb-4">
+            integrates on top / does not replace
+          </p>
+          <h2 className="font-serif text-3xl md:text-5xl font-semibold text-cream leading-tight">
+            The Noell system layers on top of{" "}
+            <span className="italic text-wine-light">
+              the tools you already run.
+            </span>
+          </h2>
+        </div>
+
+        <div className="max-w-5xl mx-auto">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+            {marqueeIntegrations.map((tool) => (
+              <div
+                key={tool}
+                className="rounded-[14px] border border-white/10 bg-white/[0.04] px-4 py-5 text-center"
+              >
+                <p className="font-serif text-lg text-cream">{tool}</p>
+                <p className="font-mono text-[9px] uppercase tracking-widest text-cream/40 mt-1">
+                  supported
+                </p>
+              </div>
+            ))}
+          </div>
+          <p className="text-center text-sm text-cream/60 mt-8 max-w-2xl mx-auto leading-relaxed">
+            Also supported: Dentrix Ascend, Eaglesoft, Curve Dental, Denticon,
+            Booker, Jobber, and most vertical-standard tools. If yours isn&apos;t
+            listed, the audit tells us whether it&apos;s supported.
+          </p>
+          <p className="text-center text-xs text-cream/50 mt-6 max-w-2xl mx-auto leading-relaxed">
+            Deep two-way integration (read availability, write bookings back)
+            is available on Growth and Custom Ops. Essentials uses SMS/text
+            automations that work alongside any existing booking tool.{" "}
+            <Link
+              href="/pricing"
+              className="underline underline-offset-4 decoration-cream/30 hover:text-cream"
+            >
+              See how it scales with your tier
+            </Link>
+            .
+          </p>
+        </div>
+      </section>
+
+      <CTA
+        eyebrow="See how it layers on"
+        headlineStart="See how it layers on"
+        headlineAccent="your business."
+        body="A 30-minute audit gives you a clear map of what's leaking, whether you work with us or not. No pitch. No pressure."
+        primaryCta={{ label: "Book Your Free Audit", href: "/book" }}
+        secondaryCta={{
+          label: "Talk to Noell Support first",
+          href: "/noell-support",
+        }}
+        trustLine="Free 30-minute audit · No contracts · Live in 14 days"
+      />
+    </div>
+  );
+}

--- a/src/app/verticals/dental/page.tsx
+++ b/src/app/verticals/dental/page.tsx
@@ -16,6 +16,7 @@ import { Features3 } from "@/components/features3";
 import { VerticalCaseStudyPlaceholder } from "@/components/vertical-case-study";
 import { localBusinessSchema } from "@/lib/schema";
 import { FAQ } from "@/components/faq";
+import { VerticalPricingSection } from "@/components/pricing";
 import CTA from "@/components/cta";
 import { cn } from "@/lib/utils";
 
@@ -387,6 +388,12 @@ export default function DentalVerticalPage() {
         headlineAccent="that close the gap."
         body="Not a 40-feature list. The three touchpoints that move the numbers in a dental practice."
         capabilities={dentalCapabilities}
+      />
+
+      <VerticalPricingSection
+        vertical="dental"
+        auditPhrase="dental audit"
+        sourcePage="verticals_dental"
       />
 
       {/* Dental FAQ */}

--- a/src/app/verticals/estheticians/page.tsx
+++ b/src/app/verticals/estheticians/page.tsx
@@ -12,6 +12,7 @@ import { Features3 } from "@/components/features3";
 import { VerticalCaseStudyPlaceholder } from "@/components/vertical-case-study";
 import { localBusinessSchema } from "@/lib/schema";
 import { FAQ } from "@/components/faq";
+import { VerticalPricingSection } from "@/components/pricing";
 import CTA from "@/components/cta";
 import { cn } from "@/lib/utils";
 
@@ -279,6 +280,12 @@ export default function EstheticiansVerticalPage() {
         headlineAccent="that protect the routine."
         body="Not a feature list. The three plays that hold a skincare client to the plan without forcing the tone."
         capabilities={estheticianCapabilities}
+      />
+
+      <VerticalPricingSection
+        vertical="estheticians"
+        auditPhrase="skincare audit"
+        sourcePage="verticals_estheticians"
       />
 
       <FAQ

--- a/src/app/verticals/hvac/page.tsx
+++ b/src/app/verticals/hvac/page.tsx
@@ -12,6 +12,7 @@ import { Features3 } from "@/components/features3";
 import { VerticalCaseStudyPlaceholder } from "@/components/vertical-case-study";
 import { localBusinessSchema } from "@/lib/schema";
 import { FAQ } from "@/components/faq";
+import { VerticalPricingSection } from "@/components/pricing";
 import CTA from "@/components/cta";
 import { cn } from "@/lib/utils";
 
@@ -281,6 +282,12 @@ export default function HvacVerticalPage() {
         headlineAccent="that triage the inbound."
         body="Not a feature list. The three plays that keep emergency, service, and maintenance in the right queues."
         capabilities={hvacCapabilities}
+      />
+
+      <VerticalPricingSection
+        vertical="hvac"
+        auditPhrase="HVAC audit"
+        sourcePage="verticals_hvac"
       />
 
       <FAQ

--- a/src/app/verticals/massage/page.tsx
+++ b/src/app/verticals/massage/page.tsx
@@ -12,6 +12,7 @@ import { Features3 } from "@/components/features3";
 import { VerticalCaseStudy } from "@/components/vertical-case-study";
 import { localBusinessSchema } from "@/lib/schema";
 import { FAQ } from "@/components/faq";
+import { VerticalPricingSection } from "@/components/pricing";
 import CTA from "@/components/cta";
 import { cn } from "@/lib/utils";
 
@@ -287,6 +288,12 @@ export default function MassageVerticalPage() {
         headlineAccent="that fill the calendar."
         body="Not a feature list. The three plays that work without making you feel like a salesperson."
         capabilities={massageCapabilities}
+      />
+
+      <VerticalPricingSection
+        vertical="massage"
+        auditPhrase="massage audit"
+        sourcePage="verticals_massage"
       />
 
       <FAQ

--- a/src/app/verticals/med-spas/page.tsx
+++ b/src/app/verticals/med-spas/page.tsx
@@ -12,6 +12,7 @@ import { Features3 } from "@/components/features3";
 import { VerticalCaseStudyPlaceholder } from "@/components/vertical-case-study";
 import { localBusinessSchema } from "@/lib/schema";
 import { FAQ } from "@/components/faq";
+import { VerticalPricingSection } from "@/components/pricing";
 import CTA from "@/components/cta";
 import { cn } from "@/lib/utils";
 
@@ -275,6 +276,12 @@ export default function MedSpasVerticalPage() {
         headlineAccent="that hold the consult."
         body="Not a feature list. The three touchpoints that decide whether warm intent becomes a booked consult."
         capabilities={medSpaCapabilities}
+      />
+
+      <VerticalPricingSection
+        vertical="med_spas"
+        auditPhrase="spa audit"
+        sourcePage="verticals_med_spas"
       />
 
       <FAQ

--- a/src/app/verticals/salons/page.tsx
+++ b/src/app/verticals/salons/page.tsx
@@ -12,6 +12,7 @@ import { Features3 } from "@/components/features3";
 import { VerticalCaseStudyPlaceholder } from "@/components/vertical-case-study";
 import { localBusinessSchema } from "@/lib/schema";
 import { FAQ } from "@/components/faq";
+import { VerticalPricingSection } from "@/components/pricing";
 import CTA from "@/components/cta";
 import { cn } from "@/lib/utils";
 
@@ -274,6 +275,12 @@ export default function SalonsVerticalPage() {
         headlineAccent="that fill the chair."
         body="Not a feature list. The three plays that protect rebook rate and chair utilization."
         capabilities={salonCapabilities}
+      />
+
+      <VerticalPricingSection
+        vertical="salons"
+        auditPhrase="salon audit"
+        sourcePage="verticals_salons"
       />
 
       <FAQ

--- a/src/components/faq.tsx
+++ b/src/components/faq.tsx
@@ -3,10 +3,13 @@ import { useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { IconPlus } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
+import { trackMetaCustomEvent } from "@/lib/meta-pixel-track";
 
-interface FaqItem {
+export interface FaqItem {
+  id?: string;
   question: string;
   answer: string;
+  group?: string;
 }
 
 const defaultFaqs: FaqItem[] = [
@@ -76,6 +79,13 @@ export function FAQ({
         next.delete(index);
       } else {
         next.add(index);
+        const faq = faqs[index];
+        if (faq?.id) {
+          trackMetaCustomEvent("faq_open", {
+            question_id: faq.id,
+            question_group: faq.group,
+          });
+        }
       }
       return next;
     });

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -4,7 +4,7 @@ import { Logo } from "./logo";
 export function Footer() {
   const pages = [
     { title: "Home", href: "/" },
-    { title: "Systems", href: "/#systems" },
+    { title: "Systems", href: "/systems" },
     { title: "Verticals", href: "/verticals" },
     { title: "Pricing", href: "/pricing" },
     { title: "ROI calculator", href: "/roi" },

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -33,7 +33,7 @@ interface NavbarProps {
 export const Navbar = () => {
   const navItems = [
     { name: "Home", link: "/" },
-    { name: "Systems", link: "/#systems" },
+    { name: "Systems", link: "/systems" },
     { name: "Verticals", link: "/verticals" },
     { name: "Pricing", link: "/pricing" },
     { name: "Noell Support", link: "/noell-support", isAccent: true },

--- a/src/components/pricing.tsx
+++ b/src/components/pricing.tsx
@@ -1,78 +1,104 @@
-import React from "react";
+"use client";
+import React, { useEffect, useRef } from "react";
+import Link from "next/link";
 import { Button } from "./button";
 import { IconCheck } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
+import { PRICING_TIERS, type PricingTier, type TierId } from "@/lib/pricing";
+import { trackMetaCustomEvent } from "@/lib/meta-pixel-track";
 
-interface PricingTier {
-  tier: string;
-  priceFrom: string;
-  cadence: string;
-  tagline: string;
-  features: string[];
-  ctaLabel: string;
-  ctaHref: string;
-  isHighlighted?: boolean;
-  note?: string;
+type PricingSourcePage =
+  | "pricing"
+  | "verticals_dental"
+  | "verticals_med_spas"
+  | "verticals_salons"
+  | "verticals_massage"
+  | "verticals_estheticians"
+  | "verticals_hvac"
+  | "systems";
+
+function trackTierClick(tier: TierId, sourcePage: PricingSourcePage) {
+  trackMetaCustomEvent("tier_card_click", {
+    tier,
+    source_page: sourcePage,
+  });
 }
 
-const tiers: PricingTier[] = [
-  {
-    tier: "Essentials",
-    priceFrom: "$197",
-    cadence: "/mo",
-    tagline:
-      "One system. Ideal for solo practitioners who want to stop missing calls.",
-    features: [
-      "Missed Call Text-Back",
-      "Appointment Confirmations",
-      "1 Review Request Sequence",
-      "Monthly Report",
-      "Email Support",
-    ],
-    ctaLabel: "Start with Essentials",
-    ctaHref: "/book",
-    note: "+ $497 one-time setup",
-  },
-  {
-    tier: "Growth",
-    priceFrom: "$797",
-    cadence: "/mo",
-    tagline:
-      "The full front desk system. Most popular for growing practices.",
-    features: [
-      "Everything in Essentials",
-      "Noell Support AI Chat (24/7 booking)",
-      "No-Show Recovery Sequences",
-      "Google Review Automation",
-      "Lead Pipeline Management",
-      "Monthly Strategy Call",
-    ],
-    ctaLabel: "Get Growth",
-    ctaHref: "/book",
-    isHighlighted: true,
-    note: "Most popular · + $997 one-time setup",
-  },
-  {
-    tier: "Custom Ops",
-    priceFrom: "$1,497",
-    cadence: "/mo",
-    tagline:
-      "Full system plus reactivation. For practices ready to scale.",
-    features: [
-      "Everything in Growth",
-      "Reactivation Campaigns",
-      "Multi-location Support",
-      "Custom Reporting Dashboard",
-      "Priority Support (same day)",
-      "Quarterly Business Review",
-    ],
-    ctaLabel: "Book a scoping call",
-    ctaHref: "/book",
-    note: "+ $1,497 one-time setup",
-  },
-];
+export function PricingCard({
+  tier,
+  variant = "full",
+  sourcePage = "pricing",
+}: {
+  tier: PricingTier;
+  variant?: "full" | "compact";
+  sourcePage?: PricingSourcePage;
+}) {
+  if (variant === "compact") {
+    const previewFeatures = tier.features.slice(0, 3);
+    return (
+      <div
+        className={cn(
+          "relative rounded-[26px] flex flex-col gap-3 p-3",
+          tier.isHighlighted
+            ? "border border-white bg-gradient-to-b from-wine-light via-wine to-wine-dark"
+            : "bg-warm-border/70"
+        )}
+      >
+        <div className="space-y-4 p-5 bg-cream rounded-[20px] shadow-[0px_15px_15px_0px_rgba(28,25,23,0.08),0px_4px_8px_0px_rgba(28,25,23,0.10)]">
+          <div className="flex flex-col">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xs font-medium text-charcoal rounded-full border border-warm-border bg-white inline-flex items-center px-3 py-1">
+                {tier.tier}
+              </h3>
+              {tier.isHighlighted && (
+                <span className="text-[10px] font-mono uppercase tracking-widest text-wine">
+                  most popular
+                </span>
+              )}
+            </div>
+            <div className="mt-3 flex items-baseline">
+              <span className="font-serif text-3xl font-bold text-charcoal">
+                {tier.priceFrom}
+              </span>
+              <span className="ml-1 text-xs text-charcoal/50">
+                {tier.cadence}
+              </span>
+            </div>
+            <p className="text-[11px] text-charcoal/50 mt-1">{tier.note}</p>
+          </div>
 
-const PricingCard = ({ tier }: { tier: PricingTier }) => {
+          <ul className="space-y-2 pt-1">
+            {previewFeatures.map((feature) => (
+              <li key={feature} className="flex items-start gap-2">
+                <span
+                  className={cn(
+                    "flex-shrink-0 mt-0.5 w-3.5 h-3.5 rounded-full flex items-center justify-center",
+                    tier.isHighlighted
+                      ? "bg-wine text-cream"
+                      : "bg-blush text-wine"
+                  )}
+                >
+                  <IconCheck size={10} strokeWidth={3} />
+                </span>
+                <span className="text-xs text-charcoal/80 leading-snug">
+                  {feature}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <Link
+            href="/pricing"
+            onClick={() => trackTierClick(tier.id, sourcePage)}
+            className="text-xs font-medium text-wine hover:text-wine-dark underline underline-offset-4 decoration-wine/30 inline-block"
+          >
+            See details &rarr;
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       className={cn(
@@ -106,6 +132,7 @@ const PricingCard = ({ tier }: { tier: PricingTier }) => {
           href={tier.ctaHref}
           variant={tier.isHighlighted ? "primary" : "secondary"}
           className="w-full py-3"
+          onClick={() => trackTierClick(tier.id, sourcePage)}
         >
           {tier.ctaLabel}
         </Button>
@@ -116,7 +143,9 @@ const PricingCard = ({ tier }: { tier: PricingTier }) => {
               <span
                 className={cn(
                   "flex-shrink-0 mt-0.5 w-4 h-4 rounded-full flex items-center justify-center",
-                  tier.isHighlighted ? "bg-wine text-cream" : "bg-blush text-wine"
+                  tier.isHighlighted
+                    ? "bg-wine text-cream"
+                    : "bg-blush text-wine"
                 )}
               >
                 <IconCheck size={11} strokeWidth={3} />
@@ -136,12 +165,84 @@ const PricingCard = ({ tier }: { tier: PricingTier }) => {
       </div>
     </div>
   );
-};
+}
+
+export function VerticalPricingSection({
+  vertical,
+  auditPhrase,
+  sourcePage,
+}: {
+  vertical: string;
+  auditPhrase: string;
+  sourcePage: PricingSourcePage;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting && !firedRef.current) {
+            firedRef.current = true;
+            trackMetaCustomEvent("vertical_pricing_shown", { vertical });
+          }
+        });
+      },
+      { threshold: 0.3 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [vertical]);
+
+  return (
+    <section ref={ref} className="w-full py-16 md:py-20 px-4">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-12 max-w-3xl mx-auto">
+          <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+            pricing, plain
+          </p>
+          <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+            The same three packages power{" "}
+            <span className="italic bg-gradient-to-b from-wine to-wine-light bg-clip-text text-transparent">
+              every vertical.
+            </span>
+          </h2>
+          <p className="mt-5 text-charcoal/75 max-w-xl mx-auto">
+            Your {auditPhrase} confirms the right fit.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-start">
+          {PRICING_TIERS.map((tier) => (
+            <PricingCard
+              key={tier.id}
+              tier={tier}
+              variant="compact"
+              sourcePage={sourcePage}
+            />
+          ))}
+        </div>
+
+        <div className="text-center mt-8">
+          <Link
+            href="/pricing"
+            className="text-sm text-wine hover:text-wine-dark underline underline-offset-4 decoration-wine/30"
+          >
+            See full feature list &rarr;
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
 
 export default function Pricing() {
   return (
     <div id="pricing" className="py-24 px-4 max-w-7xl mx-auto">
-      <div className="text-center mb-16 max-w-3xl mx-auto">
+      <div className="text-center mb-12 max-w-3xl mx-auto">
         <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
           Packages
         </p>
@@ -156,15 +257,39 @@ export default function Pricing() {
           running behind the scenes for your business.
         </p>
       </div>
+
+      {/* Decision D: integration depth by tier (prevents Essentials mis-sale) */}
+      <div className="max-w-3xl mx-auto mb-14 rounded-[20px] border border-warm-border bg-cream/70 p-6 md:p-7 text-sm md:text-[15px] text-charcoal/80 leading-relaxed space-y-3">
+        <p>
+          <span className="font-semibold text-charcoal">
+            All packages include:
+          </span>{" "}
+          vertical-appropriate copy and cadences, A2P-registered SMS,
+          missed-call text-back, and a 14-day install managed by the Noell team.
+        </p>
+        <p>
+          <span className="font-semibold text-charcoal">
+            Growth and Custom Ops also include
+          </span>{" "}
+          two-way integration with your existing booking or practice management
+          tool &mdash; reading availability out, writing confirmed bookings
+          back. Custom Ops adds multi-location sync.
+        </p>
+      </div>
+
       <div className="grid md:grid-cols-3 gap-5 items-start">
-        {tiers.map((tier) => (
-          <PricingCard key={tier.tier} tier={tier} />
+        {PRICING_TIERS.map((tier) => (
+          <PricingCard key={tier.id} tier={tier} sourcePage="pricing" />
         ))}
       </div>
       <p className="text-center text-xs text-charcoal/50 mt-10 max-w-2xl mx-auto">
         Each package includes a one-time setup in addition to the monthly
         subscription. Your audit is where we confirm the right fit, answer any
         questions, and book the install. No bait pricing, no mystery scope.
+      </p>
+      <p className="text-center text-[11px] italic text-charcoal/45 mt-3 max-w-2xl mx-auto">
+        Upgrading between tiers is prorated and takes effect immediately.
+        Downgrades take effect at the start of the next billing month.
       </p>
     </div>
   );

--- a/src/components/systems-page-analytics.tsx
+++ b/src/components/systems-page-analytics.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { useEffect } from "react";
+import { trackMetaCustomEvent } from "@/lib/meta-pixel-track";
+
+export function SystemsPageAnalytics() {
+  useEffect(() => {
+    trackMetaCustomEvent("systems_page_view");
+  }, []);
+  return null;
+}

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -1,0 +1,72 @@
+export type TierId = "essentials" | "growth" | "custom_ops";
+
+export interface PricingTier {
+  id: TierId;
+  tier: string;
+  priceFrom: string;
+  cadence: string;
+  tagline: string;
+  features: string[];
+  ctaLabel: string;
+  ctaHref: string;
+  isHighlighted?: boolean;
+  note: string;
+}
+
+export const PRICING_TIERS: PricingTier[] = [
+  {
+    id: "essentials",
+    tier: "Essentials",
+    priceFrom: "$197",
+    cadence: "/mo",
+    tagline:
+      "One system. Ideal for solo practitioners who want to stop missing calls.",
+    features: [
+      "Missed Call Text-Back",
+      "Appointment Confirmations",
+      "1 Review Request Sequence",
+      "Monthly Report",
+      "Email Support",
+    ],
+    ctaLabel: "Start with Essentials",
+    ctaHref: "/book",
+    note: "+ $497 one-time setup",
+  },
+  {
+    id: "growth",
+    tier: "Growth",
+    priceFrom: "$797",
+    cadence: "/mo",
+    tagline: "The full front desk system. Most popular for growing practices.",
+    features: [
+      "Everything in Essentials",
+      "Noell Support AI Chat (24/7 booking)",
+      "No-Show Recovery Sequences",
+      "Google Review Automation",
+      "Lead Pipeline Management",
+      "Monthly Strategy Call",
+    ],
+    ctaLabel: "Get Growth",
+    ctaHref: "/book",
+    isHighlighted: true,
+    note: "Most popular · + $997 one-time setup",
+  },
+  {
+    id: "custom_ops",
+    tier: "Custom Ops",
+    priceFrom: "$1,497",
+    cadence: "/mo",
+    tagline: "Full system plus reactivation. For practices ready to scale.",
+    features: [
+      "Everything in Growth",
+      "Reactivation Campaigns",
+      "Multi-location Support",
+      "Custom Reporting Dashboard",
+      "Priority Support (same day)",
+      "Quarterly Business Review",
+    ],
+    ctaLabel: "Book a scoping call",
+    ctaHref: "/book",
+    note: "+ $1,497 one-time setup",
+  },
+];


### PR DESCRIPTION
## Summary
- Adds the new `/systems` page for The Noell system with three-agent overview, install process, integration coverage, and CTA.
- Fixes Systems nav/footer links from `/#systems` to `/systems`.
- Adds pricing integration-depth clarity, upgrade/downgrade language, and the expanded 15-question FAQ.
- Adds compact pricing sections to all six vertical pages using shared pricing data.
- Adds Meta Pixel events for `/systems` page views, tier clicks, vertical pricing visibility, and FAQ opens.

## Verification
- A2P guardrail diff check returned clean for contact, sms-policy, privacy, terms, legal, and chat widget files.
- `next build` passed and generated `/systems` as a static route.
- Lint surfaced only pre-existing issues in untouched files.

## Notes
- Does not touch PR #14.
- Does not promote any preview to production.
- Reference: Ops by Noell Packages Brief / Claude Code handoff from Apr 20, 2026.
