### PR TITLE
feat: SMS alerts on qualified leads (GHL LC Phone, post-A2P)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "node --import ./scripts/test-loader.mjs --test --experimental-strip-types --experimental-test-module-mocks --disable-warning=ExperimentalWarning 'src/lib/**/*.test.ts'",
     "twilio:smoke": "tsx scripts/twilio-smoke-test.ts"
   },
   "dependencies": {

--- a/scripts/test-loader.mjs
+++ b/scripts/test-loader.mjs
@@ -1,0 +1,12 @@
+/**
+ * Minimal ESM resolver hook for `node --test` with TypeScript sources.
+ *
+ * Node's native ESM resolver requires explicit extensions, but our
+ * source files use extensionless relative imports (resolved at build
+ * time by the Next.js bundler). This hook falls back to appending
+ * `.ts` when the original specifier fails to resolve, so tests can
+ * run without any bundler or new dependencies.
+ */
+import { register } from "node:module";
+
+register(new URL("./test-resolve-hook.mjs", import.meta.url));

--- a/scripts/test-resolve-hook.mjs
+++ b/scripts/test-resolve-hook.mjs
@@ -1,0 +1,17 @@
+/**
+ * ESM resolver hook: falls back to `.ts` for extensionless relative
+ * imports when the original resolution fails. Used only by `npm test`.
+ */
+export async function resolve(specifier, context, nextResolve) {
+  try {
+    return await nextResolve(specifier, context);
+  } catch (err) {
+    if (
+      err?.code === "ERR_MODULE_NOT_FOUND" &&
+      (specifier.startsWith("./") || specifier.startsWith("../"))
+    ) {
+      return nextResolve(specifier + ".ts", context);
+    }
+    throw err;
+  }
+}

--- a/src/lib/agents/runner.ts
+++ b/src/lib/agents/runner.ts
@@ -21,6 +21,7 @@ import { classifyIntent, claudeComplete } from "./claude";
 import { getClientConfig } from "./config";
 import { sendAgentEmailAlert } from "./email-alert";
 import { buildSystemPrompt } from "./prompts";
+import { sendOwnerSmsAlert } from "./sms-alert";
 import { sbInsert, sbSelect, sbUpdate } from "./supabase";
 import { sendTelegramAlert } from "./telegram";
 import type {
@@ -240,25 +241,36 @@ export async function runTurn({
       `Session: ${session.id}\n` +
       `Last message: "${payload.message}"`;
 
-    await sendTelegramAlert({
-      agent,
-      businessName: cfg.businessName,
-      chatId: cfg.telegramChatId,
-      message: alertText,
-    });
+    const agentLabel = AGENT_LABEL[agent];
+    const smsAlertBody =
+      `New ${agentLabel} lead (${cfg.businessName})\n` +
+      `${session.visitor_name ?? "Unknown"} — ${session.visitor_phone ?? session.visitor_email ?? "no contact"}\n` +
+      `Why: ${reason}\n` +
+      `Session: ${session.id.slice(0, 8)}`;
 
-    // Parallel email alert (interim, until Twilio SMS ships post-A2P).
-    await sendAgentEmailAlert({
-      subject: `New ${AGENT_LABEL[agent]} lead — ${session.visitor_name ?? "Unknown"}`,
-      text:
-        `New ${AGENT_LABEL[agent]} lead\n\n` +
-        `Name: ${session.visitor_name ?? "Unknown"}\n` +
-        `Business: ${cfg.businessName}${cfg.vertical ? ` (${cfg.vertical})` : ""}\n` +
-        `Problem: ${reason}\n` +
-        `Contact: ${session.visitor_email ?? "—"} / ${session.visitor_phone ?? "—"}\n` +
-        `Next step: discovery call\n\n` +
-        `Conversation snippet:\n${payload.message.slice(0, 500)}`,
-    });
+    await Promise.all([
+      sendTelegramAlert({
+        agent,
+        businessName: cfg.businessName,
+        chatId: cfg.telegramChatId,
+        message: alertText,
+      }),
+      sendAgentEmailAlert({
+        subject: `New ${agentLabel} lead — ${session.visitor_name ?? "Unknown"}`,
+        text:
+          `New ${agentLabel} lead\n\n` +
+          `Name: ${session.visitor_name ?? "Unknown"}\n` +
+          `Business: ${cfg.businessName}${cfg.vertical ? ` (${cfg.vertical})` : ""}\n` +
+          `Problem: ${reason}\n` +
+          `Contact: ${session.visitor_email ?? "—"} / ${session.visitor_phone ?? "—"}\n` +
+          `Next step: discovery call\n\n` +
+          `Conversation snippet:\n${payload.message.slice(0, 500)}`,
+      }),
+      sendOwnerSmsAlert({
+        cfg,
+        message: smsAlertBody,
+      }),
+    ]);
   }
 
   return {

--- a/src/lib/agents/sms-alert.test.ts
+++ b/src/lib/agents/sms-alert.test.ts
@@ -1,0 +1,61 @@
+import { strict as assert } from "node:assert";
+import { mock, test } from "node:test";
+import type { ClientConfig } from "./types";
+
+let sendSMS: (to: string, body: string) => Promise<{ messageId: string }> =
+  async () => ({ messageId: "default" });
+const calls: Array<[string, string]> = [];
+
+mock.module("./integrations/registry.ts", {
+  namedExports: {
+    getSmsIntegration: () => ({
+      sendSMS: async (to: string, body: string) => {
+        calls.push([to, body]);
+        return sendSMS(to, body);
+      },
+    }),
+  },
+});
+
+const { sendOwnerSmsAlert } = await import("./sms-alert.ts");
+
+const baseCfg = (smsConfig: Record<string, unknown> = {}): ClientConfig =>
+  ({
+    clientId: "c1",
+    businessName: "Biz",
+    vertical: "internal",
+    agents: { support: true, frontDesk: false, care: false },
+    smsProvider: "ghl",
+    smsConfig,
+    active: true,
+  }) as unknown as ClientConfig;
+
+test("returns no_alert_sms_to when alertSmsTo missing", async () => {
+  calls.length = 0;
+  const r = await sendOwnerSmsAlert({ cfg: baseCfg(), message: "hi" });
+  assert.deepEqual(r, { ok: false, error: "no_alert_sms_to" });
+  assert.equal(calls.length, 0);
+});
+
+test("calls sendSMS with the configured to and message", async () => {
+  calls.length = 0;
+  sendSMS = async () => ({ messageId: "mX" });
+  const r = await sendOwnerSmsAlert({
+    cfg: baseCfg({ alertSmsTo: "+15551230000" }),
+    message: "lead!",
+  });
+  assert.deepEqual(r, { ok: true, messageId: "mX" });
+  assert.deepEqual(calls, [["+15551230000", "lead!"]]);
+});
+
+test("returns ok:false when sendSMS throws (does not re-throw)", async () => {
+  calls.length = 0;
+  sendSMS = async () => {
+    throw new Error("boom");
+  };
+  const r = await sendOwnerSmsAlert({
+    cfg: baseCfg({ alertSmsTo: "+15551230000" }),
+    message: "x",
+  });
+  assert.deepEqual(r, { ok: false, error: "boom" });
+});

--- a/src/lib/agents/sms-alert.ts
+++ b/src/lib/agents/sms-alert.ts
@@ -1,0 +1,39 @@
+/**
+ * Owner SMS alert sender.
+ *
+ * Sends a qualified-lead SMS to the owner via whatever SMS provider the
+ * client is configured for (GHL LC Phone, Twilio, etc.). Destination
+ * number is read from `cfg.smsConfig.alertSmsTo` (E.164).
+ *
+ * Fails soft: a missing alertSmsTo or a send failure logs a warning and
+ * returns `{ ok: false }` so a visitor-facing chat request never 500s
+ * because the operator-notification channel is down.
+ */
+
+import { getSmsIntegration } from "./integrations/registry";
+import type { ClientConfig } from "./types";
+
+export async function sendOwnerSmsAlert(params: {
+  cfg: ClientConfig;
+  message: string;
+}): Promise<{ ok: boolean; error?: string; messageId?: string }> {
+  const to = (params.cfg.smsConfig?.alertSmsTo as string | undefined) ?? undefined;
+  if (!to) {
+    console.warn(
+      `[sms-alert] No alertSmsTo configured for client=${params.cfg.clientId} — SMS alert skipped`
+    );
+    return { ok: false, error: "no_alert_sms_to" };
+  }
+  try {
+    const sms = getSmsIntegration(params.cfg);
+    const { messageId } = await sms.sendSMS(to, params.message);
+    return { ok: true, messageId };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown";
+    console.error(
+      `[sms-alert] send failed for client=${params.cfg.clientId}:`,
+      message
+    );
+    return { ok: false, error: message };
+  }
+}

--- a/supabase/seeds/opsbynoell_seed_ghl.sql
+++ b/supabase/seeds/opsbynoell_seed_ghl.sql
@@ -93,7 +93,7 @@ Be concise, plain-spoken, and grounded. Never invent pricing. If asked about cos
   -- The locationId below routes through the Ops by Noell GHL sub-account,
   -- which sends from +19499973915 ("Nikki's number", A2P verified).
   'ghl',
-  '{"locationId": "Un5H1b2zXJM3agZ56j7c", "fromNumber": "+19499973915"}'::jsonb,
+  '{"locationId": "Un5H1b2zXJM3agZ56j7c", "fromNumber": "+19499973915", "alertSmsTo": "+19497849726"}'::jsonb,
 
   NULL,            -- missed_call_text_template (Front Desk not in use)
   'google',
@@ -161,7 +161,7 @@ ON CONFLICT (id) DO UPDATE SET
 --
 -- Expected:
 --   sms_provider = 'ghl'
---   sms_config   = {"locationId":"Un5H1b2zXJM3agZ56j7c","fromNumber":"+19499973915"}
+--   sms_config   = {"locationId":"Un5H1b2zXJM3agZ56j7c","fromNumber":"+19499973915","alertSmsTo":"+19497849726"}
 --   escalation_rules.qualifiedLead.smsTo = +19497849726
 --   telegram_chat_id = NULL
 -- ============================================================

--- a/supabase/seeds/opsbynoell_seed_ghl.sql
+++ b/supabase/seeds/opsbynoell_seed_ghl.sql
@@ -21,6 +21,12 @@
 --
 -- Telegram is intentionally disabled (telegram_chat_id = NULL).
 -- Qualified-lead alerts route: SMS -> +19497849726, email -> hello@opsbynoell.com.
+--
+-- sms_config.alertSmsTo is a LIVE field read by src/lib/agents/sms-alert.ts
+-- at escalation time — it is no longer just stored for future use. When
+-- the runner's escalation block fires, sendOwnerSmsAlert() reads this
+-- value and dispatches the qualified-lead SMS via the configured GHL
+-- LC Phone integration (in parallel with the Telegram + email alerts).
 -- ============================================================
 
 


### PR DESCRIPTION
## Why

GHL LC Phone A2P 10DLC approved 2026-04-18. Wire outbound SMS into the escalation path so qualified leads text the owner in addition to the existing Telegram + email alerts. Uses the existing `GhlSms` integration. No new deps, no new env vars.

## Changes

- **`src/lib/agents/sms-alert.ts`** (new) — fail-soft `sendOwnerSmsAlert` helper reading from `cfg.smsConfig.alertSmsTo`.
- **`src/lib/agents/runner.ts`** — fire Telegram + email + SMS in parallel via `Promise.all` on escalation. Dropped stale "until Twilio SMS ships post-A2P" comment.
- **`supabase/seeds/opsbynoell_seed_ghl.sql`** — header comment note + one-line seed fix to include `alertSmsTo` in `sms_config` (closes drift with prod, which already has this field set).
- **`src/lib/agents/sms-alert.test.ts`** (new, 57 lines) — 3 unit tests (missing `alertSmsTo`, happy path, thrown-error soft-fail).
- **`package.json`** + **`scripts/test-loader.mjs`**, **`scripts/test-resolve-hook.mjs`** — Node 22 built-in `node:test` runner with tiny ESM resolver hook for extensionless relative imports. Zero added packages.

## Expected behavior for opsbynoell

Qualified lead → SMS arrives at **+1 949-784-9726** from **+1 949-997-3915** (A2P-approved LC Phone), plus email to hello@opsbynoell.com, plus Telegram (only if `telegram_chat_id` is set — currently NULL, so silent).

## Prod state

Already verified via direct SQL on project `clipzfkbzupjctherijz`:

```
client_id  = opsbynoell
sms_provider = ghl
sms_config = {"alertSmsTo":"+19497849726","fromNumber":"+19499973915","locationId":"Un5H1b2zXJM3agZ56j7c"}
```

This PR is safe to merge without any Supabase change.

## QA

- `npm run build` ✅ — compiled successfully, 33 pages generated
- `npm test` ✅ — 3/3 tests pass
- `grep -rn "until Twilio SMS ships" src/` → 0 hits
- `grep -rn "sendOwnerSmsAlert" src/` → 7 hits across the three files
- No new lint issues in touched files

## Rollout

Merge → Vercel auto-deploys → smoke-test with a fake lead in the `/` chat widget. Expect SMS at +1 949-784-9726 within ~30s of qualification.