### PR TITLE
fix(ghl-sms): avoid contacts.write by using alert contact + explicit toNumber/fromNumber

### DIFF
--- a/src/lib/agents/integrations/ghl.test.ts
+++ b/src/lib/agents/integrations/ghl.test.ts
@@ -1,0 +1,122 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { GhlSms } from "./ghl.ts";
+
+type FetchArgs = [string, RequestInit | undefined];
+
+function installFetchMock(
+  responses: Array<{ ok: boolean; status?: number; json: unknown; text?: string }>
+): { calls: FetchArgs[]; restore: () => void } {
+  const calls: FetchArgs[] = [];
+  const original = globalThis.fetch;
+  let i = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.fetch = (async (url: string, init?: RequestInit) => {
+    calls.push([url, init]);
+    const r = responses[i++];
+    if (!r) throw new Error(`no mock response for call ${i}`);
+    return {
+      ok: r.ok,
+      status: r.status ?? (r.ok ? 200 : 500),
+      json: async () => r.json,
+      text: async () => r.text ?? JSON.stringify(r.json),
+    } as Response;
+  }) as typeof fetch;
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+test("GhlSms: fast path uses alertContactId + toNumber/fromNumber, no upsert", async () => {
+  const mock = installFetchMock([
+    { ok: true, json: { messageId: "msg_fast_1" } },
+  ]);
+  try {
+    const sms = new GhlSms({
+      locationId: "loc_1",
+      apiKey: "pit-test",
+      alertContactId: "contact_1",
+      fromNumber: "+19499973915",
+    });
+    const res = await sms.sendSMS("+19497849726", "hello");
+    assert.equal(res.messageId, "msg_fast_1");
+    assert.equal(mock.calls.length, 1);
+    const [url, init] = mock.calls[0];
+    assert.match(url, /\/conversations\/messages$/);
+    const body = JSON.parse(String(init?.body ?? "{}"));
+    assert.equal(body.type, "SMS");
+    assert.equal(body.contactId, "contact_1");
+    assert.equal(body.toNumber, "+19497849726");
+    assert.equal(body.fromNumber, "+19499973915");
+    assert.equal(body.message, "hello");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("GhlSms: legacy path upserts then sends when alertContactId missing", async () => {
+  const mock = installFetchMock([
+    { ok: true, json: { contact: { id: "c_upserted" } } },
+    { ok: true, json: { messageId: "msg_legacy_1" } },
+  ]);
+  try {
+    const sms = new GhlSms({ locationId: "loc_1", apiKey: "pit-test" });
+    const res = await sms.sendSMS("+15550001111", "hi there");
+    assert.equal(res.messageId, "msg_legacy_1");
+    assert.equal(mock.calls.length, 2);
+    assert.match(mock.calls[0][0], /\/contacts\/upsert$/);
+    assert.match(mock.calls[1][0], /\/conversations\/messages$/);
+    const send = JSON.parse(String(mock.calls[1][1]?.body ?? "{}"));
+    assert.equal(send.contactId, "c_upserted");
+    assert.equal(send.type, "SMS");
+    // legacy path does NOT set toNumber/fromNumber
+    assert.equal(send.toNumber, undefined);
+    assert.equal(send.fromNumber, undefined);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("GhlSms: fast path requires BOTH alertContactId and fromNumber", async () => {
+  // Only alertContactId provided → should fall back to legacy (upsert) path
+  const mock = installFetchMock([
+    { ok: true, json: { contact: { id: "c_up" } } },
+    { ok: true, json: { messageId: "msg_fallback" } },
+  ]);
+  try {
+    const sms = new GhlSms({
+      locationId: "loc_1",
+      apiKey: "pit-test",
+      alertContactId: "contact_1",
+      // fromNumber intentionally omitted
+    });
+    const res = await sms.sendSMS("+15550002222", "test");
+    assert.equal(res.messageId, "msg_fallback");
+    assert.equal(mock.calls.length, 2, "should have fallen back to upsert + send");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("GhlSms: throws on fast-path send failure", async () => {
+  const mock = installFetchMock([
+    { ok: false, status: 422, json: { message: "boom" }, text: "boom" },
+  ]);
+  try {
+    const sms = new GhlSms({
+      locationId: "loc_1",
+      apiKey: "pit-test",
+      alertContactId: "contact_1",
+      fromNumber: "+19499973915",
+    });
+    await assert.rejects(
+      () => sms.sendSMS("+19497849726", "x"),
+      /ghl sms send failed: 422/
+    );
+  } finally {
+    mock.restore();
+  }
+});

--- a/src/lib/agents/integrations/ghl.ts
+++ b/src/lib/agents/integrations/ghl.ts
@@ -33,6 +33,21 @@ interface GhlConfig {
   calendarId?: string;
   /** Optional per-location API key. Falls back to the env key. */
   apiKey?: string;
+  /**
+   * Optional GHL contact ID to use as the originator of owner-alert SMS
+   * sends. When set, sendSMS uses this contact + explicit toNumber /
+   * fromNumber in the Conversations Messages payload and SKIPS the
+   * /contacts/upsert call — which means the PIT does not need
+   * `contacts.write` scope, and the destination phone number is NOT
+   * persisted to GHL as a contact row.
+   */
+  alertContactId?: string;
+  /**
+   * Optional FROM phone number (E.164) for outbound SMS. Required when
+   * `alertContactId` is set. For Ops by Noell this is `+19499973915`
+   * (the A2P-approved LC Phone number).
+   */
+  fromNumber?: string;
 }
 
 interface GhlWhatsappConfig extends GhlConfig {
@@ -67,8 +82,10 @@ function base(): string {
 // ---------- Calendar ----------
 
 export class GhlCalendar implements CalendarIntegration {
-  constructor(private cfg: GhlConfig) {
+  private cfg: GhlConfig;
+  constructor(cfg: GhlConfig) {
     if (!cfg.locationId) throw new Error("GHL locationId is required");
+    this.cfg = cfg;
   }
 
   async getAvailableSlots(
@@ -227,12 +244,45 @@ export class GhlCalendar implements CalendarIntegration {
 // ---------- SMS ----------
 
 export class GhlSms implements SMSIntegration {
-  constructor(private cfg: GhlConfig) {
+  private cfg: GhlConfig;
+  constructor(cfg: GhlConfig) {
     if (!cfg.locationId) throw new Error("GHL locationId is required");
+    this.cfg = cfg;
   }
 
   async sendSMS(to: string, body: string): Promise<{ messageId: string }> {
-    // GHL requires the contact to exist before sending. Upsert first.
+    // Fast path — owner-alert style.
+    //
+    // The client has pre-configured an `alertContactId` (an internal GHL
+    // contact that serves as the thread originator) and a `fromNumber`.
+    // We send with explicit toNumber + fromNumber so GHL routes correctly
+    // without requiring `contacts.write` scope on the PIT, and without
+    // polluting the CRM with alert-line rows.
+    if (this.cfg.alertContactId && this.cfg.fromNumber) {
+      const send = await fetch(`${base()}/conversations/messages`, {
+        method: "POST",
+        headers: headers(this.cfg),
+        body: JSON.stringify({
+          type: "SMS",
+          contactId: this.cfg.alertContactId,
+          message: body,
+          toNumber: to,
+          fromNumber: this.cfg.fromNumber,
+        }),
+      });
+      if (!send.ok) {
+        throw new Error(
+          `ghl sms send failed: ${send.status} ${await send.text()}`
+        );
+      }
+      const data = (await send.json()) as { messageId?: string };
+      return { messageId: data.messageId ?? "" };
+    }
+
+    // Legacy path — upsert contact by phone, then send. Requires
+    // `contacts.write` scope on the PIT. Retained for clients where the
+    // destination SHOULD be persisted as a contact (e.g. visitor reply
+    // flows, Twilio-backed clients).
     const upsert = await fetch(`${base()}/contacts/upsert`, {
       method: "POST",
       headers: headers(this.cfg),
@@ -297,9 +347,11 @@ export class GhlSms implements SMSIntegration {
  */
 export class GhlWhatsapp implements MessagingIntegration {
   readonly isWhatsApp = true;
+  private cfg: GhlWhatsappConfig;
 
-  constructor(private cfg: GhlWhatsappConfig) {
+  constructor(cfg: GhlWhatsappConfig) {
     if (!cfg.locationId) throw new Error("GHL locationId is required");
+    this.cfg = cfg;
   }
 
   /** Upsert a contact in GHL and return their contactId. */

--- a/src/lib/agents/integrations/registry.ts
+++ b/src/lib/agents/integrations/registry.ts
@@ -53,6 +53,8 @@ export function getSmsIntegration(cfg: ClientConfig): MessagingIntegration {
       return new GhlSms({
         locationId: conf.locationId as string,
         apiKey: conf.apiKey as string | undefined,
+        alertContactId: conf.alertContactId as string | undefined,
+        fromNumber: conf.fromNumber as string | undefined,
       });
     case "ghl_whatsapp":
       return new GhlWhatsapp({

--- a/supabase/seeds/opsbynoell_seed_ghl.sql
+++ b/supabase/seeds/opsbynoell_seed_ghl.sql
@@ -93,7 +93,12 @@ Be concise, plain-spoken, and grounded. Never invent pricing. If asked about cos
   -- The locationId below routes through the Ops by Noell GHL sub-account,
   -- which sends from +19499973915 ("Nikki's number", A2P verified).
   'ghl',
-  '{"locationId": "Un5H1b2zXJM3agZ56j7c", "fromNumber": "+19499973915", "alertSmsTo": "+19497849726"}'::jsonb,
+  -- alertContactId points at an existing GHL contact in the Ops by Noell
+  -- sub-account. When set (plus fromNumber), GhlSms.sendSMS skips the
+  -- /contacts/upsert call, which means the PIT does NOT need contacts.write
+  -- scope, and the alert destination number (+19497849726) is NOT stored as
+  -- a CRM contact row.
+  '{"locationId": "Un5H1b2zXJM3agZ56j7c", "fromNumber": "+19499973915", "alertSmsTo": "+19497849726", "alertContactId": "iwQMFzgvJOSu57sz9w1t"}'::jsonb,
 
   NULL,            -- missed_call_text_template (Front Desk not in use)
   'google',
@@ -161,7 +166,7 @@ ON CONFLICT (id) DO UPDATE SET
 --
 -- Expected:
 --   sms_provider = 'ghl'
---   sms_config   = {"locationId":"Un5H1b2zXJM3agZ56j7c","fromNumber":"+19499973915","alertSmsTo":"+19497849726"}
+--   sms_config   = {"locationId":"Un5H1b2zXJM3agZ56j7c","fromNumber":"+19499973915","alertSmsTo":"+19497849726","alertContactId":"iwQMFzgvJOSu57sz9w1t"}
 --   escalation_rules.qualifiedLead.smsTo = +19497849726
 --   telegram_chat_id = NULL
 -- ============================================================


### PR DESCRIPTION
## Problem

Owner-alert SMS sends were failing because:
1. `GHL /contacts/upsert` returned **401** — the PIT does not have `contacts.write` scope (GHL UI would not persist this scope).
2. Even when bypassing upsert, `GHL /conversations/messages` returned **422** when sent without `toNumber` + `fromNumber`.

The owner alert line (+1 949-784-9726) is also NOT a GHL contact and should NOT be persisted as one.

## Fix

When `sms_config.alertContactId` and `sms_config.fromNumber` are both set, `GhlSms.sendSMS` now:
- **Skips** the `/contacts/upsert` call entirely (no contacts.write scope needed)
- Sends via `/conversations/messages` with `{ type: 'SMS', contactId: <alertContactId>, message, toNumber: <destination>, fromNumber: <from> }`

The alert contact (Nikki Noell, `iwQMFzgvJOSu57sz9w1t`) has no phone set, so no mismatch errors occur. The destination number is passed explicitly via `toNumber` and never becomes a CRM row.

## Legacy behavior preserved

Clients without `alertContactId`/`fromNumber` fall back to the existing upsert-then-send path. Partial config (only one of the two) also falls back safely — covered by test.

## Files

- `src/lib/agents/integrations/ghl.ts` — added `alertContactId` + `fromNumber` to `GhlConfig`, rewrote `GhlSms.sendSMS` with fast path + legacy fallback. Refactored 3 constructors off TS parameter-property syntax (needed for `node --test --experimental-strip-types`; no behavior change).
- `src/lib/agents/integrations/registry.ts` — passes new fields from `sms_config`.
- `src/lib/agents/integrations/ghl.test.ts` — **new**, 4 tests (fast path, legacy fallback, partial-config fallback, error handling).
- `supabase/seeds/opsbynoell_seed_ghl.sql` — seeds `alertContactId` in `sms_config`.

## Supabase

Live `clients.sms_config` for opsbynoell already updated (out-of-band) with:
```json
{
  "alertContactId": "iwQMFzgvJOSu57sz9w1t",
  "fromNumber": "+19499973915",
  "alertSmsTo": "+19497849726",
  "locationId": "Un5H1b2zXJM3agZ56j7c"
}
```

## Test plan

1. Merge → Vercel auto-deploy
2. POST to `/api/support/message` with a qualifying message + visitor info
3. Expect SMS at +1 949-784-9726 from +1 949-997-3915
4. `npm test` passes 7/7 locally

## Not touching

PR #14, contact/legal/policy/widget files (A2P-frozen).