### PR TITLE
fix(supabase): opsbynoell uses GHL LC Phone, not Twilio (park Twilio seed)

### DIFF
--- a/supabase/seeds/opsbynoell_seed.twilio.pending.sql
+++ b/supabase/seeds/opsbynoell_seed.twilio.pending.sql
@@ -1,0 +1,177 @@
+-- ============================================================
+-- ⚠️  DO NOT APPLY — PENDING STANDALONE TWILIO ACCOUNT ⚠️
+--
+-- This seed sets sms_provider='twilio' and requires a standalone
+-- Twilio account with its own TCR A2P brand + campaign approval,
+-- purchased number, and TWILIO_ACCOUNT_SID / TWILIO_AUTH_TOKEN /
+-- TWILIO_FROM_NUMBER env vars set in Vercel.
+--
+-- As of 2026-04-22, none of that exists. The A2P approval on
+-- Saturday 2026-04-18 was for GHL LC Phone (+1 949-997-3915),
+-- not a standalone Twilio account. GHL's TCR approval does NOT
+-- transfer to Twilio — a separate Twilio brand/campaign review
+-- (~1–3 weeks) would be required.
+--
+-- For current state: apply supabase/seeds/opsbynoell_seed_ghl.sql
+-- instead. Promote THIS file only after a standalone Twilio
+-- account is fully set up and smoke-tested.
+-- ============================================================
+
+-- ============================================================
+-- Ops by Noell — clients row (internal support agent)
+-- Target project: clipzfkbzupjctherijz
+-- GHL location ID: Un5H1b2zXJM3agZ56j7c
+-- SMS provider: Twilio (standalone account, post-A2P 10DLC approval)
+--
+-- Run AFTER:
+--   supabase/migrations/0001_agents_schema.sql
+--   supabase/migrations/0002_multi_tenant_admin.sql
+--
+-- PLACEHOLDERS — must be updated before go-live:
+--   PHONE_PLACEHOLDER — replace with the purchased Twilio A2P number
+--                      (E.164, e.g. +19499991234). Used in:
+--                        - clients.phone
+--                        - clients.locations[0].phone
+--                        - clients.escalation_rules.qualifiedLead.smsTo
+--                          (set this one to Nikki's personal cell, NOT
+--                          the Twilio number)
+--
+-- Notes:
+--   - Ops by Noell only runs the Support tier on its own marketing site.
+--     Front Desk and Care are products sold to reseller clients, not used
+--     internally.
+--   - sms_provider='twilio' — SMS sends go through the standalone Twilio
+--     account configured via TWILIO_ACCOUNT_SID / TWILIO_AUTH_TOKEN /
+--     TWILIO_FROM_NUMBER env vars (see docs/ENV_VARS.md).
+--   - sms_config.from is informational only; TwilioSms reads the real
+--     From number from env at send-time.
+-- ============================================================
+
+
+INSERT INTO public.clients (
+  id,
+  brand_name,
+  vertical,
+  phone,
+  email,
+  agents,
+
+  -- Noell Support config
+  support_system_prompt,
+  support_greeting,
+  support_booking_url,
+
+  -- Noell Front Desk config (unused for Ops by Noell)
+  front_desk_system_prompt,
+  calendar_provider,
+  calendar_config,
+  sms_provider,
+  sms_config,
+  missed_call_text_template,
+  review_platform,
+  review_url,
+  reactivation_threshold_days,
+
+  -- Noell Care config (unused for Ops by Noell)
+  care_system_prompt,
+  care_greeting,
+
+  -- Business metadata
+  hours,
+  locations,
+  team,
+  escalation_rules,
+  telegram_chat_id
+)
+VALUES (
+  'opsbynoell',
+  'Ops by Noell',
+  'internal',
+  'PHONE_PLACEHOLDER',
+  'hello@opsbynoell.com',
+  '{"support": true, "frontDesk": false, "care": false}'::jsonb,
+
+  -- Support system prompt (fallback — v2 prompt file not present at seed-write time)
+  'You are the Support agent for Ops by Noell, a small automation agency run by Nikki. Ops by Noell sells three tiers of AI-powered agents to service businesses: Noell Support (website chat + lead capture), Noell Front Desk (24/7 missed-call text-back + booking), and Noell Care (returning-client scheduling and follow-up).
+
+Your job is to (1) greet visitors warmly, (2) answer questions about the three tiers and what each one does, (3) capture the visitor''s name, business, and contact info, and (4) route qualified leads to the contact form at https://www.opsbynoell.com/contact. When a lead is clearly qualified (they run a service business, they''ve described a concrete pain point, and they''ve given contact info), escalate to Nikki via SMS and email using the escalation rules configured on this client.
+
+Be concise, plain-spoken, and grounded. Never invent pricing. If asked about cost, explain that Nikki scopes pricing per-client after a short intake and point them to the contact form. Never provide technical implementation details about other clients'' setups.',
+
+  'Hi — I''m Noell Support. I help with questions about the Noell Support, Front Desk, and Care tiers, and I can route you straight to Nikki. What can I help with?',
+  'https://www.opsbynoell.com/book',
+
+  -- Front Desk: not enabled for Ops by Noell
+  NULL,
+
+  'ghl',
+  '{"locationId": "Un5H1b2zXJM3agZ56j7c"}'::jsonb,
+
+  -- KEY CHANGE: Twilio (standalone account) instead of GHL LC Phone.
+  -- The actual From number is read from TWILIO_FROM_NUMBER env at send-time;
+  -- the JSON below is informational so operators can see the source.
+  'twilio',
+  '{"from": "env:TWILIO_FROM_NUMBER"}'::jsonb,
+
+  NULL,            -- missed_call_text_template (Front Desk not in use)
+  'google',
+  NULL,            -- review_url (not in use yet)
+  NULL,            -- reactivation_threshold_days (Care not in use)
+
+  NULL,            -- care_system_prompt
+  NULL,            -- care_greeting
+
+  '{}'::jsonb,     -- hours (internal agency, no public hours)
+
+  -- Locations: iPostal1 mailing address (NEVER use 14 Quinn Way publicly)
+  '[{
+    "name": "Ops by Noell HQ",
+    "address": "23710 El Toro Road #1086, Lake Forest, CA 92630",
+    "phone": "PHONE_PLACEHOLDER"
+  }]'::jsonb,
+
+  '[{"name": "Nikki", "role": "Founder"}]'::jsonb,
+
+  -- Escalation rules: qualified leads alert Nikki via SMS + email.
+  -- Replace PHONE_PLACEHOLDER with Nikki's personal cell in E.164 post-Twilio setup.
+  '{
+    "qualifiedLead": {
+      "smsTo":   "PHONE_PLACEHOLDER",
+      "emailTo": "hello@opsbynoell.com"
+    }
+  }'::jsonb,
+
+  NULL             -- telegram_chat_id (not in use)
+)
+ON CONFLICT (id) DO UPDATE SET
+  brand_name                  = EXCLUDED.brand_name,
+  vertical                    = EXCLUDED.vertical,
+  phone                       = EXCLUDED.phone,
+  email                       = EXCLUDED.email,
+  agents                      = EXCLUDED.agents,
+  support_system_prompt       = EXCLUDED.support_system_prompt,
+  support_greeting            = EXCLUDED.support_greeting,
+  support_booking_url         = EXCLUDED.support_booking_url,
+  front_desk_system_prompt    = EXCLUDED.front_desk_system_prompt,
+  calendar_provider           = EXCLUDED.calendar_provider,
+  calendar_config             = EXCLUDED.calendar_config,
+  sms_provider                = EXCLUDED.sms_provider,
+  sms_config                  = EXCLUDED.sms_config,
+  missed_call_text_template   = EXCLUDED.missed_call_text_template,
+  review_platform             = EXCLUDED.review_platform,
+  review_url                  = EXCLUDED.review_url,
+  reactivation_threshold_days = EXCLUDED.reactivation_threshold_days,
+  care_system_prompt          = EXCLUDED.care_system_prompt,
+  care_greeting               = EXCLUDED.care_greeting,
+  hours                       = EXCLUDED.hours,
+  locations                   = EXCLUDED.locations,
+  team                        = EXCLUDED.team,
+  escalation_rules            = EXCLUDED.escalation_rules,
+  telegram_chat_id            = EXCLUDED.telegram_chat_id;
+
+
+-- ============================================================
+-- Verify with:
+--   SELECT id, brand_name, sms_provider, sms_config
+--   FROM clients WHERE id = 'opsbynoell';
+-- ============================================================

--- a/supabase/seeds/opsbynoell_seed_ghl.sql
+++ b/supabase/seeds/opsbynoell_seed_ghl.sql
@@ -2,30 +2,25 @@
 -- Ops by Noell — clients row (internal support agent)
 -- Target project: clipzfkbzupjctherijz
 -- GHL location ID: Un5H1b2zXJM3agZ56j7c
--- SMS provider: Twilio (standalone account, post-A2P 10DLC approval)
+-- SMS provider: GHL LC Phone (A2P 10DLC approved 2026-04-18)
+--
+-- APPLY THIS SEED. The sibling file opsbynoell_seed.twilio.pending.sql
+-- is parked until a standalone Twilio account exists.
 --
 -- Run AFTER:
 --   supabase/migrations/0001_agents_schema.sql
 --   supabase/migrations/0002_multi_tenant_admin.sql
 --
--- PLACEHOLDERS — must be updated before go-live:
---   PHONE_PLACEHOLDER — replace with the purchased Twilio A2P number
---                      (E.164, e.g. +19499991234). Used in:
---                        - clients.phone
---                        - clients.locations[0].phone
---                        - clients.escalation_rules.qualifiedLead.smsTo
---                          (set this one to Nikki's personal cell, NOT
---                          the Twilio number)
+-- Numbers in this file:
+--   +19499973915 — "Nikki's number" in GHL LC Phone (A2P verified).
+--                  Used as the From number for outbound SMS from the
+--                  Noell Support chat widget, and as the public
+--                  business phone on the locations block.
+--   +19497849726 — Business receiving line (Verizon, James Noell).
+--                  All qualified-lead escalation SMS alerts go here.
 --
--- Notes:
---   - Ops by Noell only runs the Support tier on its own marketing site.
---     Front Desk and Care are products sold to reseller clients, not used
---     internally.
---   - sms_provider='twilio' — SMS sends go through the standalone Twilio
---     account configured via TWILIO_ACCOUNT_SID / TWILIO_AUTH_TOKEN /
---     TWILIO_FROM_NUMBER env vars (see docs/ENV_VARS.md).
---   - sms_config.from is informational only; TwilioSms reads the real
---     From number from env at send-time.
+-- Telegram is intentionally disabled (telegram_chat_id = NULL).
+-- Qualified-lead alerts route: SMS -> +19497849726, email -> hello@opsbynoell.com.
 -- ============================================================
 
 
@@ -68,11 +63,11 @@ VALUES (
   'opsbynoell',
   'Ops by Noell',
   'internal',
-  'PHONE_PLACEHOLDER',
+  '+19499973915',
   'hello@opsbynoell.com',
   '{"support": true, "frontDesk": false, "care": false}'::jsonb,
 
-  -- Support system prompt (fallback — v2 prompt file not present at seed-write time)
+  -- Support system prompt
   'You are the Support agent for Ops by Noell, a small automation agency run by Nikki. Ops by Noell sells three tiers of AI-powered agents to service businesses: Noell Support (website chat + lead capture), Noell Front Desk (24/7 missed-call text-back + booking), and Noell Care (returning-client scheduling and follow-up).
 
 Your job is to (1) greet visitors warmly, (2) answer questions about the three tiers and what each one does, (3) capture the visitor''s name, business, and contact info, and (4) route qualified leads to the contact form at https://www.opsbynoell.com/contact. When a lead is clearly qualified (they run a service business, they''ve described a concrete pain point, and they''ve given contact info), escalate to Nikki via SMS and email using the escalation rules configured on this client.
@@ -88,11 +83,11 @@ Be concise, plain-spoken, and grounded. Never invent pricing. If asked about cos
   'ghl',
   '{"locationId": "Un5H1b2zXJM3agZ56j7c"}'::jsonb,
 
-  -- KEY CHANGE: Twilio (standalone account) instead of GHL LC Phone.
-  -- The actual From number is read from TWILIO_FROM_NUMBER env at send-time;
-  -- the JSON below is informational so operators can see the source.
-  'twilio',
-  '{"from": "env:TWILIO_FROM_NUMBER"}'::jsonb,
+  -- SMS via GHL LC Phone. A2P 10DLC approved 2026-04-18.
+  -- The locationId below routes through the Ops by Noell GHL sub-account,
+  -- which sends from +19499973915 ("Nikki's number", A2P verified).
+  'ghl',
+  '{"locationId": "Un5H1b2zXJM3agZ56j7c", "fromNumber": "+19499973915"}'::jsonb,
 
   NULL,            -- missed_call_text_template (Front Desk not in use)
   'google',
@@ -108,21 +103,22 @@ Be concise, plain-spoken, and grounded. Never invent pricing. If asked about cos
   '[{
     "name": "Ops by Noell HQ",
     "address": "23710 El Toro Road #1086, Lake Forest, CA 92630",
-    "phone": "PHONE_PLACEHOLDER"
+    "phone": "+19499973915"
   }]'::jsonb,
 
   '[{"name": "Nikki", "role": "Founder"}]'::jsonb,
 
-  -- Escalation rules: qualified leads alert Nikki via SMS + email.
-  -- Replace PHONE_PLACEHOLDER with Nikki's personal cell in E.164 post-Twilio setup.
+  -- Escalation rules: qualified leads alert the Ops by Noell business line
+  -- (Verizon, James Noell) via SMS, plus email to hello@opsbynoell.com.
+  -- Telegram is intentionally disabled.
   '{
     "qualifiedLead": {
-      "smsTo":   "PHONE_PLACEHOLDER",
+      "smsTo":   "+19497849726",
       "emailTo": "hello@opsbynoell.com"
     }
   }'::jsonb,
 
-  NULL             -- telegram_chat_id (not in use)
+  NULL             -- telegram_chat_id (disabled; alerts go via SMS + email)
 )
 ON CONFLICT (id) DO UPDATE SET
   brand_name                  = EXCLUDED.brand_name,
@@ -153,6 +149,13 @@ ON CONFLICT (id) DO UPDATE SET
 
 -- ============================================================
 -- Verify with:
---   SELECT id, brand_name, sms_provider, sms_config
+--   SELECT id, brand_name, sms_provider, sms_config,
+--          escalation_rules, telegram_chat_id
 --   FROM clients WHERE id = 'opsbynoell';
+--
+-- Expected:
+--   sms_provider = 'ghl'
+--   sms_config   = {"locationId":"Un5H1b2zXJM3agZ56j7c","fromNumber":"+19499973915"}
+--   escalation_rules.qualifiedLead.smsTo = +19497849726
+--   telegram_chat_id = NULL
 -- ============================================================


### PR DESCRIPTION
## Why

PR #9 merged a seed that sets `sms_provider='twilio'` for the `opsbynoell` client. That seed was **not applied to Supabase** (good), but its premise was wrong: the A2P 10DLC approval on 2026-04-18 was for **GHL LC Phone** (+1 949-997-3915), not for a standalone Twilio account. No standalone Twilio account exists yet, and TCR approvals do not transfer between CSPs — a Twilio-side brand/campaign review (~1–3 weeks) would be required to flip.

This PR corrects the seed so SMS actually works today via GHL, and parks the Twilio seed behind a clear DO-NOT-APPLY header.

## Changes

- Rename `supabase/seeds/opsbynoell_seed.sql` → `supabase/seeds/opsbynoell_seed.twilio.pending.sql` with a prominent DO-NOT-APPLY header explaining when to promote it.
- Add `supabase/seeds/opsbynoell_seed_ghl.sql` — **this is the one to apply now**:
  - `sms_provider = 'ghl'`
  - `sms_config = {"locationId": "Un5H1b2zXJM3agZ56j7c", "fromNumber": "+19499973915"}`
  - `phone = +19499973915`
  - `escalation_rules.qualifiedLead.smsTo = +19497849726` (Ops by Noell business line, Verizon, James Noell)
  - `escalation_rules.qualifiedLead.emailTo = hello@opsbynoell.com`
  - `telegram_chat_id = NULL` (Telegram intentionally disabled)

**No code changes.** The `registry.ts` switch already handles both providers.

## To apply

After merging, open Supabase SQL editor on project `clipzfkbzupjctherijz` and run:

```sql
-- paste contents of supabase/seeds/opsbynoell_seed_ghl.sql
```

Then verify:

```sql
SELECT id, brand_name, sms_provider, sms_config, escalation_rules, telegram_chat_id
FROM clients WHERE id = 'opsbynoell';
```

Expected:
- `sms_provider = 'ghl'`
- `sms_config` contains `locationId` and `fromNumber`
- `escalation_rules.qualifiedLead.smsTo = +19497849726`
- `telegram_chat_id` is NULL

## When to promote the Twilio seed

Only after all of these are true:
1. Standalone Twilio account signed up (NOT through GHL)
2. Twilio Trust Hub brand registered + approved
3. Twilio A2P campaign registered + approved (separate from GHL's)
4. Number purchased inside Twilio and linked to the approved campaign
5. Vercel env vars set in all three scopes: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER`
6. `pnpm twilio:smoke +19497849726` succeeds and the test SMS is received

At that point, apply `opsbynoell_seed.twilio.pending.sql` (ideally after another PR that renames it back).