### PR TITLE
Homepage: Pick-your-path + full-system feature grid

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,17 @@
+import type { Metadata } from "next";
 import { Hero } from "@/components/hero";
 import { Testimonials } from "@/components/testimonials";
 import { Systems } from "@/components/systems";
 import CTA from "@/components/cta";
+import { PickYourPath } from "@/components/pick-your-path";
+import { FullSystemFeatures } from "@/components/full-system-features";
+
+export const metadata: Metadata = {
+  title:
+    "Ops by Noell | AI Agents + Full Operations Platform for Service Businesses",
+  description:
+    "Three AI agents, or the full white-labeled operations platform. Built for dental, med spas, salons, massage, estheticians, and HVAC. Live in 14 days.",
+};
 
 export default function Home() {
   return (
@@ -25,13 +35,19 @@ export default function Home() {
         }}
       />
 
-      {/* 2. What We Do — three agents, tight */}
+      {/* 2. Pick your path — two tracks (agents-only vs full system) */}
+      <PickYourPath />
+
+      {/* 3. What We Do — three agents, tight */}
       <Systems />
 
-      {/* 3. Proof — one strong testimonial */}
+      {/* 4. What's in the full system — feature grid */}
+      <FullSystemFeatures />
+
+      {/* 5. Proof — one strong testimonial */}
       <Testimonials />
 
-      {/* 4. Final CTA band */}
+      {/* 6. Final CTA band */}
       <CTA
         eyebrow="The first step"
         headlineStart="Start with a"

--- a/src/components/full-system-features.tsx
+++ b/src/components/full-system-features.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import Link from "next/link";
+import {
+  IconUsers,
+  IconLayoutKanban,
+  IconCalendarEvent,
+  IconMessage2,
+  IconFilter,
+  IconStar,
+  IconRotate,
+  IconCertificate,
+  IconClipboardList,
+  IconDeviceMobile,
+  IconChartLine,
+  IconShieldCheck,
+} from "@tabler/icons-react";
+
+type Feature = {
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+};
+
+const features: Feature[] = [
+  {
+    title: "CRM + contact database",
+    description: "Every lead, client, and interaction in one place.",
+    icon: <IconUsers size={22} stroke={1.6} />,
+  },
+  {
+    title: "Pipeline management",
+    description: "Track leads from first touch to booked appointment.",
+    icon: <IconLayoutKanban size={22} stroke={1.6} />,
+  },
+  {
+    title: "Booking calendar",
+    description:
+      "Native calendar that integrates with your PMS or runs standalone.",
+    icon: <IconCalendarEvent size={22} stroke={1.6} />,
+  },
+  {
+    title: "Email + SMS marketing",
+    description: "Broadcasts, drip campaigns, nurture sequences.",
+    icon: <IconMessage2 size={22} stroke={1.6} />,
+  },
+  {
+    title: "Funnels + landing pages",
+    description: "Lead capture pages that match your brand.",
+    icon: <IconFilter size={22} stroke={1.6} />,
+  },
+  {
+    title: "Reputation dashboard",
+    description: "Request, monitor, and respond to reviews from one place.",
+    icon: <IconStar size={22} stroke={1.6} />,
+  },
+  {
+    title: "Reactivation campaigns",
+    description:
+      "Win back lapsed clients automatically (Custom Ops only).",
+    icon: <IconRotate size={22} stroke={1.6} />,
+  },
+  {
+    title: "Memberships + courses",
+    description:
+      "Offer memberships, packages, or educational content.",
+    icon: <IconCertificate size={22} stroke={1.6} />,
+  },
+  {
+    title: "Forms + surveys",
+    description: "Intake forms, client surveys, feedback collection.",
+    icon: <IconClipboardList size={22} stroke={1.6} />,
+  },
+  {
+    title: "Client mobile app",
+    description: "Your own branded app for clients to book and pay.",
+    icon: <IconDeviceMobile size={22} stroke={1.6} />,
+  },
+  {
+    title: "Reporting + analytics",
+    description:
+      "Calls, bookings, revenue, funnel metrics in one dashboard.",
+    icon: <IconChartLine size={22} stroke={1.6} />,
+  },
+  {
+    title: "Managed updates",
+    description:
+      "New features shipped automatically. No maintenance on your end.",
+    icon: <IconShieldCheck size={22} stroke={1.6} />,
+  },
+];
+
+export function FullSystemFeatures() {
+  return (
+    <section className="w-full py-16 md:py-24 px-4">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-14 max-w-3xl mx-auto">
+          <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+            The full system &middot; Included in Growth and Custom Ops
+          </p>
+          <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+            Everything the front of your{" "}
+            <span className="italic bg-gradient-to-b from-wine to-wine-light bg-clip-text text-transparent">
+              business runs on.
+            </span>
+          </h2>
+          <p className="mt-5 text-charcoal/75 max-w-2xl mx-auto leading-relaxed">
+            The agents are one layer. The full system gives you the platform
+            underneath.
+          </p>
+        </div>
+
+        <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-10 md:gap-y-12">
+          {features.map((feature) => (
+            <li key={feature.title} className="flex gap-4">
+              <span className="flex-shrink-0 w-10 h-10 rounded-lg bg-wine/10 text-wine flex items-center justify-center">
+                {feature.icon}
+              </span>
+              <div>
+                <h3 className="font-serif text-lg md:text-xl font-semibold text-charcoal mb-1.5 leading-snug">
+                  {feature.title}
+                </h3>
+                <p className="text-sm text-charcoal/70 leading-relaxed">
+                  {feature.description}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-14 text-center">
+          <Link
+            href="/pricing"
+            className="inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.25em] text-charcoal hover:text-wine transition-colors"
+          >
+            See how it&apos;s priced
+            <span className="text-wine">&rarr;</span>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/pick-your-path.tsx
+++ b/src/components/pick-your-path.tsx
@@ -1,0 +1,151 @@
+import React from "react";
+import Link from "next/link";
+import { IconCheck } from "@tabler/icons-react";
+import { cn } from "@/lib/utils";
+
+type CardProps = {
+  eyebrow: string;
+  title: string;
+  oneLiner: string;
+  bullets: string[];
+  banner?: string;
+  priceLine: string;
+  ctaLabel: string;
+  ctaHref: string;
+  highlighted?: boolean;
+};
+
+const cards: CardProps[] = [
+  {
+    eyebrow: "Self-serve",
+    title: "Noell Agents",
+    oneLiner:
+      "Three AI agents. Works alongside the booking tool you already use.",
+    bullets: [
+      "Noell Support — 24/7 website chat + lead qualification",
+      "Noell Front Desk — calls, scheduling, confirmations, reminders",
+      "Noell Care — rebooking + existing-client support",
+      "Works with any booking tool",
+      "Light onboarding, live in under a week",
+    ],
+    banner: "Founding rate: $197/mo (through June 30)",
+    priceLine: "$297/mo",
+    ctaLabel: "Start the agents",
+    ctaHref: "/agents",
+  },
+  {
+    eyebrow: "Done-for-you · 14-day install",
+    title: "The Noell System",
+    oneLiner:
+      "The entire operations platform, your brand, installed and managed by our team.",
+    bullets: [
+      "Full white-labeled operations platform (CRM, calendars, marketing)",
+      "Three AI agents included (Growth tier and up)",
+      "Two-way integration with your PMS/booking tool",
+      "Free 30-minute audit before you commit",
+      "Managed install in 14 days",
+      "Ongoing updates, no maintenance on your end",
+    ],
+    priceLine: "From $197/mo to $1,497/mo + setup",
+    ctaLabel: "Book a free audit",
+    ctaHref: "/book",
+    highlighted: true,
+  },
+];
+
+function Card({ card }: { card: CardProps }) {
+  return (
+    <div
+      className={cn(
+        "relative flex flex-col rounded-[22px] bg-white p-7 md:p-8 h-full",
+        "shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]",
+        card.highlighted
+          ? "border border-wine"
+          : "border border-warm-border"
+      )}
+    >
+      <p className="text-[11px] uppercase tracking-[0.2em] text-wine/70 mb-2">
+        {card.eyebrow}
+      </p>
+      <h3 className="font-serif text-2xl md:text-3xl font-semibold text-charcoal mb-3">
+        {card.title}
+      </h3>
+      <p className="text-sm md:text-base text-charcoal/80 leading-relaxed mb-6">
+        {card.oneLiner}
+      </p>
+
+      <ul className="space-y-3 mb-7 flex-1">
+        {card.bullets.map((bullet) => (
+          <li key={bullet} className="flex items-start gap-2.5">
+            <span className="flex-shrink-0 mt-0.5 w-5 h-5 rounded-full bg-wine/10 text-wine flex items-center justify-center">
+              <IconCheck size={12} strokeWidth={3} />
+            </span>
+            <span className="text-sm text-charcoal/80 leading-snug">
+              {bullet}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-auto">
+        {card.banner && (
+          <div className="mb-3 rounded-md bg-wine/10 px-3 py-2 text-center">
+            <p className="text-xs font-medium text-wine">{card.banner}</p>
+          </div>
+        )}
+        <p
+          className={cn(
+            "text-center mb-5",
+            card.highlighted
+              ? "font-serif text-lg text-charcoal"
+              : "text-sm text-charcoal/70"
+          )}
+        >
+          {card.priceLine}
+        </p>
+        <Link
+          href={card.ctaHref}
+          className={cn(
+            "inline-flex w-full items-center justify-center rounded-[8px] h-12 px-6 text-sm font-medium transition-colors tap-target",
+            card.highlighted
+              ? "bg-[linear-gradient(181deg,_#8B4D5E_18.12%,_#5A1F30_99.57%)] text-white shadow-[0px_4px_8px_0px_rgba(90,31,48,0.18),_0px_2px_4px_0px_rgba(90,31,48,0.12),0px_0px_0px_1px_rgba(90,31,48,0.12),_0px_1px_1px_2px_rgba(255,255,255,0.28)_inset,0px_-1px_5px_2px_rgba(255,255,255,0.20)_inset]"
+              : "bg-white border border-warm-border text-charcoal hover:bg-cream"
+          )}
+        >
+          {card.ctaLabel}
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export function PickYourPath() {
+  return (
+    <section className="w-full py-16 md:py-24 px-4">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-12 max-w-3xl mx-auto">
+          <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+            Two ways to run it
+          </p>
+          <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+            Just the agents, or the{" "}
+            <span className="italic bg-gradient-to-b from-wine to-wine-light bg-clip-text text-transparent">
+              full system.
+            </span>
+          </h2>
+          <p className="mt-5 text-charcoal/75 max-w-2xl mx-auto leading-relaxed">
+            Run only the AI layer on top of what you already have. Or let us
+            install the entire operation end-to-end — platform, automations,
+            agents, and managed updates.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-[repeat(auto-fit,minmax(320px,1fr))] items-stretch">
+          {cards.map((card) => (
+            <Card key={card.title} card={card} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Adds two new homepage sections slotted into the existing flow, plus a homepage-scoped `metadata` override. The existing `<Hero>`, `<Systems>` (agents roster), `<Testimonials>` (Santa E. proof), and `<CTA>` sections are unchanged — I only edited the wrapper in `src/app/page.tsx` to import the new pieces and insert them at the right positions.

New homepage order:
1. Hero *(unchanged)*
2. **Pick your path** *(new)* — "Just the agents, or the full system."
3. Systems *(unchanged)* — the existing three-agent roster
4. **What's in the full system** *(new)* — 12-feature grid linking to `/pricing`
5. Testimonials *(unchanged)*
6. CTA *(unchanged)*

## Files changed

- `src/app/page.tsx` — added `metadata` export (new title + description), imported + inserted the two new sections in the correct slots. Hero / Systems / Testimonials / CTA JSX is byte-for-byte what was on main.
- `src/components/pick-your-path.tsx` *(new)* — "Pick your path" server component with two equal-height cards.
- `src/components/full-system-features.tsx` *(new)* — "What's in the full system" server component with the 12-feature grid.

## Design decisions worth calling out

- **Highlight treatment on Card B (The Noell System):** the brief said pick one, either a "Most complete" ribbon OR a 1px wine border. I went with the **1px wine border** — it's quieter, reads "premium" not "loud," and avoids competing with the urgency treatment on `/agents`. Flag if you'd rather see the ribbon.
- **Tablet wrap behavior** on "Pick your path": used `grid-cols-[repeat(auto-fit,minmax(320px,1fr))]` so cards go 2-up when the container has room for 2 × 320px + gap, and stack cleanly below that. Tested mentally: at 375px viewport → stacked; at 768px → 2-up; at 1280px → 2-up. No awkward mid-range wrap.
- **Icons:** the site already uses `@tabler/icons-react` everywhere (lucide is in `package.json` but unused in `src/`). Kept Tabler for visual consistency — used line-style (stroke 1.6) icons only, nothing filled, per the brief.
- **"SEE HOW IT'S PRICED →" CTA** is rendered as a small-caps charcoal link with a wine arrow (matches the quiet editorial tone of the feature grid, doesn't compete with the primary CTAs elsewhere).
- **Color:** used the existing `wine` token (#6A2C3E) throughout, as confirmed for this session. No new colors, no new fonts.

## Meta tags

- `<title>` → `Ops by Noell | AI Agents + Full Operations Platform for Service Businesses`
- `<meta name="description">` → `Three AI agents, or the full white-labeled operations platform. Built for dental, med spas, salons, massage, estheticians, and HVAC. Live in 14 days.`

Layout-level OG tags and pixel setup are untouched — the Meta Pixel component still renders once in `layout.tsx` and fires `PageView` on the homepage exactly as before.

## A2P-frozen paths — untouched

```
$ git diff --stat origin/main -- src/app/contact src/app/sms-policy src/app/privacy src/app/terms src/app/legal src/components/noell-support-chat.tsx src/components/agent-chat-widget.tsx
(empty)
```

## Guardrails verified

- Zero hits for `GoHighLevel`, `GHL`, or `SaaS Pro` across the three files touched
- No "unleash / supercharge / powerful / 10x / game-changing" language
- Reuses existing tokens (`wine`, `warm-border`, `cream`, `charcoal`, `blush`), existing fonts (Playfair Display serif, Inter body), existing shadow recipe from `systems.tsx` card pattern, existing primary-button gradient (inlined on Card B's CTA because it's a `<Link>` not a `<Button>`)
- Pixel events: no new pixel init, no re-init; `PageView` still fires via the root `MetaPixel` on every navigation. No custom events added on homepage (by design)

## Build + lint

- `npm run build` — clean, 32/32 static pages generated, homepage still prerendered (`○`)
- `npm run lint` — zero new errors on the three files I touched (same 10 pre-existing errors in `hero.tsx`, `use-media-query.tsx`, `detected-timezone.tsx` as last PR — out of scope)

## QA checklist for Noell

**Copy / layout:**
- [ ] Both card headlines, one-liners, and bullets read right in operator voice
- [ ] Card B's 1px wine border reads "premium" without screaming — if not, say so and I'll swap to the ribbon
- [ ] Pricing labels: Card A shows `$297/mo` with `Founding rate: $197/mo (through June 30)` banner above; Card B shows `From $197/mo to $1,497/mo + setup`
- [ ] 12-feature grid headings + descriptions are accurate (especially the `Reactivation campaigns (Custom Ops only)` qualifier and `Memberships + courses` positioning)

**Wiring:**
- [ ] Card A CTA `Start the agents` → `/agents`
- [ ] Card B CTA `Book a free audit` → `/book` (same target as hero audit CTA)
- [ ] `SEE HOW IT'S PRICED →` at bottom of feature grid → `/pricing`
- [ ] Homepage `<title>` + `<meta name="description">` reflect the two tracks (DevTools → Elements → `<head>`)

**Responsive (test at 375px / 768px / 1280px):**
- [ ] 375px — both Pick-your-path cards stack vertically, no horizontal scroll; feature grid is 1-col
- [ ] 768px — Pick-your-path cards go 2-up; feature grid is 2-col
- [ ] 1280px — feature grid is 3-col × 4-row with generous spacing

**Regression check:**
- [ ] Existing hero, Systems agents roster, Santa E. testimonial, and audit CTA render identically
- [ ] Meta Pixel `PageView` still fires on homepage load

Do **not** auto-merge. Session 3 (pricing rebuild + nav update + verticals callouts + `/faq` redirect) waits on this.
