### PR TITLE
feat(runner): every-turn SMS alert toggle for live chat monitoring

### DIFF
--- a/src/lib/agents/runner.ts
+++ b/src/lib/agents/runner.ts
@@ -38,6 +38,16 @@ interface RunnerTables {
   messages: string; // "front_desk_messages" | "care_messages"
 }
 
+/**
+ * In-process rate-limit map for every-turn SMS alerts.
+ *
+ * Keyed by session id, value is the epoch-ms of the last shadow-SMS send.
+ * This is intentionally memory-only: serverless instances recycle, which
+ * is fine — worst case a cold instance sends one extra SMS per session.
+ * Use sms_config.everyTurnRateLimitMs to tune (default 60_000).
+ */
+const shadowSmsLastAlert = new Map<string, number>();
+
 interface SessionRow {
   id: string;
   client_id: string;
@@ -207,6 +217,40 @@ export async function runTurn({
   );
   const escalated = classification.escalate || Boolean(keywordReason);
   const intent: Intent = classification.intent;
+
+  // Every-turn SMS alert — fires on every visitor message (not just escalations).
+  // Useful during early testing so the operator can jump into the inbox live.
+  // Gated behind sms_config.everyTurnSms === true. Skips if the turn is already
+  // being escalated (the escalation SMS below will fire with richer context).
+  // Rate-limited to one SMS per session per SHADOW_SMS_RATE_LIMIT_MS (default 60s)
+  // to prevent spam loops from rapid-fire messages.
+  const everyTurnEnabled = Boolean(cfg.smsConfig?.everyTurnSms);
+  if (everyTurnEnabled && !escalated) {
+    const rateLimitMs = Number(
+      cfg.smsConfig?.everyTurnRateLimitMs ?? 60_000
+    );
+    const lastAlertAt = shadowSmsLastAlert.get(session.id) ?? 0;
+    const now = Date.now();
+    if (now - lastAlertAt >= rateLimitMs) {
+      shadowSmsLastAlert.set(session.id, now);
+      const who =
+        session.visitor_name ??
+        session.visitor_phone ??
+        session.visitor_email ??
+        "anon visitor";
+      const snippet = payload.message
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 140);
+      const shadowBody =
+        `Chat turn (${cfg.businessName})\n` +
+        `From: ${who}\n` +
+        `"${snippet}"\n` +
+        `Session: ${session.id.slice(0, 8)}`;
+      // Fire-and-forget — do not block the reply.
+      void sendOwnerSmsAlert({ cfg, message: shadowBody });
+    }
+  }
 
   // Persist the assistant reply.
   await sbInsert(tables.messages, {


### PR DESCRIPTION
## What

Adds `sms_config.everyTurnSms` flag. When true, **every visitor chat message** fires a lightweight SMS to the operator (+19497849726) alongside the bot's reply — so Nikki can see in real time when a conversation is happening and jump into the inbox live.

## Why

Early-phase testing. Normal escalation-only SMS is too quiet when traffic is low and we're tuning the bot. We want to watch live conversations on the GHL inbox without refreshing.

## Behavior

- **Toggle per client** via `sms_config.everyTurnSms: true/false` in Supabase. Off by default.
- **Skipped when escalated** — the existing escalation SMS already fires with richer context (name, phone, intent, reason). No double-notify.
- **Rate-limited** to 1 SMS per session per 60s (configurable via `sms_config.everyTurnRateLimitMs`). Prevents spam loops from rapid-fire messages.
- **Fire-and-forget** — `void sendOwnerSmsAlert(...)`. Never blocks the chat reply.
- **In-process Map** for rate-limit state. Serverless cold starts may let one extra SMS through per session — acceptable tradeoff vs. adding DB writes.

## SMS format

```
Chat turn (Ops by Noell)
From: {name | phone | email | "anon visitor"}
"{first 140 chars of the message}"
Session: {8-char prefix}
```

## Test plan

1. Merge → Vercel deploys
2. `UPDATE clients SET sms_config = jsonb_set(sms_config::jsonb, '{everyTurnSms}', 'true'::jsonb) WHERE client_id='opsbynoell'`
3. Open widget, send "hi how are you" → SMS lands with that snippet
4. Rapid-fire 3 more messages → only 1 additional SMS within 60s window
5. Send escalating message ("need a human now") → only the escalation SMS, not the every-turn one

## Turn-off

`UPDATE clients SET sms_config = sms_config::jsonb - 'everyTurnSms' WHERE client_id='opsbynoell'` — takes effect on next request, no redeploy needed.