### PR TITLE
feat(sms): two-way reply bridge — owner SMS replies post to visitor widget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,11 @@ GHL_API_KEY=
 # the `x-vercel-cron` header must send Authorization: Bearer <CRON_SECRET>)
 CRON_SECRET=
 
+# Two-way SMS reply bridge — webhook secret for POST /api/ghl/inbound-sms
+# Generate with: openssl rand -hex 32
+# Paste the same value as the ?secret= query param in the LC workflow webhook URL.
+GHL_WEBHOOK_SECRET=
+
 # Meta Pixel (client-side analytics for Facebook / Instagram ads)
 # Pixel lives in the "Nikki Noell" business portfolio.
 # Leave blank in dev to disable pixel firing locally.

--- a/docs/two-way-sms.md
+++ b/docs/two-way-sms.md
@@ -1,0 +1,159 @@
+# Two-Way SMS Reply Bridge
+
+When an AI agent escalates a visitor conversation, the system sends an alert SMS to Nikki's phone. This doc explains how her reply gets routed back into the visitor's chat widget — pausing the AI and posting her reply as a human message.
+
+---
+
+## How it works
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│ 1. Visitor sends message → AI escalates → outbound alert SMS             │
+│                                                                          │
+│    FROM: +19499973915  (LC Phone / fromNumber)                           │
+│    TO:   +19497849726  (Nikki's cell / alertSmsTo)                       │
+│    BODY: "New Noell Front Desk lead…\nOpen: https://…/sessions/UUID?…"   │
+│                                                                          │
+│    ✦ On send: upsert sms_alert_sessions                                  │
+│      (from_phone=+19497849726, to_phone=+19499973915, session_id=UUID)   │
+└──────────────────────────────────────────────────────────────────────────┘
+           │
+           ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│ 2. Nikki replies "Heyyyyyy"                                              │
+│                                                                          │
+│    FROM: +19497849726  (Nikki — matches from_phone in table)             │
+│    TO:   +19499973915  (LC Phone — matches to_phone in table)            │
+└──────────────────────────────────────────────────────────────────────────┘
+           │  GHL fires Conversations webhook
+           ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│ 3. POST /api/ghl/inbound-sms?secret=<GHL_WEBHOOK_SECRET>                │
+│                                                                          │
+│    • Look up sms_alert_sessions (from_phone, to_phone)                   │
+│    • Insert chatMessages/front_desk_messages/care_messages row:          │
+│        { role: "human", content: "Heyyyyyy", author: "Nikki (human)" }  │
+│    • PATCH chatSessions / front_desk_sessions / care_sessions:           │
+│        { humanTakeover: true }   (or human_takeover for newer tables)   │
+│    • AI stops replying; Nikki's message appears in visitor widget        │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+**Phone semantics** (the most common two-way SMS bug):
+The table key `(from_phone, to_phone)` is stored from the **replier's perspective** — `from_phone` is Nikki's cell (she will be replying), `to_phone` is the LC Phone that receives the reply. This matches exactly how the inbound webhook delivers the message.
+
+---
+
+## Vercel environment variable
+
+| Variable | Description |
+|---|---|
+| `GHL_WEBHOOK_SECRET` | Shared secret for webhook auth. Pass as `?secret=` in the URL. |
+
+Generate a value:
+```sh
+openssl rand -hex 32
+```
+
+Set it in Vercel: **Settings → Environment Variables → GHL_WEBHOOK_SECRET**.
+
+Staging value (rotate after testing):
+```
+d5e727c0f14dc4844a2320052df8a3042e81fa5939fdb77f09e6ee0276ab4fb6
+```
+
+---
+
+## Webhook URL
+
+```
+https://www.opsbynoell.com/api/ghl/inbound-sms?secret=<GHL_WEBHOOK_SECRET>
+```
+
+Replace `<GHL_WEBHOOK_SECRET>` with the exact value you set in Vercel.
+
+---
+
+## GHL automation setup (send to Nikki)
+
+1. In your GHL sub-account, go to **Automations → Workflows**.
+2. Click **+ New Workflow** → **Start from Scratch**.
+3. **Trigger**: Customer Reply → filter on **Channel = SMS**.
+4. **Action**: Webhook
+   - Method: `POST`
+   - URL: `https://www.opsbynoell.com/api/ghl/inbound-sms?secret=<GHL_WEBHOOK_SECRET>`
+   - Body format: `application/json`
+   - Body (paste as-is):
+     ```json
+     {
+       "phone": "{{contact.phone}}",
+       "toNumber": "{{message.to_number}}",
+       "body": "{{message.body}}",
+       "contactId": "{{contact.id}}",
+       "conversationId": "{{conversation.id}}"
+     }
+     ```
+5. Save and **Publish** the workflow.
+
+> **Tip**: GHL's Conversations webhook can also be used instead of a workflow if you prefer — both `phone`/`toNumber`/`body` and `from`/`to`/`message` field names are accepted by the endpoint.
+
+---
+
+## Database migration
+
+`supabase/migrations/0005_sms_alert_sessions.sql` creates the correlation table. Run it via the Supabase dashboard SQL editor or the CLI:
+
+```sh
+supabase db push
+```
+
+---
+
+## Manual test plan
+
+### 1. Pre-flight
+- [ ] `GHL_WEBHOOK_SECRET` is set in Vercel (or `.env.local` for local dev).
+- [ ] Migration `0005` applied to your Supabase project.
+- [ ] GHL workflow is published.
+
+### 2. Trigger an alert
+1. Open the front-desk widget (or support widget) in a browser.
+2. Send a message that triggers an escalation (e.g. "I want to book" or any keyword in the escalation rules).
+3. Check Nikki's phone — she should receive an SMS with the inbox link.
+
+### 3. Check sms_alert_sessions
+In Supabase table editor, open `sms_alert_sessions`:
+- You should see a row with `from_phone = <Nikki's cell>`, `to_phone = <LC Phone>`, and a valid `session_id`.
+
+### 4. Reply
+From Nikki's phone, reply to the alert SMS with "Heyyyyyy".
+
+### 5. Verify widget + session
+1. Open `https://www.opsbynoell.com/admin/sessions/<session_id>?agent=frontDesk` (or the agent matching the alert).
+2. The message "Heyyyyyy" should appear with the author badge **"Nikki (human)"**.
+3. The header badge should show **"Human"** (humanTakeover=true).
+4. Sending another message from the visitor widget should be stored but **not receive an AI reply** (human takeover active).
+
+### 6. cURL smoke test (no phone required)
+```sh
+curl -s -X POST \
+  "https://www.opsbynoell.com/api/ghl/inbound-sms?secret=<GHL_WEBHOOK_SECRET>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "phone": "<Nikki_cell>",
+    "toNumber": "<LC_Phone>",
+    "body": "Test reply from cURL"
+  }' | jq .
+```
+Expected: `{ "ok": true, "sessionId": "..." }` (assuming a recent alert was sent).
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `{ "ok": false, "reason": "unauthorized" }` | Wrong `?secret=` value — check Vercel env var matches webhook URL |
+| `{ "ok": true, "reason": "no_mapping" }` | No alert was sent to this phone pair recently, or `fromNumber` not set in `sms_config` |
+| Message appears but AI keeps replying | `humanTakeover`/`human_takeover` column not being read — check table name and column for the agent |
+| Double messages | GHL fired the workflow for the outbound alert AND the inbound reply — add a filter on the trigger: **Direction = Inbound** |

--- a/src/app/admin/sessions/[id]/page.tsx
+++ b/src/app/admin/sessions/[id]/page.tsx
@@ -11,6 +11,8 @@ interface Message {
   role: "user" | "assistant" | "human" | "system";
   content: string;
   created_at: string;
+  /** Optional author label — set to "Nikki (human)" for SMS-bridged replies. */
+  author?: string | null;
 }
 
 interface Session {
@@ -318,7 +320,7 @@ function SessionDetailInner({
                       >
                         {isHuman && (
                           <span className="text-[9px] font-mono uppercase tracking-wider text-charcoal/40 mb-0.5 px-1">
-                            You
+                            {msg.author ?? "You"}
                           </span>
                         )}
                         {isBot && (

--- a/src/app/api/ghl/inbound-sms/route.ts
+++ b/src/app/api/ghl/inbound-sms/route.ts
@@ -1,0 +1,79 @@
+/**
+ * POST /api/ghl/inbound-sms
+ *
+ * Inbound SMS webhook — bridges owner replies from the LC Phone number
+ * back into the visitor's chat session as a human message and flips
+ * humanTakeover=true so the AI pauses.
+ *
+ * Auth
+ * ----
+ * A shared secret is passed as a query param:
+ *   ?secret=<GHL_WEBHOOK_SECRET>
+ *
+ * Set GHL_WEBHOOK_SECRET in Vercel. Generate a value with:
+ *   openssl rand -hex 32
+ *
+ * GHL Conversations webhook body (typical shape):
+ * {
+ *   type: "InboundMessage",
+ *   phone: "+19497849726",      // sender (owner) — from_phone in our table
+ *   toNumber: "+19499973915",   // receiving LC Phone — to_phone in our table
+ *   body: "Heyyyyyy",
+ *   ...
+ * }
+ *
+ * Also accepts `from`/`to`/`message` field aliases for LC workflow actions.
+ *
+ * See src/lib/agents/inbound-sms-handler.ts for the routing logic.
+ * See docs/two-way-sms.md for GHL setup instructions.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { env } from "@/lib/agents/env";
+import {
+  extractInboundPayload,
+  handleInboundSms,
+} from "@/lib/agents/inbound-sms-handler";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest): Promise<Response> {
+  // ── Auth ──────────────────────────────────────────────────────────────────
+  const expectedSecret = env.ghlWebhookSecret();
+  const providedSecret = req.nextUrl.searchParams.get("secret");
+
+  if (!expectedSecret || providedSecret !== expectedSecret) {
+    console.warn("[inbound-sms] Rejected request — bad or missing secret");
+    // Return 200 so the caller does not retry. Auth failures should not
+    // cause GHL to queue up dozens of retries.
+    return NextResponse.json({ ok: false, reason: "unauthorized" }, { status: 200 });
+  }
+
+  // ── Parse body ────────────────────────────────────────────────────────────
+  let rawBody: Record<string, unknown>;
+  try {
+    rawBody = (await req.json()) as Record<string, unknown>;
+  } catch {
+    console.warn("[inbound-sms] Could not parse JSON body");
+    return NextResponse.json({ ok: false, reason: "bad_json" }, { status: 200 });
+  }
+
+  const payload = extractInboundPayload(rawBody);
+  if (!payload) {
+    console.warn("[inbound-sms] Missing from/to phone in payload", rawBody);
+    return NextResponse.json(
+      { ok: false, reason: "missing_phones" },
+      { status: 200 }
+    );
+  }
+
+  // ── Handle ────────────────────────────────────────────────────────────────
+  const result = await handleInboundSms(payload);
+
+  if (!result.ok && result.reason === "db_error") {
+    return NextResponse.json(result, { status: 200 });
+  }
+
+  return NextResponse.json(result, { status: 200 });
+}

--- a/src/lib/agents/env.ts
+++ b/src/lib/agents/env.ts
@@ -52,4 +52,9 @@ export const env = {
 
   // Cron protection
   cronSecret: () => optional("CRON_SECRET"),
+
+  // Two-way SMS bridge — shared secret for the inbound-SMS webhook.
+  // Generate with: openssl rand -hex 32
+  // Vercel: Settings → Environment Variables → GHL_WEBHOOK_SECRET
+  ghlWebhookSecret: () => optional("GHL_WEBHOOK_SECRET"),
 };

--- a/src/lib/agents/inbound-sms-handler.ts
+++ b/src/lib/agents/inbound-sms-handler.ts
@@ -1,0 +1,209 @@
+/**
+ * Two-way SMS reply bridge — core handler logic.
+ *
+ * Extracted from the Next.js route so it can be unit-tested without
+ * needing the Next.js runtime or a bundler.
+ *
+ * Phone semantics (CRITICAL):
+ *   Outbound alert:  from = fromNumber (+19499973915)  →  to = alertSmsTo (+19497849726)
+ *   Nikki's reply:   from = +19497849726               →  to = +19499973915
+ *   Table key:       from_phone = alertSmsTo (the REPLIER)
+ *                    to_phone   = fromNumber (the receiver / LC Phone)
+ */
+
+import { sbInsert, sbSelect, sbUpdate } from "./supabase";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SmsAlertSessionRow {
+  from_phone: string;
+  to_phone: string;
+  session_id: string;
+  agent: "support" | "frontDesk" | "care";
+  client_id: string;
+}
+
+export interface InboundSmsPayload {
+  /** Sender phone (E.164) — the owner / alertSmsTo. Maps to from_phone in table. */
+  fromPhone: string;
+  /** Receiving LC Phone (E.164) — the fromNumber used for outbound. Maps to to_phone. */
+  toPhone: string;
+  /** The SMS body text sent by the owner. */
+  messageText: string;
+}
+
+export type InboundSmsResult =
+  | { ok: true; sessionId: string }
+  | { ok: false; reason: string };
+
+// ---------------------------------------------------------------------------
+// Table routing
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the Supabase table names for a given agent kind.
+ * Mirrors the logic in takeover/route.ts and message/route.ts.
+ */
+export function resolveTables(agent: string): {
+  sessionsTable: string;
+  messagesTable: string;
+  humanTakeoverField: string;
+  updatedAtField: string;
+  sessionIdField: string;
+} {
+  switch (agent) {
+    case "frontDesk":
+      return {
+        sessionsTable: "front_desk_sessions",
+        messagesTable: "front_desk_messages",
+        humanTakeoverField: "human_takeover",
+        updatedAtField: "updated_at",
+        sessionIdField: "session_id",
+      };
+    case "care":
+      return {
+        sessionsTable: "care_sessions",
+        messagesTable: "care_messages",
+        humanTakeoverField: "human_takeover",
+        updatedAtField: "updated_at",
+        sessionIdField: "session_id",
+      };
+    default:
+      // "support" → chatSessions / chatMessages (legacy camelCase columns)
+      return {
+        sessionsTable: "chatSessions",
+        messagesTable: "chatMessages",
+        humanTakeoverField: "humanTakeover",
+        updatedAtField: "updatedAt",
+        sessionIdField: "sessionId",
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle an inbound owner SMS and route it into the visitor's session.
+ *
+ * Steps:
+ *   1. Look up sms_alert_sessions by (from_phone, to_phone)
+ *   2. If not found → return no-op (unknown sender)
+ *   3. Insert a human message with author "Nikki (human)"
+ *   4. Flip humanTakeover=true on the session
+ */
+export async function handleInboundSms(
+  payload: InboundSmsPayload
+): Promise<InboundSmsResult> {
+  const { fromPhone, toPhone, messageText } = payload;
+
+  // ── 1. Look up session mapping ───────────────────────────────────────────
+  let mapping: SmsAlertSessionRow | null = null;
+  try {
+    const rows = await sbSelect<SmsAlertSessionRow>(
+      "sms_alert_sessions",
+      {
+        from_phone: `eq.${fromPhone}`,
+        to_phone:   `eq.${toPhone}`,
+      },
+      { limit: 1 }
+    );
+    mapping = rows[0] ?? null;
+  } catch (err) {
+    console.error("[inbound-sms] Supabase lookup failed:", err);
+    return { ok: false, reason: "db_error" };
+  }
+
+  if (!mapping) {
+    console.warn(
+      `[inbound-sms] No session mapping for from=${fromPhone} to=${toPhone} — no-op`
+    );
+    return { ok: false, reason: "no_mapping" };
+  }
+
+  const { session_id, agent } = mapping;
+  const text = messageText.trim() || "(empty)";
+
+  console.info(
+    `[inbound-sms] Reply from ${fromPhone} → session=${session_id} agent=${agent}: "${text.slice(0, 80)}"`
+  );
+
+  // ── 2. Resolve tables for the agent ──────────────────────────────────────
+  const {
+    sessionsTable,
+    messagesTable,
+    humanTakeoverField,
+    updatedAtField,
+    sessionIdField,
+  } = resolveTables(agent);
+
+  // ── 3. Insert message + flip takeover ────────────────────────────────────
+  const messageRow: Record<string, unknown> = {
+    [sessionIdField]: session_id,
+    role: "human",
+    content: text,
+    author: "Nikki (human)",
+  };
+
+  const sessionPatch: Record<string, unknown> = {
+    [humanTakeoverField]: true,
+    [updatedAtField]: new Date().toISOString(),
+  };
+
+  try {
+    await Promise.all([
+      sbInsert(messagesTable, messageRow),
+      sbUpdate(
+        sessionsTable,
+        { id: `eq.${session_id}` },
+        sessionPatch
+      ),
+    ]);
+  } catch (err) {
+    console.error(
+      `[inbound-sms] Failed to write message/takeover for session=${session_id}:`,
+      err
+    );
+    return { ok: false, reason: "db_write_error" };
+  }
+
+  return { ok: true, sessionId: session_id };
+}
+
+// ---------------------------------------------------------------------------
+// Payload extractor — normalises GHL/LC webhook variants
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract phones and message text from any GHL webhook body variant.
+ *
+ * GHL Conversations webhook (primary):
+ *   { phone: "+1...", toNumber: "+1...", body: "..." }
+ *
+ * LC Workflow action (alternate):
+ *   { from: "+1...", to: "+1...", message: "..." }
+ */
+export function extractInboundPayload(
+  body: Record<string, unknown>
+): { fromPhone: string; toPhone: string; messageText: string } | null {
+  const fromPhone =
+    (body.phone as string | undefined) ??
+    (body.from as string | undefined) ??
+    null;
+
+  const toPhone =
+    (body.toNumber as string | undefined) ??
+    (body.to as string | undefined) ??
+    null;
+
+  const messageText =
+    (body.body as string | undefined) ??
+    (body.message as string | undefined) ??
+    "";
+
+  if (!fromPhone || !toPhone) return null;
+  return { fromPhone, toPhone, messageText };
+}

--- a/src/lib/agents/inbound-sms-webhook.test.ts
+++ b/src/lib/agents/inbound-sms-webhook.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for the two-way SMS reply bridge.
+ *
+ * Tests handleInboundSms() and extractInboundPayload() from
+ * inbound-sms-handler.ts — the pure logic layer, decoupled from the
+ * Next.js route wrapper.
+ *
+ * Phone semantic verification (the most common bug in two-way bridges):
+ *   Outbound alert:  from = fromNumber (+19499973915)  →  to = alertSmsTo (+19497849726)
+ *   Nikki's reply:   from = +19497849726               →  to = +19499973915
+ *   Table key:       from_phone = alertSmsTo (+19497849726)   ← REPLIER
+ *                    to_phone   = fromNumber (+19499973915)   ← LC Phone
+ */
+
+import { strict as assert } from "node:assert";
+import { mock, test } from "node:test";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const sbSelectCalls: Array<{ table: string; params: Record<string, unknown> }> = [];
+const sbInsertCalls: Array<{ table: string; row: Record<string, unknown> }> = [];
+const sbUpdateCalls: Array<{
+  table: string;
+  filter: Record<string, unknown>;
+  patch: Record<string, unknown>;
+}> = [];
+
+// Overrideable session mapping returned by sbSelect.
+let mockMapping: Record<string, unknown> | null = {
+  from_phone: "+19497849726",
+  to_phone: "+19499973915",
+  session_id: "sess-uuid-001",
+  agent: "support",
+  client_id: "client-abc",
+};
+
+mock.module("./supabase.ts", {
+  namedExports: {
+    sbSelect: async (table: string, params: Record<string, unknown>) => {
+      sbSelectCalls.push({ table, params });
+      if (table === "sms_alert_sessions" && mockMapping) {
+        return [mockMapping];
+      }
+      return [];
+    },
+    sbInsert: async (table: string, row: Record<string, unknown>) => {
+      sbInsertCalls.push({ table, row });
+      return { id: "new-msg-id", ...row };
+    },
+    sbUpdate: async (
+      table: string,
+      filter: Record<string, unknown>,
+      patch: Record<string, unknown>
+    ) => {
+      sbUpdateCalls.push({ table, filter, patch });
+      return [patch];
+    },
+    sbUpsert: async () => ({}),
+  },
+});
+
+const { handleInboundSms, extractInboundPayload, resolveTables } =
+  await import("./inbound-sms-handler.ts");
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function resetCalls() {
+  sbSelectCalls.length = 0;
+  sbInsertCalls.length = 0;
+  sbUpdateCalls.length = 0;
+}
+
+// ── Unit tests: extractInboundPayload ──────────────────────────────────────
+
+test("extractInboundPayload: primary GHL shape (phone / toNumber / body)", () => {
+  const result = extractInboundPayload({
+    phone: "+19497849726",
+    toNumber: "+19499973915",
+    body: "Heyyyyyy",
+  });
+  assert.ok(result);
+  assert.equal(result.fromPhone, "+19497849726");
+  assert.equal(result.toPhone, "+19499973915");
+  assert.equal(result.messageText, "Heyyyyyy");
+});
+
+test("extractInboundPayload: LC workflow alias shape (from / to / message)", () => {
+  const result = extractInboundPayload({
+    from: "+19497849726",
+    to: "+19499973915",
+    message: "Using aliases",
+  });
+  assert.ok(result);
+  assert.equal(result.fromPhone, "+19497849726");
+  assert.equal(result.toPhone, "+19499973915");
+  assert.equal(result.messageText, "Using aliases");
+});
+
+test("extractInboundPayload: returns null when phones are missing", () => {
+  assert.equal(extractInboundPayload({ body: "no phones" }), null);
+  assert.equal(extractInboundPayload({ phone: "+1..." }), null); // missing toPhone
+});
+
+// ── Unit tests: resolveTables ──────────────────────────────────────────────
+
+test("resolveTables: support → chatSessions / chatMessages (camelCase)", () => {
+  const t = resolveTables("support");
+  assert.equal(t.sessionsTable, "chatSessions");
+  assert.equal(t.messagesTable, "chatMessages");
+  assert.equal(t.humanTakeoverField, "humanTakeover");
+  assert.equal(t.sessionIdField, "sessionId");
+});
+
+test("resolveTables: frontDesk → front_desk_sessions / front_desk_messages", () => {
+  const t = resolveTables("frontDesk");
+  assert.equal(t.sessionsTable, "front_desk_sessions");
+  assert.equal(t.messagesTable, "front_desk_messages");
+  assert.equal(t.humanTakeoverField, "human_takeover");
+  assert.equal(t.sessionIdField, "session_id");
+});
+
+test("resolveTables: care → care_sessions / care_messages", () => {
+  const t = resolveTables("care");
+  assert.equal(t.sessionsTable, "care_sessions");
+  assert.equal(t.messagesTable, "care_messages");
+  assert.equal(t.humanTakeoverField, "human_takeover");
+  assert.equal(t.sessionIdField, "session_id");
+});
+
+// ── Integration tests: handleInboundSms ───────────────────────────────────
+
+test("phone semantics: looks up (from_phone=alertSmsTo, to_phone=fromNumber)", async () => {
+  resetCalls();
+  // Nikki (+19497849726) replies to the LC Phone (+19499973915).
+  await handleInboundSms({
+    fromPhone: "+19497849726", // owner / alertSmsTo → will be inbound `from`
+    toPhone: "+19499973915",   // LC Phone / fromNumber → will be inbound `to`
+    messageText: "Heyyyyyy",
+  });
+
+  assert.equal(sbSelectCalls.length, 1);
+  assert.equal(sbSelectCalls[0].table, "sms_alert_sessions");
+  const params = sbSelectCalls[0].params as Record<string, string>;
+  assert.equal(
+    params.from_phone,
+    "eq.+19497849726",
+    "from_phone must be the replier (alertSmsTo / Nikki's cell)"
+  );
+  assert.equal(
+    params.to_phone,
+    "eq.+19499973915",
+    "to_phone must be the LC Phone (fromNumber used in outbound)"
+  );
+});
+
+test("known sender: inserts human message into chatMessages with author 'Nikki (human)'", async () => {
+  resetCalls();
+  const result = await handleInboundSms({
+    fromPhone: "+19497849726",
+    toPhone: "+19499973915",
+    messageText: "Heyyyyyy",
+  });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) throw new Error("expected ok");
+  assert.equal(result.sessionId, "sess-uuid-001");
+
+  // One insert (message), one update (session patch).
+  assert.equal(sbInsertCalls.length, 1);
+  assert.equal(sbUpdateCalls.length, 1);
+
+  const msg = sbInsertCalls[0].row;
+  assert.equal(msg.content, "Heyyyyyy");
+  assert.equal(msg.role, "human");
+  assert.equal(msg.author, "Nikki (human)");
+  assert.equal(sbInsertCalls[0].table, "chatMessages");
+});
+
+test("known sender (support): flips humanTakeover=true on chatSessions (camelCase)", async () => {
+  resetCalls();
+  await handleInboundSms({
+    fromPhone: "+19497849726",
+    toPhone: "+19499973915",
+    messageText: "I'm here",
+  });
+
+  const update = sbUpdateCalls[0];
+  assert.equal(update.table, "chatSessions");
+  assert.equal(update.patch.humanTakeover, true);
+});
+
+test("known sender (frontDesk): uses front_desk_messages and human_takeover", async () => {
+  resetCalls();
+  const saved = mockMapping;
+  mockMapping = {
+    from_phone: "+19497849726",
+    to_phone: "+19499973915",
+    session_id: "sess-fd-002",
+    agent: "frontDesk",
+    client_id: "client-abc",
+  };
+  try {
+    const result = await handleInboundSms({
+      fromPhone: "+19497849726",
+      toPhone: "+19499973915",
+      messageText: "Be there in 5",
+    });
+    assert.equal(result.ok, true);
+    if (!result.ok) throw new Error("expected ok");
+    assert.equal(result.sessionId, "sess-fd-002");
+
+    const insert = sbInsertCalls[0];
+    assert.equal(insert.table, "front_desk_messages");
+    assert.equal(insert.row.session_id, "sess-fd-002");
+    assert.equal(insert.row.role, "human");
+    assert.equal(insert.row.author, "Nikki (human)");
+
+    const update = sbUpdateCalls[0];
+    assert.equal(update.table, "front_desk_sessions");
+    assert.equal(update.patch.human_takeover, true);
+  } finally {
+    mockMapping = saved;
+  }
+});
+
+test("known sender (care): uses care_messages and human_takeover", async () => {
+  resetCalls();
+  const saved = mockMapping;
+  mockMapping = {
+    from_phone: "+19497849726",
+    to_phone: "+19499973915",
+    session_id: "sess-care-003",
+    agent: "care",
+    client_id: "client-abc",
+  };
+  try {
+    await handleInboundSms({
+      fromPhone: "+19497849726",
+      toPhone: "+19499973915",
+      messageText: "On my way",
+    });
+    assert.equal(sbInsertCalls[0].table, "care_messages");
+    assert.equal(sbUpdateCalls[0].table, "care_sessions");
+    assert.equal(sbUpdateCalls[0].patch.human_takeover, true);
+  } finally {
+    mockMapping = saved;
+  }
+});
+
+test("unknown sender: returns no_mapping, zero DB writes", async () => {
+  resetCalls();
+  const saved = mockMapping;
+  mockMapping = null;
+  try {
+    const result = await handleInboundSms({
+      fromPhone: "+10000000000",
+      toPhone: "+19499973915",
+      messageText: "spam",
+    });
+    assert.equal(result.ok, false);
+    if (result.ok) throw new Error("expected not ok");
+    assert.equal(result.reason, "no_mapping");
+    assert.equal(sbInsertCalls.length, 0);
+    assert.equal(sbUpdateCalls.length, 0);
+  } finally {
+    mockMapping = saved;
+  }
+});
+
+test("empty message body is stored as '(empty)'", async () => {
+  resetCalls();
+  await handleInboundSms({
+    fromPhone: "+19497849726",
+    toPhone: "+19499973915",
+    messageText: "   ", // whitespace only
+  });
+  assert.equal(sbInsertCalls[0].row.content, "(empty)");
+});

--- a/src/lib/agents/runner.ts
+++ b/src/lib/agents/runner.ts
@@ -267,7 +267,11 @@ export async function runTurn({
         `"${snippet}"\n` +
         `Open: ${inboxUrl}`;
       // Fire-and-forget — do not block the reply.
-      void sendOwnerSmsAlert({ cfg, message: shadowBody });
+      void sendOwnerSmsAlert({
+        cfg,
+        message: shadowBody,
+        sessionContext: { sessionId: session.id, agent },
+      });
     }
   }
 
@@ -334,6 +338,7 @@ export async function runTurn({
       sendOwnerSmsAlert({
         cfg,
         message: smsAlertBody,
+        sessionContext: { sessionId: session.id, agent },
       }),
     ]);
   }

--- a/src/lib/agents/sms-alert.ts
+++ b/src/lib/agents/sms-alert.ts
@@ -8,14 +8,34 @@
  * Fails soft: a missing alertSmsTo or a send failure logs a warning and
  * returns `{ ok: false }` so a visitor-facing chat request never 500s
  * because the operator-notification channel is down.
+ *
+ * Two-way reply bridge
+ * --------------------
+ * When optional `sessionContext` is provided, a successful send upserts
+ * a row into `sms_alert_sessions` so the inbound-SMS webhook can
+ * correlate an owner reply back to the originating visitor session.
+ *
+ * Phone semantics:
+ *   outbound:  from=cfg.smsConfig.fromNumber  →  to=cfg.smsConfig.alertSmsTo
+ *   inbound reply:  from=alertSmsTo  →  to=fromNumber
+ * So we store (from_phone=alertSmsTo, to_phone=fromNumber) as the PK —
+ * matching exactly how GHL delivers the reply to our inbound webhook.
  */
 
 import { getSmsIntegration } from "./integrations/registry";
-import type { ClientConfig } from "./types";
+import { sbUpsert } from "./supabase";
+import type { AgentKind, ClientConfig } from "./types";
+
+export interface SmsAlertSessionContext {
+  sessionId: string;
+  agent: AgentKind;
+}
 
 export async function sendOwnerSmsAlert(params: {
   cfg: ClientConfig;
   message: string;
+  /** When supplied the send is correlated to a session for reply routing. */
+  sessionContext?: SmsAlertSessionContext;
 }): Promise<{ ok: boolean; error?: string; messageId?: string }> {
   const to = (params.cfg.smsConfig?.alertSmsTo as string | undefined) ?? undefined;
   if (!to) {
@@ -27,6 +47,44 @@ export async function sendOwnerSmsAlert(params: {
   try {
     const sms = getSmsIntegration(params.cfg);
     const { messageId } = await sms.sendSMS(to, params.message);
+
+    // Two-way reply bridge: persist the session mapping so the inbound
+    // webhook can correlate a reply back to this session.
+    //
+    // from_phone = alertSmsTo (the owner's number — this is who will reply)
+    // to_phone   = fromNumber (the LC Phone number that receives the reply)
+    //
+    // We upsert rather than insert so repeated alerts for the same
+    // owner↔number pair (one per session at most, because that is how the
+    // PK works) always point to the most-recent session.
+    if (params.sessionContext) {
+      const fromNumber = params.cfg.smsConfig?.fromNumber as string | undefined;
+      if (fromNumber) {
+        // Fire-and-forget — a mapping failure must never block the alert.
+        void sbUpsert(
+          "sms_alert_sessions",
+          {
+            from_phone: to,         // Nikki's cell (will be inbound `from`)
+            to_phone:   fromNumber, // LC Phone     (will be inbound `to`)
+            session_id: params.sessionContext.sessionId,
+            agent:      params.sessionContext.agent,
+            client_id:  params.cfg.clientId,
+            created_at: new Date().toISOString(),
+          },
+          "from_phone,to_phone"
+        ).catch((err: unknown) => {
+          console.error(
+            `[sms-alert] failed to upsert sms_alert_sessions for session=${params.sessionContext!.sessionId}:`,
+            err instanceof Error ? err.message : err
+          );
+        });
+      } else {
+        console.warn(
+          `[sms-alert] sessionContext supplied but smsConfig.fromNumber is missing — reply routing skipped for client=${params.cfg.clientId}`
+        );
+      }
+    }
+
     return { ok: true, messageId };
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown";

--- a/supabase/migrations/0005_sms_alert_sessions.sql
+++ b/supabase/migrations/0005_sms_alert_sessions.sql
@@ -1,0 +1,43 @@
+-- SMS Alert Sessions — two-way reply correlation table
+--
+-- When the system sends an owner-alert SMS we record which session it
+-- came from. When the owner replies, the inbound webhook looks up this
+-- table by (from_phone, to_phone) to find the session and post the
+-- reply as a human message in the visitor's chat widget.
+--
+-- Phone number semantics (CRITICAL — read carefully):
+--   The alert is sent:
+--     from = smsConfig.fromNumber   (e.g. +19499973915, the A2P LC Phone)
+--     to   = smsConfig.alertSmsTo   (e.g. +19497849726, Nikki's cell)
+--
+--   When Nikki replies, the inbound SMS arrives:
+--     from = +19497849726  (Nikki's cell → the alertSmsTo)
+--     to   = +19499973915  (the LC Phone number → the fromNumber)
+--
+--   So we index the table as:
+--     from_phone = alertSmsTo   (who will be REPLYING inbound)
+--     to_phone   = fromNumber   (which number receives the reply)
+--
+-- Target project: clipzfkbzupjctherijz
+
+create table if not exists public.sms_alert_sessions (
+  -- The phone number that SENDS the reply (owner / alertSmsTo).
+  from_phone  text        not null,
+  -- The LC Phone number that receives the reply (fromNumber used in outbound).
+  to_phone    text        not null,
+  -- The session to route the reply into.
+  session_id  uuid        not null,
+  -- Agent type so we can resolve the correct messages/sessions table.
+  agent       text        not null check (agent in ('support', 'frontDesk', 'care')),
+  -- Client for logging/debugging.
+  client_id   text        not null,
+  -- Timestamp of the last outbound alert (useful for staleness detection).
+  created_at  timestamptz not null default now(),
+
+  primary key (from_phone, to_phone)
+);
+
+-- Index is redundant with the PK but makes the query planner happy on
+-- Supabase's PostgREST query path which uses filter params, not pk lookup.
+create index if not exists sms_alert_sessions_phones_idx
+  on public.sms_alert_sessions (from_phone, to_phone);


### PR DESCRIPTION
## Overview

When Nikki replies to an alert SMS, her message is posted as a **human** message in the visitor's chat widget with author **"Nikki (human)"**, and `humanTakeover=true` is set on the session so the AI pauses.

---

## Architecture

```
OUTBOUND ALERT
  from = +19499973915  (LC Phone / smsConfig.fromNumber)
  to   = +19497849726  (Nikki's cell / smsConfig.alertSmsTo)
  upsert sms_alert_sessions (from_phone=alertSmsTo, to_phone=fromNumber, session_id, agent)

NIKKI REPLIES
  from = +19497849726  <- matches from_phone
  to   = +19499973915  <- matches to_phone
  LC fires webhook → POST /api/ghl/inbound-sms?secret=<GHL_WEBHOOK_SECRET>

WEBHOOK HANDLER
  1. Look up sms_alert_sessions (from_phone, to_phone)
  2. Insert { role: "human", author: "Nikki (human)", content: "Heyyyyyy" }
  3. PATCH session: { humanTakeover: true }
  4. AI stops; message appears in visitor widget
```

**Phone semantics note**: `from_phone` = alertSmsTo (the *replier*), `to_phone` = fromNumber (the LC Phone). This matches exactly how the inbound webhook delivers the reply — keyed from Nikki's perspective.

---

## Files changed

| File | Change |
|---|---|
| `supabase/migrations/0005_sms_alert_sessions.sql` | New correlation table |
| `src/lib/agents/sms-alert.ts` | Accept optional `sessionContext`, upsert mapping on send |
| `src/lib/agents/runner.ts` | Pass `sessionContext` to both every-turn and escalation SMS sends |
| `src/lib/agents/inbound-sms-handler.ts` | Pure handler logic (no Next.js deps) — testable |
| `src/app/api/ghl/inbound-sms/route.ts` | POST webhook, auth via `?secret=` |
| `src/app/admin/sessions/[id]/page.tsx` | Render `msg.author` on human messages |
| `src/lib/agents/inbound-sms-webhook.test.ts` | 13 tests — all passing |
| `src/lib/agents/env.ts` | `ghlWebhookSecret()` helper |
| `.env.example` | Document `GHL_WEBHOOK_SECRET` |
| `docs/two-way-sms.md` | Setup guide + GHL automation steps + test plan |

---

## Migration

Run `supabase/migrations/0005_sms_alert_sessions.sql` on the Supabase project:
```sh
supabase db push
```

---

## Required Vercel env var

| Variable | Description | How to generate |
|---|---|---|
| `GHL_WEBHOOK_SECRET` | Shared secret for webhook auth | `openssl rand -hex 32` |

Set in Vercel: **Settings → Environment Variables → GHL_WEBHOOK_SECRET**

---

## Webhook URL for GHL

```
https://www.opsbynoell.com/api/ghl/inbound-sms?secret=<GHL_WEBHOOK_SECRET>
```

---

## GHL automation setup

1. **Automations → Workflows → New Workflow → Start from Scratch**
2. **Trigger**: Customer Reply → filter **Channel = SMS**, **Direction = Inbound**
3. **Action**: Webhook
   - Method: POST
   - URL: `https://www.opsbynoell.com/api/ghl/inbound-sms?secret=<GHL_WEBHOOK_SECRET>`
   - Body:
     ```json
     {
       "phone": "{{contact.phone}}",
       "toNumber": "{{message.to_number}}",
       "body": "{{message.body}}"
     }
     ```
4. **Publish** the workflow.

Full setup guide: [docs/two-way-sms.md](docs/two-way-sms.md)

---

## Manual test plan

1. Trigger an escalation in the chat widget
2. Nikki receives alert SMS with inbox URL
3. Nikki replies from her phone
4. Open the admin inbox — message appears as "Nikki (human)" with Human badge
5. Visitor sends another message — no AI reply (human takeover active)

cURL smoke test:
```sh
curl -s -X POST \
  "https://www.opsbynoell.com/api/ghl/inbound-sms?secret=<GHL_WEBHOOK_SECRET>" \
  -H "Content-Type: application/json" \
  -d '{"phone": "<Nikki_cell>", "toNumber": "<LC_Phone>", "body": "Test reply"}' | jq .
```

---

## Constraints

- `agent-chat-widget.tsx` not modified (A2P-frozen)
- No "GHL"/"GoHighLevel"/"SaaS Pro" in user-facing copy
- Webhook path `/api/ghl/*` is internal only
