### PR TITLE
feat(admin): forgot-password magic-link flow

### DIFF
--- a/src/app/admin/forgot-password/page.tsx
+++ b/src/app/admin/forgot-password/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+export default function AdminForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/forgot-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      if (res.ok) {
+        setSubmitted(true);
+      } else {
+        setError("Something went wrong. Try again.");
+      }
+    } catch {
+      setError("Connection error. Try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-cream flex flex-col items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="mb-8 text-center">
+          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-charcoal/50 mb-2">
+            Ops by Noell
+          </p>
+          <h1 className="font-serif text-2xl font-semibold text-charcoal">
+            Reset password
+          </h1>
+        </div>
+
+        <div className="bg-white rounded-[20px] border border-warm-border shadow-[0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)] p-8">
+          {submitted ? (
+            <div className="space-y-4 text-center">
+              <p className="font-serif text-lg text-charcoal">Check your inbox</p>
+              <p className="text-sm text-charcoal/70 leading-relaxed">
+                If that email is registered, we&rsquo;ve sent a reset link.
+                It expires in 1 hour.
+              </p>
+              <Link
+                href="/admin/login"
+                className="inline-block text-sm text-wine hover:text-wine-dark underline underline-offset-2"
+              >
+                Back to sign in
+              </Link>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <p className="text-sm text-charcoal/70 leading-relaxed">
+                Enter your email and we&rsquo;ll send you a link to reset your
+                password.
+              </p>
+
+              <div>
+                <label
+                  htmlFor="email"
+                  className="block text-xs font-medium text-charcoal/70 mb-1.5"
+                >
+                  Email
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@opsbynoell.com"
+                  autoFocus
+                  required
+                  autoComplete="email"
+                  className="w-full h-11 px-4 text-sm bg-cream rounded-xl border border-warm-border focus:outline-none focus:border-wine/50 text-charcoal placeholder:text-charcoal/35"
+                />
+              </div>
+
+              {error && (
+                <p className="text-xs text-red-500 bg-red-50 px-3 py-2 rounded-lg">
+                  {error}
+                </p>
+              )}
+
+              <button
+                type="submit"
+                disabled={!email || loading}
+                className="w-full h-11 rounded-xl bg-wine text-cream text-sm font-medium hover:bg-wine/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                {loading ? "Sending..." : "Send reset link"}
+              </button>
+
+              <div className="text-center pt-2">
+                <Link
+                  href="/admin/login"
+                  className="text-xs text-charcoal/60 hover:text-charcoal underline underline-offset-2"
+                >
+                  Back to sign in
+                </Link>
+              </div>
+            </form>
+          )}
+        </div>
+
+        <p className="text-center text-[10px] text-charcoal/35 mt-6 font-mono">
+          three agents &middot; one inbox
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
@@ -122,6 +123,15 @@ function AdminLoginForm() {
             >
               {loading ? "Signing in..." : "Sign in"}
             </button>
+
+            <div className="text-center pt-1">
+              <Link
+                href="/admin/forgot-password"
+                className="text-xs text-charcoal/60 hover:text-charcoal underline underline-offset-2"
+              >
+                Forgot password?
+              </Link>
+            </div>
           </form>
         </div>
 

--- a/src/app/admin/reset-password/page.tsx
+++ b/src/app/admin/reset-password/page.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
+
+type Status =
+  | { kind: "loading" }
+  | { kind: "invalid"; message: string }
+  | { kind: "ready"; email: string };
+
+function ResetPasswordForm() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const token = params.get("token") ?? "";
+
+  const [status, setStatus] = useState<Status>({ kind: "loading" });
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      setStatus({
+        kind: "invalid",
+        message: "This reset link is missing its token.",
+      });
+      return;
+    }
+    fetch(
+      `/api/admin/reset-password?token=${encodeURIComponent(token)}`
+    )
+      .then(async (r) => {
+        const data = await r.json().catch(() => ({}));
+        if (r.ok && typeof data.email === "string") {
+          setStatus({ kind: "ready", email: data.email });
+        } else {
+          setStatus({
+            kind: "invalid",
+            message:
+              typeof data.error === "string"
+                ? data.error
+                : "This reset link is invalid or has expired.",
+          });
+        }
+      })
+      .catch(() => {
+        setStatus({
+          kind: "invalid",
+          message: "Could not verify the reset link. Try again later.",
+        });
+      });
+  }, [token]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters.");
+      return;
+    }
+    if (password !== confirm) {
+      setError("Passwords do not match.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/admin/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, password }),
+      });
+      if (res.ok) {
+        router.replace("/admin/login?reset=1");
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setError(
+          typeof data.error === "string"
+            ? data.error
+            : "Could not reset password. Try again."
+        );
+      }
+    } catch {
+      setError("Connection error. Try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-cream flex flex-col items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="mb-8 text-center">
+          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-charcoal/50 mb-2">
+            Ops by Noell
+          </p>
+          <h1 className="font-serif text-2xl font-semibold text-charcoal">
+            Set new password
+          </h1>
+        </div>
+
+        <div className="bg-white rounded-[20px] border border-warm-border shadow-[0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)] p-8">
+          {status.kind === "loading" && (
+            <div className="flex justify-center py-4">
+              <div className="w-5 h-5 border-2 border-wine/30 border-t-wine rounded-full animate-spin" />
+            </div>
+          )}
+
+          {status.kind === "invalid" && (
+            <div className="space-y-4 text-center">
+              <p className="font-serif text-lg text-charcoal">Link unavailable</p>
+              <p className="text-sm text-charcoal/70 leading-relaxed">
+                {status.message}
+              </p>
+              <Link
+                href="/admin/forgot-password"
+                className="inline-block text-sm text-wine hover:text-wine-dark underline underline-offset-2"
+              >
+                Request a new link
+              </Link>
+            </div>
+          )}
+
+          {status.kind === "ready" && (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <p className="text-sm text-charcoal/70 leading-relaxed">
+                Reset password for{" "}
+                <span className="font-medium text-charcoal">
+                  {status.email}
+                </span>
+              </p>
+
+              <div>
+                <label
+                  htmlFor="password"
+                  className="block text-xs font-medium text-charcoal/70 mb-1.5"
+                >
+                  New password
+                </label>
+                <input
+                  id="password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="At least 8 characters"
+                  autoFocus
+                  required
+                  autoComplete="new-password"
+                  className="w-full h-11 px-4 text-sm bg-cream rounded-xl border border-warm-border focus:outline-none focus:border-wine/50 text-charcoal placeholder:text-charcoal/35"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="confirm"
+                  className="block text-xs font-medium text-charcoal/70 mb-1.5"
+                >
+                  Confirm password
+                </label>
+                <input
+                  id="confirm"
+                  type="password"
+                  value={confirm}
+                  onChange={(e) => setConfirm(e.target.value)}
+                  placeholder="Re-enter password"
+                  required
+                  autoComplete="new-password"
+                  className="w-full h-11 px-4 text-sm bg-cream rounded-xl border border-warm-border focus:outline-none focus:border-wine/50 text-charcoal placeholder:text-charcoal/35"
+                />
+              </div>
+
+              {error && (
+                <p className="text-xs text-red-500 bg-red-50 px-3 py-2 rounded-lg">
+                  {error}
+                </p>
+              )}
+
+              <button
+                type="submit"
+                disabled={!password || !confirm || submitting}
+                className="w-full h-11 rounded-xl bg-wine text-cream text-sm font-medium hover:bg-wine/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                {submitting ? "Saving..." : "Save new password"}
+              </button>
+            </form>
+          )}
+        </div>
+
+        <p className="text-center text-[10px] text-charcoal/35 mt-6 font-mono">
+          three agents &middot; one inbox
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function AdminResetPasswordPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-cream flex items-center justify-center">
+          <div className="w-5 h-5 border-2 border-wine/30 border-t-wine rounded-full animate-spin" />
+        </div>
+      }
+    >
+      <ResetPasswordForm />
+    </Suspense>
+  );
+}

--- a/src/app/api/admin/forgot-password/route.ts
+++ b/src/app/api/admin/forgot-password/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { handleForgotPassword } from "@/lib/admin-forgot-password";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request): Promise<Response> {
+  let body: { email?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid json" }, { status: 400 });
+  }
+
+  const email = typeof body.email === "string" ? body.email : "";
+  await handleForgotPassword(email);
+
+  // Always neutral — prevents enumeration. The UI renders the same
+  // confirmation whether the email matches a user or not.
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/reset-password/route.ts
+++ b/src/app/api/admin/reset-password/route.ts
@@ -1,0 +1,127 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { hashPassword } from "@/lib/admin-password";
+import { hashResetToken } from "@/lib/admin-password-reset";
+import { sbSelect, sbUpdate } from "@/lib/agents/supabase";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface ResetRow {
+  id: string;
+  user_id: string;
+  expires_at: string;
+  used_at: string | null;
+}
+
+interface UserRow {
+  id: string;
+  email: string;
+}
+
+async function lookupValidReset(
+  rawToken: string
+): Promise<{ reset: ResetRow; user: UserRow } | null> {
+  if (!rawToken) return null;
+  const tokenHash = await hashResetToken(rawToken);
+
+  let resetRows: ResetRow[] = [];
+  try {
+    resetRows = await sbSelect<ResetRow>(
+      "admin_password_resets",
+      { token_hash: `eq.${tokenHash}` },
+      { select: "id,user_id,expires_at,used_at", limit: 1 }
+    );
+  } catch {
+    return null;
+  }
+
+  const reset = resetRows[0];
+  if (!reset) return null;
+  if (reset.used_at) return null;
+  if (new Date(reset.expires_at).getTime() <= Date.now()) return null;
+
+  let userRows: UserRow[] = [];
+  try {
+    userRows = await sbSelect<UserRow>(
+      "admin_users",
+      { id: `eq.${reset.user_id}` },
+      { select: "id,email", limit: 1 }
+    );
+  } catch {
+    return null;
+  }
+
+  const user = userRows[0];
+  if (!user) return null;
+  return { reset, user };
+}
+
+/** GET /api/admin/reset-password?token=... — validate and reveal the email. */
+export async function GET(req: NextRequest): Promise<Response> {
+  const token = req.nextUrl.searchParams.get("token") ?? "";
+  const found = await lookupValidReset(token);
+  if (!found) {
+    return NextResponse.json(
+      { error: "This reset link is invalid or has expired." },
+      { status: 400 }
+    );
+  }
+  return NextResponse.json({ email: found.user.email });
+}
+
+/** POST /api/admin/reset-password — body { token, password }. */
+export async function POST(req: Request): Promise<Response> {
+  let body: { token?: string; password?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid json" }, { status: 400 });
+  }
+
+  const token = typeof body.token === "string" ? body.token : "";
+  const password = typeof body.password === "string" ? body.password : "";
+
+  if (!password || password.length < 8) {
+    return NextResponse.json(
+      { error: "Password must be at least 8 characters." },
+      { status: 400 }
+    );
+  }
+
+  const found = await lookupValidReset(token);
+  if (!found) {
+    return NextResponse.json(
+      { error: "This reset link is invalid or has expired." },
+      { status: 400 }
+    );
+  }
+
+  const newHash = await hashPassword(password);
+
+  try {
+    await sbUpdate(
+      "admin_users",
+      { id: `eq.${found.user.id}` },
+      { password_hash: newHash }
+    );
+  } catch (err) {
+    console.error("[reset-password] user update failed:", err);
+    return NextResponse.json(
+      { error: "Could not reset password. Try again." },
+      { status: 500 }
+    );
+  }
+
+  try {
+    await sbUpdate(
+      "admin_password_resets",
+      { id: `eq.${found.reset.id}` },
+      { used_at: new Date().toISOString() }
+    );
+  } catch (err) {
+    // Password was updated; log but don't fail the request.
+    console.error("[reset-password] marking used failed:", err);
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/lib/admin-forgot-password.test.ts
+++ b/src/lib/admin-forgot-password.test.ts
@@ -1,0 +1,161 @@
+import { strict as assert } from "node:assert";
+import { mock, test } from "node:test";
+
+interface SbSelectCall {
+  table: string;
+  params: Record<string, unknown>;
+}
+
+interface SbInsertCall {
+  table: string;
+  row: Record<string, unknown>;
+}
+
+interface SendCall {
+  toEmail: string;
+  rawToken: string;
+}
+
+const sbSelectCalls: SbSelectCall[] = [];
+const sbInsertCalls: SbInsertCall[] = [];
+const sendCalls: SendCall[] = [];
+
+let userRowsForNextSelect: Array<{ id: string; email: string }> = [];
+let sbSelectShouldThrow = false;
+let sbInsertShouldThrow = false;
+
+mock.module("./agents/supabase.ts", {
+  namedExports: {
+    sbSelect: async (
+      table: string,
+      params: Record<string, unknown>
+    ) => {
+      sbSelectCalls.push({ table, params });
+      if (sbSelectShouldThrow) throw new Error("db down");
+      return userRowsForNextSelect;
+    },
+    sbInsert: async (table: string, row: Record<string, unknown>) => {
+      sbInsertCalls.push({ table, row });
+      if (sbInsertShouldThrow) throw new Error("insert failed");
+      return row;
+    },
+    sbUpdate: async () => [],
+    sbUpsert: async () => ({}),
+    sbRpc: async () => ({}),
+  },
+});
+
+mock.module("./admin-password-reset.ts", {
+  namedExports: {
+    RESET_TOKEN_TTL_MS: 60 * 60 * 1000,
+    generateResetToken: () => "raw-token-123",
+    hashResetToken: async (t: string) => `hash:${t}`,
+    buildResetUrl: (t: string) => `https://example.com/reset?token=${t}`,
+    sendResetEmail: async (params: {
+      toEmail: string;
+      rawToken: string;
+    }) => {
+      sendCalls.push(params);
+      return { ok: true };
+    },
+  },
+});
+
+const { handleForgotPassword } = await import("./admin-forgot-password.ts");
+
+function resetState() {
+  sbSelectCalls.length = 0;
+  sbInsertCalls.length = 0;
+  sendCalls.length = 0;
+  userRowsForNextSelect = [];
+  sbSelectShouldThrow = false;
+  sbInsertShouldThrow = false;
+}
+
+test("always resolves ok for an unknown email — no token, no email", async () => {
+  resetState();
+  userRowsForNextSelect = [];
+
+  const result = await handleForgotPassword("ghost@example.com");
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(sbSelectCalls.length, 1);
+  assert.equal(sbSelectCalls[0].table, "admin_users");
+  assert.equal(
+    sbSelectCalls[0].params.email,
+    "eq.ghost@example.com",
+    "email should be lowercased and used as eq filter"
+  );
+  assert.equal(sbInsertCalls.length, 0, "no token row inserted for unknown user");
+  assert.equal(sendCalls.length, 0, "no email sent for unknown user");
+});
+
+test("creates reset token + sends email when email matches an admin user", async () => {
+  resetState();
+  userRowsForNextSelect = [
+    { id: "user-abc", email: "hello@opsbynoell.com" },
+  ];
+
+  const result = await handleForgotPassword("Hello@OpsByNoell.com");
+
+  assert.deepEqual(result, { ok: true });
+
+  assert.equal(sbInsertCalls.length, 1, "one token row inserted");
+  const insert = sbInsertCalls[0];
+  assert.equal(insert.table, "admin_password_resets");
+  assert.equal(insert.row.user_id, "user-abc");
+  assert.equal(insert.row.token_hash, "hash:raw-token-123");
+  assert.ok(
+    typeof insert.row.expires_at === "string" &&
+      !Number.isNaN(new Date(insert.row.expires_at).getTime()),
+    "expires_at is an ISO timestamp"
+  );
+  const expiresMs = new Date(insert.row.expires_at as string).getTime();
+  const delta = expiresMs - Date.now();
+  assert.ok(
+    delta > 55 * 60 * 1000 && delta <= 60 * 60 * 1000 + 1000,
+    `expires_at should be ~1 hour out (got ${delta}ms)`
+  );
+
+  assert.equal(sendCalls.length, 1, "one email sent");
+  assert.deepEqual(sendCalls[0], {
+    toEmail: "hello@opsbynoell.com",
+    rawToken: "raw-token-123",
+  });
+});
+
+test("returns ok with the same shape for known and unknown emails — no enumeration signal", async () => {
+  resetState();
+  userRowsForNextSelect = [];
+  const unknown = await handleForgotPassword("nobody@example.com");
+
+  resetState();
+  userRowsForNextSelect = [
+    { id: "user-abc", email: "hello@opsbynoell.com" },
+  ];
+  const known = await handleForgotPassword("hello@opsbynoell.com");
+
+  assert.deepEqual(unknown, known);
+});
+
+test("still resolves ok when the DB lookup throws — no email sent", async () => {
+  resetState();
+  sbSelectShouldThrow = true;
+
+  const result = await handleForgotPassword("hello@opsbynoell.com");
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(sbInsertCalls.length, 0);
+  assert.equal(sendCalls.length, 0);
+});
+
+test("empty email short-circuits without hitting the DB", async () => {
+  resetState();
+
+  const result = await handleForgotPassword("   ");
+
+  assert.deepEqual(result, { ok: true });
+  assert.equal(sbSelectCalls.length, 0);
+  assert.equal(sbInsertCalls.length, 0);
+  assert.equal(sendCalls.length, 0);
+});

--- a/src/lib/admin-forgot-password.ts
+++ b/src/lib/admin-forgot-password.ts
@@ -1,0 +1,64 @@
+/**
+ * Core forgot-password logic, separated from the route handler so
+ * it can be exercised directly from the node:test runner.
+ *
+ * Behavior:
+ *   - Always resolves as `{ ok: true }` so the caller can return
+ *     a neutral response to prevent email enumeration.
+ *   - Silently no-ops when the email doesn't match an admin user.
+ *   - On match: creates a SHA-256-hashed reset token (1h TTL) and
+ *     emails a link containing the raw token.
+ */
+
+import { sbInsert, sbSelect } from "./agents/supabase";
+import {
+  RESET_TOKEN_TTL_MS,
+  generateResetToken,
+  hashResetToken,
+  sendResetEmail,
+} from "./admin-password-reset";
+
+interface AdminUserRow {
+  id: string;
+  email: string;
+}
+
+export async function handleForgotPassword(
+  rawEmail: string
+): Promise<{ ok: true }> {
+  const email = rawEmail.trim().toLowerCase();
+  if (!email) return { ok: true };
+
+  let user: AdminUserRow | null = null;
+  try {
+    const rows = await sbSelect<AdminUserRow>(
+      "admin_users",
+      { email: `eq.${email}` },
+      { select: "id,email", limit: 1 }
+    );
+    user = rows[0] ?? null;
+  } catch (err) {
+    console.error("[forgot-password] lookup failed:", err);
+    return { ok: true };
+  }
+
+  if (!user) return { ok: true };
+
+  const rawToken = generateResetToken();
+  const tokenHash = await hashResetToken(rawToken);
+  const expiresAt = new Date(Date.now() + RESET_TOKEN_TTL_MS).toISOString();
+
+  try {
+    await sbInsert("admin_password_resets", {
+      user_id: user.id,
+      token_hash: tokenHash,
+      expires_at: expiresAt,
+    });
+  } catch (err) {
+    console.error("[forgot-password] token insert failed:", err);
+    return { ok: true };
+  }
+
+  await sendResetEmail({ toEmail: user.email, rawToken });
+  return { ok: true };
+}

--- a/src/lib/admin-password-reset.ts
+++ b/src/lib/admin-password-reset.ts
@@ -1,0 +1,163 @@
+/**
+ * Password-reset token helpers for admin_users.
+ *
+ * The raw token is generated here, emailed to the user, and never
+ * stored — the DB only holds a SHA-256 hex digest of it. When a
+ * reset link is opened we hash the incoming value and look it up.
+ *
+ * Node.js runtime only — imported from API routes that talk to
+ * Supabase and Resend. Never imported from the Edge-Runtime proxy.
+ */
+
+import { Resend } from "resend";
+import { env } from "./agents/env";
+
+export const RESET_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+function toBase64url(buf: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(buf)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+}
+
+function bytesToHex(buf: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** 32 random bytes → url-safe base64 (43 chars). */
+export function generateResetToken(): string {
+  const buf = new ArrayBuffer(32);
+  crypto.getRandomValues(new Uint8Array(buf));
+  return toBase64url(buf);
+}
+
+/** SHA-256 hex digest of the raw token — this is what we store. */
+export async function hashResetToken(rawToken: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(rawToken)
+  );
+  return bytesToHex(digest);
+}
+
+function siteBaseUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ??
+    "https://www.opsbynoell.com"
+  );
+}
+
+export function buildResetUrl(rawToken: string): string {
+  return `${siteBaseUrl()}/admin/reset-password?token=${encodeURIComponent(rawToken)}`;
+}
+
+/**
+ * Branded HTML email — cream background, deep wine CTA, Playfair
+ * heading. Kept inline so the template lives next to the sender;
+ * no separate MJML/JSX email rendering pipeline.
+ */
+function renderResetEmailHtml(resetUrl: string): string {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Password reset</title>
+  </head>
+  <body style="margin:0;padding:0;background:#FAF5F0;font-family:'Inter','Helvetica Neue',Arial,sans-serif;color:#3D2430;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#FAF5F0;padding:40px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:520px;background:#ffffff;border:1px solid #E7DFD6;border-radius:20px;padding:40px 32px;">
+            <tr>
+              <td style="text-align:center;padding-bottom:8px;">
+                <p style="margin:0;font-family:'Courier New',monospace;font-size:10px;letter-spacing:0.28em;text-transform:uppercase;color:rgba(61,36,48,0.5);">
+                  Ops by Noell
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td style="text-align:center;padding-bottom:24px;">
+                <h1 style="margin:0;font-family:'Playfair Display',Georgia,'Times New Roman',serif;font-size:28px;font-weight:600;color:#3D2430;">
+                  Password reset
+                </h1>
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:15px;line-height:1.6;color:#3D2430;padding-bottom:24px;">
+                Someone requested a password reset for your Ops by Noell admin account. Click the button below to choose a new password.
+              </td>
+            </tr>
+            <tr>
+              <td align="center" style="padding-bottom:28px;">
+                <a href="${resetUrl}" style="display:inline-block;background:#6A2C3E;color:#FAF5F0;text-decoration:none;font-size:15px;font-weight:500;padding:14px 28px;border-radius:12px;">
+                  Reset password
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:13px;line-height:1.6;color:rgba(61,36,48,0.7);padding-bottom:16px;">
+                This link expires in 1 hour. If you didn&rsquo;t request a reset, you can ignore this email &mdash; your password stays the same.
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:12px;line-height:1.5;color:rgba(61,36,48,0.5);word-break:break-all;border-top:1px solid #E7DFD6;padding-top:16px;">
+                If the button doesn&rsquo;t work, paste this into your browser:<br />
+                <span style="color:#6A2C3E;">${resetUrl}</span>
+              </td>
+            </tr>
+          </table>
+          <p style="margin:24px 0 0;font-family:'Courier New',monospace;font-size:10px;color:rgba(61,36,48,0.35);">
+            three agents &middot; one inbox
+          </p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+}
+
+function renderResetEmailText(resetUrl: string): string {
+  return [
+    "Password reset — Ops by Noell",
+    "",
+    "Someone requested a password reset for your admin account.",
+    "Open this link to choose a new password (expires in 1 hour):",
+    "",
+    resetUrl,
+    "",
+    "If you didn't request a reset, you can ignore this email.",
+  ].join("\n");
+}
+
+export async function sendResetEmail(params: {
+  toEmail: string;
+  rawToken: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  const apiKey = env.resendApiKey();
+  if (!apiKey) {
+    console.warn("[password-reset] Resend not configured — email skipped");
+    return { ok: false, error: "resend_not_configured" };
+  }
+
+  const resend = new Resend(apiKey);
+  const resetUrl = buildResetUrl(params.rawToken);
+
+  try {
+    await resend.emails.send({
+      from: env.resendFromEmail(),
+      to: params.toEmail,
+      subject: "Reset your Ops by Noell admin password",
+      html: renderResetEmailHtml(resetUrl),
+      text: renderResetEmailText(resetUrl),
+    });
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown";
+    console.error("[password-reset] send failed:", message);
+    return { ok: false, error: message };
+  }
+}

--- a/supabase/migrations/0006_admin_password_resets.sql
+++ b/supabase/migrations/0006_admin_password_resets.sql
@@ -1,0 +1,31 @@
+-- ============================================================
+-- 0006_admin_password_resets.sql
+--
+-- One-time password-reset tokens for admin_users. The forgot-
+-- password flow inserts a row here when a known email is submitted,
+-- emails the corresponding link, and consumes the row on reset.
+--
+-- Token storage: SHA-256 hex digest of the raw token. The raw token
+-- only ever lives in the emailed URL — the DB never sees it.
+--
+-- Run AFTER: 0003_admin_users_table.sql
+-- Idempotent — safe to re-run.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.admin_password_resets (
+  id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       uuid        NOT NULL REFERENCES public.admin_users(id) ON DELETE CASCADE,
+  token_hash    text        NOT NULL,
+  expires_at    timestamptz NOT NULL,
+  used_at       timestamptz,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS admin_password_resets_token_hash_unique
+  ON public.admin_password_resets (token_hash);
+
+CREATE INDEX IF NOT EXISTS admin_password_resets_user_id_idx
+  ON public.admin_password_resets (user_id);
+
+CREATE INDEX IF NOT EXISTS admin_password_resets_expires_at_idx
+  ON public.admin_password_resets (expires_at);


### PR DESCRIPTION
## What this does

Self-serve password reset for admin users. Forgot password → email with reset link → set new password → log in.

## Changes

### Migration (apply before merge)
- `supabase/migrations/0006_admin_password_resets.sql` — `admin_password_resets` table. Stores only the SHA-256 hash of the token; raw token only lives in the emailed URL.

### Backend
- `src/lib/admin-password-reset.ts` — token gen (32 random bytes → base64url), hasher, branded HTML Resend email (cream #FAF5F0 bg, wine #6A2C3E CTA, Playfair 'Password reset' title, 1h expiry)
- `src/lib/admin-forgot-password.ts` — core handler; always resolves ok, only writes token / sends mail when email matches a real admin_users row (prevents enumeration)
- `POST /api/admin/forgot-password` — always returns 200 `{ ok: true }`
- `GET /api/admin/reset-password` — validates token, reveals email for UI
- `POST /api/admin/reset-password` — ≥8 char password, rejects used/expired, updates `password_hash`, marks `used_at`

### UI
- `/admin/forgot-password` — email form, neutral confirmation
- `/admin/reset-password?token=…` — validates on mount, password + confirm, redirects to `/admin/login?reset=1`
- `/admin/login` — subtle 'Forgot password?' link under sign-in button. Nothing else touched.

### Tests
- `src/lib/admin-forgot-password.test.ts` — 5 node:test cases, all green
  - unknown email: no token, no mail
  - known email: token row + mail with correct user_id/hash/~1h TTL
  - enumeration parity: identical response shape
  - DB-throw resilience
  - empty-email short-circuit

## Manual test plan
1. Apply migration 0006 to Supabase
2. `/admin/login` → click 'Forgot password?'
3. Enter `hello@opsbynoell.com` → neutral confirmation
4. Reset email arrives from hello@opsbynoell.com
5. Click link → reset page shows the email
6. Set new password → redirects to login
7. Log in with new password → success
8. Unknown email → no email sent, UI still neutral
9. Expired/used token → clear error

## Constraints respected
- Brand: cream/wine, Playfair + Inter ✅
- No GHL/GoHighLevel/SaaS Pro in copy ✅
- No A2P-frozen paths touched ✅
- PR #14 untouched ✅