### PR TITLE
feat(admin): magic-link user invites

### DIFF
--- a/src/app/admin/accept-invite/page.tsx
+++ b/src/app/admin/accept-invite/page.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useState, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+function AcceptInviteForm() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const token = params.get("token") ?? "";
+
+  const [checking, setChecking] = useState(true);
+  const [email, setEmail] = useState("");
+  const [loadError, setLoadError] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
+
+  useEffect(() => {
+    if (!token) {
+      setLoadError("This invite link is missing a token.");
+      setChecking(false);
+      return;
+    }
+    fetch(`/api/admin/accept-invite?token=${encodeURIComponent(token)}`)
+      .then(async (r) => {
+        const d = await r.json();
+        if (!r.ok) {
+          setLoadError(d.error ?? "This invite link is invalid.");
+        } else {
+          setEmail(d.email);
+        }
+      })
+      .catch(() => setLoadError("Could not verify invite. Try again later."))
+      .finally(() => setChecking(false));
+  }, [token]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitError("");
+    if (password.length < 8) {
+      setSubmitError("Password must be at least 8 characters.");
+      return;
+    }
+    if (password !== confirm) {
+      setSubmitError("Passwords do not match.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/admin/accept-invite", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, password }),
+      });
+      const d = await res.json();
+      if (!res.ok) {
+        setSubmitError(d.error ?? "Could not set password.");
+        return;
+      }
+      router.replace("/admin/login?invited=1");
+    } catch {
+      setSubmitError("Connection error. Try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (checking) {
+    return (
+      <div className="min-h-screen bg-cream flex items-center justify-center">
+        <div className="w-5 h-5 border-2 border-wine/30 border-t-wine rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-cream flex flex-col items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="mb-8 text-center">
+          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-charcoal/50 mb-2">
+            Ops by Noell
+          </p>
+          <h1 className="font-serif text-2xl font-semibold text-charcoal">
+            Welcome aboard
+          </h1>
+        </div>
+
+        <div className="bg-white rounded-[20px] border border-warm-border shadow-[0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)] p-8">
+          {loadError ? (
+            <>
+              <p className="text-sm text-charcoal/80 mb-4">{loadError}</p>
+              <p className="text-xs text-charcoal/50">
+                Ask your super admin to send a new invite.
+              </p>
+            </>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <p className="text-xs text-charcoal/60 mb-2">
+                Set your password for{" "}
+                <span className="font-medium text-charcoal">{email}</span>
+              </p>
+
+              <div>
+                <label
+                  htmlFor="password"
+                  className="block text-xs font-medium text-charcoal/70 mb-1.5"
+                >
+                  New password
+                </label>
+                <input
+                  id="password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="At least 8 characters"
+                  autoFocus
+                  autoComplete="new-password"
+                  className="w-full h-11 px-4 text-sm bg-cream rounded-xl border border-warm-border focus:outline-none focus:border-wine/50 text-charcoal placeholder:text-charcoal/35"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="confirm"
+                  className="block text-xs font-medium text-charcoal/70 mb-1.5"
+                >
+                  Confirm password
+                </label>
+                <input
+                  id="confirm"
+                  type="password"
+                  value={confirm}
+                  onChange={(e) => setConfirm(e.target.value)}
+                  placeholder="Retype password"
+                  autoComplete="new-password"
+                  className="w-full h-11 px-4 text-sm bg-cream rounded-xl border border-warm-border focus:outline-none focus:border-wine/50 text-charcoal placeholder:text-charcoal/35"
+                />
+              </div>
+
+              {submitError && (
+                <p className="text-xs text-red-500 bg-red-50 px-3 py-2 rounded-lg">
+                  {submitError}
+                </p>
+              )}
+
+              <button
+                type="submit"
+                disabled={!password || !confirm || submitting}
+                className="w-full h-11 rounded-xl bg-wine text-cream text-sm font-medium hover:bg-wine/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                {submitting ? "Saving…" : "Set password"}
+              </button>
+
+              <p className="text-[10px] text-charcoal/40 text-center pt-1">
+                This invite link expires 48 hours after it was sent.
+              </p>
+            </form>
+          )}
+        </div>
+
+        <p className="text-center text-[10px] text-charcoal/35 mt-6 font-mono">
+          three agents · one inbox
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function AcceptInvitePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-cream flex items-center justify-center">
+          <div className="w-5 h-5 border-2 border-wine/30 border-t-wine rounded-full animate-spin" />
+        </div>
+      }
+    >
+      <AcceptInviteForm />
+    </Suspense>
+  );
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -24,6 +24,7 @@ export default function UsersPage() {
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
+  const [formMode, setFormMode] = useState<"create" | "invite">("invite");
   const [form, setForm] = useState({
     email: "",
     password: "",
@@ -31,6 +32,7 @@ export default function UsersPage() {
     accessibleClients: "",
   });
   const [formError, setFormError] = useState("");
+  const [formSuccess, setFormSuccess] = useState("");
   const [formLoading, setFormLoading] = useState(false);
   const [editUser, setEditUser] = useState<AdminUser | null>(null);
   const [editForm, setEditForm] = useState({
@@ -64,28 +66,44 @@ export default function UsersPage() {
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
     setFormError("");
+    setFormSuccess("");
     setFormLoading(true);
     try {
-      const res = await fetch("/api/admin/users", {
+      const endpoint =
+        formMode === "invite" ? "/api/admin/users/invite" : "/api/admin/users";
+      const payload: Record<string, unknown> = {
+        email: form.email,
+        isSuperAdmin: form.isSuperAdmin,
+        accessibleClients: form.accessibleClients
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+      };
+      if (formMode === "create") payload.password = form.password;
+
+      const res = await fetch(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          email: form.email,
-          password: form.password,
-          isSuperAdmin: form.isSuperAdmin,
-          accessibleClients: form.accessibleClients
-            .split(",")
-            .map((s) => s.trim())
-            .filter(Boolean),
-        }),
+        body: JSON.stringify(payload),
       });
+      const d = await res.json();
       if (!res.ok) {
-        const d = await res.json();
         setFormError(d.error ?? "Failed to create user");
         return;
       }
+
+      if (formMode === "invite") {
+        if (d.emailSent) {
+          setFormSuccess(`Invite sent to ${form.email}. Link expires in 48 hours.`);
+        } else {
+          setFormError(
+            `User created, but email failed to send (${d.emailError ?? "unknown"}). Check RESEND_API_KEY.`
+          );
+        }
+      }
+
       setForm({ email: "", password: "", isSuperAdmin: false, accessibleClients: "" });
-      setShowForm(false);
+      if (formMode === "create") setShowForm(false);
       await loadUsers();
     } finally {
       setFormLoading(false);
@@ -148,7 +166,12 @@ export default function UsersPage() {
           </span>
         </div>
         <button
-          onClick={() => setShowForm(true)}
+          onClick={() => {
+            setFormMode("invite");
+            setFormError("");
+            setFormSuccess("");
+            setShowForm(true);
+          }}
           className="text-xs bg-wine text-cream px-3 py-1.5 rounded-lg hover:bg-wine/90 transition-colors"
         >
           + New user
@@ -227,13 +250,48 @@ export default function UsersPage() {
         )}
       </div>
 
-      {/* Create user modal */}
+      {/* Create / invite user modal */}
       {showForm && (
         <div className="fixed inset-0 bg-charcoal/40 flex items-center justify-center z-50 p-4">
           <div className="bg-white rounded-[20px] border border-warm-border shadow-lg p-6 w-full max-w-sm">
             <h2 className="font-serif text-lg font-semibold text-charcoal mb-4">
               New admin user
             </h2>
+
+            {/* Mode toggle */}
+            <div className="flex gap-2 mb-5 p-1 bg-cream rounded-xl border border-warm-border">
+              <button
+                type="button"
+                onClick={() => {
+                  setFormMode("invite");
+                  setFormError("");
+                  setFormSuccess("");
+                }}
+                className={`flex-1 h-8 rounded-lg text-xs font-medium transition-colors ${
+                  formMode === "invite"
+                    ? "bg-wine text-cream"
+                    : "text-charcoal/60 hover:text-charcoal"
+                }`}
+              >
+                Invite via email
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setFormMode("create");
+                  setFormError("");
+                  setFormSuccess("");
+                }}
+                className={`flex-1 h-8 rounded-lg text-xs font-medium transition-colors ${
+                  formMode === "create"
+                    ? "bg-wine text-cream"
+                    : "text-charcoal/60 hover:text-charcoal"
+                }`}
+              >
+                Create with password
+              </button>
+            </div>
+
             <form onSubmit={handleCreate} className="space-y-4">
               <div>
                 <label className="block text-xs font-medium text-charcoal/70 mb-1">
@@ -248,18 +306,20 @@ export default function UsersPage() {
                   className="w-full h-10 px-3 text-sm bg-cream rounded-xl border border-warm-border focus:outline-none focus:border-wine/50"
                 />
               </div>
-              <div>
-                <label className="block text-xs font-medium text-charcoal/70 mb-1">
-                  Temporary password
-                </label>
-                <input
-                  type="password"
-                  value={form.password}
-                  onChange={(e) => setForm({ ...form, password: e.target.value })}
-                  placeholder="Strong password"
-                  className="w-full h-10 px-3 text-sm bg-cream rounded-xl border border-warm-border focus:outline-none focus:border-wine/50"
-                />
-              </div>
+              {formMode === "create" && (
+                <div>
+                  <label className="block text-xs font-medium text-charcoal/70 mb-1">
+                    Temporary password
+                  </label>
+                  <input
+                    type="password"
+                    value={form.password}
+                    onChange={(e) => setForm({ ...form, password: e.target.value })}
+                    placeholder="Strong password"
+                    className="w-full h-10 px-3 text-sm bg-cream rounded-xl border border-warm-border focus:outline-none focus:border-wine/50"
+                  />
+                </div>
+              )}
               <div>
                 <label className="block text-xs font-medium text-charcoal/70 mb-1">
                   Accessible clients (comma-separated, leave blank for super admin)
@@ -284,25 +344,50 @@ export default function UsersPage() {
                   Super admin (sees all clients)
                 </label>
               </div>
+              {formMode === "invite" && (
+                <p className="text-[11px] text-charcoal/50 leading-relaxed">
+                  An email from hello@opsbynoell.com will be sent with a link to set
+                  their password. The link expires in 48 hours.
+                </p>
+              )}
               {formError && (
                 <p className="text-xs text-red-500 bg-red-50 px-3 py-2 rounded-lg">
                   {formError}
                 </p>
               )}
+              {formSuccess && (
+                <p className="text-xs text-green-700 bg-green-50 px-3 py-2 rounded-lg">
+                  {formSuccess}
+                </p>
+              )}
               <div className="flex gap-3 pt-1">
                 <button
                   type="button"
-                  onClick={() => setShowForm(false)}
+                  onClick={() => {
+                    setShowForm(false);
+                    setFormSuccess("");
+                    setFormError("");
+                  }}
                   className="flex-1 h-10 rounded-xl border border-warm-border text-sm text-charcoal/60 hover:text-charcoal transition-colors"
                 >
-                  Cancel
+                  {formSuccess ? "Done" : "Cancel"}
                 </button>
                 <button
                   type="submit"
-                  disabled={!form.email || !form.password || formLoading}
+                  disabled={
+                    !form.email ||
+                    (formMode === "create" && !form.password) ||
+                    formLoading
+                  }
                   className="flex-1 h-10 rounded-xl bg-wine text-cream text-sm font-medium hover:bg-wine/90 disabled:opacity-40 transition-colors"
                 >
-                  {formLoading ? "Creating..." : "Create"}
+                  {formLoading
+                    ? formMode === "invite"
+                      ? "Sending…"
+                      : "Creating…"
+                    : formMode === "invite"
+                      ? "Send invite"
+                      : "Create"}
                 </button>
               </div>
             </form>

--- a/src/app/api/admin/accept-invite/route.ts
+++ b/src/app/api/admin/accept-invite/route.ts
@@ -1,0 +1,145 @@
+/**
+ * Public invite-acceptance endpoint (no login required).
+ *
+ *   GET  /api/admin/accept-invite?token=…   → validate + return email
+ *   POST /api/admin/accept-invite            → set password, mark used
+ *
+ * A token is valid if it exists, is not used, and has not expired.
+ * On successful POST the invite row's used_at is set and the admin
+ * user's password_hash is populated.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { sbSelect, sbUpdate } from "@/lib/agents/supabase";
+import { hashInviteToken } from "@/lib/admin-invite-token";
+import { hashPassword } from "@/lib/admin-password";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface InviteRow {
+  id: string;
+  user_id: string;
+  expires_at: string;
+  used_at: string | null;
+}
+
+interface UserRow {
+  id: string;
+  email: string;
+  password_hash: string | null;
+}
+
+async function lookupInvite(
+  token: string
+): Promise<
+  | { ok: true; invite: InviteRow; user: UserRow }
+  | { ok: false; status: number; error: string }
+> {
+  if (!token || typeof token !== "string") {
+    return { ok: false, status: 400, error: "Missing invite token." };
+  }
+
+  const tokenHash = await hashInviteToken(token);
+
+  let invite: InviteRow | null = null;
+  try {
+    const rows = await sbSelect<InviteRow>(
+      "admin_invite_tokens",
+      { token_hash: `eq.${tokenHash}` },
+      { limit: 1 }
+    );
+    invite = rows[0] ?? null;
+  } catch {
+    return { ok: false, status: 500, error: "Could not verify invite." };
+  }
+
+  if (!invite) {
+    return { ok: false, status: 400, error: "This invite link is invalid." };
+  }
+  if (invite.used_at) {
+    return {
+      ok: false,
+      status: 400,
+      error: "This invite link has already been used.",
+    };
+  }
+  if (new Date(invite.expires_at).getTime() <= Date.now()) {
+    return { ok: false, status: 400, error: "This invite link has expired." };
+  }
+
+  let user: UserRow | null = null;
+  try {
+    const rows = await sbSelect<UserRow>(
+      "admin_users",
+      { id: `eq.${invite.user_id}` },
+      { limit: 1 }
+    );
+    user = rows[0] ?? null;
+  } catch {
+    return { ok: false, status: 500, error: "Could not verify invite." };
+  }
+
+  if (!user) {
+    return { ok: false, status: 400, error: "This invite link is invalid." };
+  }
+
+  return { ok: true, invite, user };
+}
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const token = req.nextUrl.searchParams.get("token") ?? "";
+  const result = await lookupInvite(token);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+  return NextResponse.json({ ok: true, email: result.user.email });
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  let body: { token?: string; password?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid json" }, { status: 400 });
+  }
+
+  const token = body.token ?? "";
+  const password = body.password ?? "";
+  if (!password || password.length < 8) {
+    return NextResponse.json(
+      { error: "Password must be at least 8 characters." },
+      { status: 400 }
+    );
+  }
+
+  const result = await lookupInvite(token);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  const passwordHash = await hashPassword(password);
+
+  try {
+    await sbUpdate(
+      "admin_users",
+      { id: `eq.${result.user.id}` },
+      { password_hash: passwordHash }
+    );
+  } catch {
+    return NextResponse.json({ error: "Could not set password." }, { status: 500 });
+  }
+
+  try {
+    await sbUpdate(
+      "admin_invite_tokens",
+      { id: `eq.${result.invite.id}` },
+      { used_at: new Date().toISOString() }
+    );
+  } catch {
+    // Password was set but token wasn't marked used. The expires_at check
+    // will still retire the token within 48 hours.
+  }
+
+  return NextResponse.json({ ok: true, email: result.user.email });
+}

--- a/src/app/api/admin/users/invite/route.ts
+++ b/src/app/api/admin/users/invite/route.ts
@@ -1,0 +1,55 @@
+/**
+ * POST /api/admin/users/invite
+ *
+ * Super-admin only. Thin wrapper around handleAdminInvite.
+ *
+ * Body:
+ *   {
+ *     email: string,
+ *     isSuperAdmin?: boolean,
+ *     accessibleClients?: string[]
+ *   }
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { verifyToken, COOKIE_NAME } from "@/lib/admin-auth";
+import { handleAdminInvite } from "@/lib/admin-invite-handler";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function originOf(req: NextRequest): string {
+  const fromEnv = process.env.PUBLIC_SITE_URL;
+  if (fromEnv) return fromEnv.replace(/\/$/, "");
+  const fromHeader = req.headers.get("origin");
+  if (fromHeader) return fromHeader.replace(/\/$/, "");
+  return `${req.nextUrl.protocol}//${req.nextUrl.host}`;
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const cookie = req.cookies.get(COOKIE_NAME)?.value;
+  const auth = await verifyToken(cookie);
+
+  let body: {
+    email?: string;
+    isSuperAdmin?: boolean;
+    accessibleClients?: string[];
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid json" }, { status: 400 });
+  }
+
+  const origin = originOf(req);
+  const result = await handleAdminInvite({
+    callerIsSuperAdmin: !!auth?.isSuperAdmin,
+    email: body.email,
+    isSuperAdmin: body.isSuperAdmin,
+    accessibleClients: body.accessibleClients,
+    buildInviteUrl: (token) =>
+      `${origin}/admin/accept-invite?token=${encodeURIComponent(token)}`,
+  });
+
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/src/lib/admin-invite-email.ts
+++ b/src/lib/admin-invite-email.ts
@@ -1,0 +1,95 @@
+/**
+ * Invite email — sent by POST /api/admin/users/invite.
+ *
+ * Branded HTML (cream background, wine CTA, Playfair title). Falls soft
+ * when RESEND_API_KEY is unset so local/dev environments don't blow up
+ * the invite endpoint.
+ */
+
+import { Resend } from "resend";
+import { env } from "./agents/env";
+
+const resend = env.resendApiKey() ? new Resend(env.resendApiKey()!) : null;
+
+const CREAM = "#FAF5F0";
+const WINE = "#6A2C3E";
+const CHARCOAL = "#3D2430";
+const BORDER = "#E7DFD6";
+const MUTED = "#6b5b55";
+
+function renderHtml(inviteUrl: string, invitedEmail: string): string {
+  // Inline styles: email clients strip <style>. Playfair Display + Inter
+  // via Google Fonts with serif / sans-serif fallbacks.
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Welcome aboard — Ops by Noell</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet" />
+</head>
+<body style="margin:0;padding:0;background-color:${CREAM};font-family:Inter,Arial,sans-serif;color:${CHARCOAL};">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:${CREAM};">
+<tr><td align="center" style="padding:40px 16px;">
+<table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;background-color:#ffffff;border:1px solid ${BORDER};border-radius:20px;overflow:hidden;">
+<tr><td style="padding:40px 40px 8px 40px;">
+<p style="margin:0 0 12px 0;font-size:11px;letter-spacing:0.28em;text-transform:uppercase;color:${MUTED};font-family:Inter,Arial,sans-serif;">Ops by Noell</p>
+<h1 style="margin:0 0 16px 0;font-family:'Playfair Display',Georgia,serif;font-size:30px;font-weight:700;color:${CHARCOAL};line-height:1.2;">Welcome aboard</h1>
+<p style="margin:0 0 16px 0;font-size:15px;line-height:1.6;color:${CHARCOAL};">You've been invited to the <strong>${invitedEmail}</strong> admin account. Set your password to get started — it only takes a moment.</p>
+</td></tr>
+<tr><td align="left" style="padding:16px 40px 8px 40px;">
+<a href="${inviteUrl}" style="display:inline-block;background-color:${WINE};color:${CREAM};text-decoration:none;font-family:Inter,Arial,sans-serif;font-weight:600;font-size:14px;padding:14px 28px;border-radius:12px;">Set your password</a>
+</td></tr>
+<tr><td style="padding:16px 40px 8px 40px;">
+<p style="margin:0 0 8px 0;font-size:13px;line-height:1.6;color:${MUTED};">Or copy this link into your browser:</p>
+<p style="margin:0 0 20px 0;font-size:12px;line-height:1.5;color:${WINE};word-break:break-all;"><a href="${inviteUrl}" style="color:${WINE};text-decoration:underline;">${inviteUrl}</a></p>
+</td></tr>
+<tr><td style="padding:8px 40px 40px 40px;border-top:1px solid ${BORDER};">
+<p style="margin:16px 0 0 0;font-size:12px;line-height:1.5;color:${MUTED};">This link expires in 48 hours. If you weren't expecting this invite you can safely ignore it.</p>
+</td></tr>
+</table>
+<p style="margin:20px 0 0 0;font-size:11px;font-family:Inter,Arial,sans-serif;color:${MUTED};letter-spacing:0.12em;">hello@opsbynoell.com</p>
+</td></tr>
+</table>
+</body>
+</html>`;
+}
+
+function renderText(inviteUrl: string, invitedEmail: string): string {
+  return [
+    `Welcome aboard.`,
+    ``,
+    `You've been invited to the ${invitedEmail} admin account at Ops by Noell.`,
+    `Set your password using the link below — it expires in 48 hours.`,
+    ``,
+    inviteUrl,
+    ``,
+    `If you weren't expecting this invite you can safely ignore it.`,
+    `— hello@opsbynoell.com`,
+  ].join("\n");
+}
+
+export async function sendAdminInviteEmail(params: {
+  toEmail: string;
+  inviteUrl: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  if (!resend) {
+    console.warn("[admin-invite-email] Resend not configured — email skipped");
+    return { ok: false, error: "resend_not_configured" };
+  }
+
+  try {
+    await resend.emails.send({
+      from: env.resendFromEmail(),
+      to: params.toEmail,
+      subject: "Welcome aboard — set your Ops by Noell password",
+      html: renderHtml(params.inviteUrl, params.toEmail),
+      text: renderText(params.inviteUrl, params.toEmail),
+    });
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown";
+    console.error("[admin-invite-email] send failed:", message);
+    return { ok: false, error: message };
+  }
+}

--- a/src/lib/admin-invite-handler.test.ts
+++ b/src/lib/admin-invite-handler.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for handleAdminInvite().
+ *
+ * Covers:
+ *   1. 403 when the caller is not a super admin
+ *   2. Successful invite inserts a user, stores a token, sends email
+ *   3. 409 when the target email already has a password set
+ */
+
+import { strict as assert } from "node:assert";
+import { mock, test } from "node:test";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+type InsertCall = { table: string; row: Record<string, unknown> };
+type SelectCall = { table: string; params: Record<string, unknown> };
+
+const insertCalls: InsertCall[] = [];
+const selectCalls: SelectCall[] = [];
+const emailCalls: Array<{ toEmail: string; inviteUrl: string }> = [];
+
+// Overrideable return for sbSelect(admin_users, …).
+let existingUser: Record<string, unknown> | null = null;
+
+mock.module("./agents/supabase.ts", {
+  namedExports: {
+    sbSelect: async (table: string, params: Record<string, unknown>) => {
+      selectCalls.push({ table, params });
+      if (table === "admin_users" && existingUser) return [existingUser];
+      return [];
+    },
+    sbInsert: async (table: string, row: Record<string, unknown>) => {
+      insertCalls.push({ table, row });
+      if (table === "admin_users") return { id: "user-uuid-123", ...row };
+      return { id: `row-${insertCalls.length}`, ...row };
+    },
+    sbUpdate: async () => [],
+    sbUpsert: async () => ({}),
+  },
+});
+
+mock.module("./admin-invite-email.ts", {
+  namedExports: {
+    sendAdminInviteEmail: async (p: { toEmail: string; inviteUrl: string }) => {
+      emailCalls.push(p);
+      return { ok: true };
+    },
+  },
+});
+
+const { handleAdminInvite } = await import("./admin-invite-handler.ts");
+
+function resetMocks() {
+  insertCalls.length = 0;
+  selectCalls.length = 0;
+  emailCalls.length = 0;
+  existingUser = null;
+}
+
+const baseInput = {
+  email: "test@example.com",
+  isSuperAdmin: false,
+  accessibleClients: [] as string[],
+  buildInviteUrl: (t: string) => `https://example.com/admin/accept-invite?token=${t}`,
+};
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+test("returns 403 when caller is not super admin", async () => {
+  resetMocks();
+  const res = await handleAdminInvite({ ...baseInput, callerIsSuperAdmin: false });
+
+  assert.equal(res.status, 403);
+  assert.equal(res.body.error, "Forbidden");
+  assert.equal(insertCalls.length, 0);
+  assert.equal(emailCalls.length, 0);
+});
+
+test("invite creates user + token row and sends email", async () => {
+  resetMocks();
+  const res = await handleAdminInvite({
+    ...baseInput,
+    callerIsSuperAdmin: true,
+    email: "NEW.user@Example.com",
+    accessibleClients: ["santa"],
+  });
+
+  assert.equal(res.status, 201);
+  assert.equal(res.body.ok, true);
+  assert.equal(res.body.userId, "user-uuid-123");
+  assert.equal(res.body.emailSent, true);
+
+  // admin_users insert — email normalized, password_hash null
+  const userInsert = insertCalls.find((c) => c.table === "admin_users");
+  assert.ok(userInsert, "expected admin_users insert");
+  assert.equal(userInsert.row.email, "new.user@example.com");
+  assert.equal(userInsert.row.password_hash, null);
+  assert.equal(userInsert.row.is_super_admin, false);
+
+  // user_clients insert
+  const ucInsert = insertCalls.find((c) => c.table === "user_clients");
+  assert.ok(ucInsert, "expected user_clients insert");
+  assert.equal(ucInsert.row.user_id, "user-uuid-123");
+  assert.equal(ucInsert.row.client_id, "santa");
+
+  // admin_invite_tokens insert — stores hash, not plaintext
+  const tokenInsert = insertCalls.find((c) => c.table === "admin_invite_tokens");
+  assert.ok(tokenInsert, "expected admin_invite_tokens insert");
+  assert.equal(tokenInsert.row.user_id, "user-uuid-123");
+  assert.ok(typeof tokenInsert.row.token_hash === "string");
+  assert.equal((tokenInsert.row.token_hash as string).length, 64); // sha256 hex
+  const expiresAt = new Date(tokenInsert.row.expires_at as string).getTime();
+  const expectedMin = Date.now() + 47 * 60 * 60 * 1000;
+  const expectedMax = Date.now() + 49 * 60 * 60 * 1000;
+  assert.ok(
+    expiresAt >= expectedMin && expiresAt <= expectedMax,
+    `expires_at should be ~48h out, got ${new Date(expiresAt).toISOString()}`
+  );
+
+  // Email sent to the normalized address, URL contains a token
+  assert.equal(emailCalls.length, 1);
+  assert.equal(emailCalls[0].toEmail, "new.user@example.com");
+  assert.match(emailCalls[0].inviteUrl, /\/admin\/accept-invite\?token=/);
+});
+
+test("returns 409 when email already has a password set", async () => {
+  resetMocks();
+  existingUser = {
+    id: "existing-uuid",
+    email: "test@example.com",
+    password_hash: "pbkdf2:100000:SHA-256:aa:bb",
+    is_super_admin: false,
+  };
+
+  const res = await handleAdminInvite({ ...baseInput, callerIsSuperAdmin: true });
+
+  assert.equal(res.status, 409);
+  assert.equal(res.body.error, "Email already exists");
+  assert.equal(insertCalls.length, 0);
+  assert.equal(emailCalls.length, 0);
+});

--- a/src/lib/admin-invite-handler.ts
+++ b/src/lib/admin-invite-handler.ts
@@ -1,0 +1,136 @@
+/**
+ * Pure-logic handler for POST /api/admin/users/invite.
+ *
+ * Split out of the route so unit tests can exercise the flow without
+ * constructing a full NextRequest or booting the Supabase REST client.
+ *
+ *   route.ts: auth → parse JSON → build invite URL → call this handler
+ *   handler:  validate email → insert user → insert token → send email
+ */
+
+import { sbInsert, sbSelect } from "./agents/supabase";
+import {
+  generateInviteToken,
+  hashInviteToken,
+  INVITE_TTL_MS,
+} from "./admin-invite-token";
+import { sendAdminInviteEmail } from "./admin-invite-email";
+
+export interface InviteHandlerInput {
+  callerIsSuperAdmin: boolean;
+  email: string | undefined;
+  isSuperAdmin?: boolean;
+  accessibleClients?: string[];
+  /** Build the accept-invite URL from the plaintext token. */
+  buildInviteUrl: (token: string) => string;
+}
+
+export interface InviteHandlerResult {
+  status: number;
+  body: {
+    ok?: true;
+    userId?: string;
+    emailSent?: boolean;
+    emailError?: string;
+    error?: string;
+  };
+}
+
+interface AdminUserRow {
+  id: string;
+  email: string;
+  password_hash: string | null;
+  is_super_admin: boolean;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function handleAdminInvite(
+  input: InviteHandlerInput
+): Promise<InviteHandlerResult> {
+  if (!input.callerIsSuperAdmin) {
+    return { status: 403, body: { error: "Forbidden" } };
+  }
+
+  const email = input.email?.trim().toLowerCase();
+  if (!email || !EMAIL_RE.test(email)) {
+    return { status: 400, body: { error: "valid email required" } };
+  }
+
+  const isSuperAdmin = input.isSuperAdmin === true;
+  const accessibleClients = Array.isArray(input.accessibleClients)
+    ? input.accessibleClients.map((s) => String(s).trim()).filter(Boolean)
+    : [];
+
+  let existing: AdminUserRow | null = null;
+  try {
+    const rows = await sbSelect<AdminUserRow>(
+      "admin_users",
+      { email: `eq.${email}` },
+      { limit: 1 }
+    );
+    existing = rows[0] ?? null;
+  } catch {
+    return { status: 500, body: { error: "DB error" } };
+  }
+
+  if (existing && existing.password_hash) {
+    return { status: 409, body: { error: "Email already exists" } };
+  }
+
+  let userId: string;
+  if (existing) {
+    userId = existing.id;
+  } else {
+    try {
+      const created = await sbInsert<{ id: string }>("admin_users", {
+        email,
+        password_hash: null,
+        is_super_admin: isSuperAdmin,
+      });
+      userId = created.id;
+    } catch {
+      return { status: 500, body: { error: "Failed to create user" } };
+    }
+
+    if (!isSuperAdmin && accessibleClients.length > 0) {
+      try {
+        for (const clientId of accessibleClients) {
+          await sbInsert("user_clients", { user_id: userId, client_id: clientId });
+        }
+      } catch {
+        // Non-fatal
+      }
+    }
+  }
+
+  const token = generateInviteToken();
+  const tokenHash = await hashInviteToken(token);
+  const expiresAt = new Date(Date.now() + INVITE_TTL_MS).toISOString();
+
+  try {
+    await sbInsert("admin_invite_tokens", {
+      token_hash: tokenHash,
+      user_id: userId,
+      expires_at: expiresAt,
+    });
+  } catch {
+    return {
+      status: 500,
+      body: { error: "Failed to create invite token" },
+    };
+  }
+
+  const inviteUrl = input.buildInviteUrl(token);
+  const emailResult = await sendAdminInviteEmail({ toEmail: email, inviteUrl });
+
+  return {
+    status: 201,
+    body: {
+      ok: true,
+      userId,
+      emailSent: emailResult.ok,
+      emailError: emailResult.ok ? undefined : emailResult.error,
+    },
+  };
+}

--- a/src/lib/admin-invite-token.ts
+++ b/src/lib/admin-invite-token.ts
@@ -1,0 +1,34 @@
+/**
+ * Magic-link invite token helpers.
+ *
+ * Tokens are 32 random bytes encoded as base64url. The plaintext token
+ * is emailed to the invitee; only the SHA-256 hash is stored in the
+ * database, so a DB leak never exposes usable invite links.
+ *
+ * Uses the Web Crypto API so this file is safe to import from both
+ * Node.js routes and the Edge runtime.
+ */
+
+export const INVITE_TTL_MS = 48 * 60 * 60 * 1000; // 48 hours
+
+function toBase64url(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+/** Random 32-byte invite token, base64url encoded (43 chars). */
+export function generateInviteToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return toBase64url(bytes);
+}
+
+/** SHA-256 hash of the token, hex encoded. This is what we store. */
+export async function hashInviteToken(token: string): Promise<string> {
+  const data = new TextEncoder().encode(token);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,8 +4,12 @@ import { verifyToken, COOKIE_NAME } from "@/lib/admin-auth";
 export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
-  // Protect /admin/* but not /admin/login
-  if (pathname.startsWith("/admin") && !pathname.startsWith("/admin/login")) {
+  // Protect /admin/* but not /admin/login or /admin/accept-invite
+  if (
+    pathname.startsWith("/admin") &&
+    !pathname.startsWith("/admin/login") &&
+    !pathname.startsWith("/admin/accept-invite")
+  ) {
     const token = req.cookies.get(COOKIE_NAME)?.value;
     const payload = await verifyToken(token);
     if (!payload) {

--- a/supabase/migrations/0006_admin_invite_tokens.sql
+++ b/supabase/migrations/0006_admin_invite_tokens.sql
@@ -1,0 +1,42 @@
+-- ============================================================
+-- 0006_admin_invite_tokens.sql
+--
+-- Magic-link invite flow for admin users.
+--
+-- 1. Makes admin_users.password_hash nullable so an invited user
+--    can exist in the table before they set their own password.
+-- 2. Creates admin_invite_tokens to track unused / used invite
+--    links. We store the SHA-256 hash of the token (never the
+--    plaintext), same approach any password-reset flow should use.
+--
+-- Run AFTER: 0005_sms_alert_sessions.sql
+-- Idempotent — safe to re-run.
+-- ============================================================
+
+
+-- ============================================================
+-- 1. admin_users.password_hash → nullable
+-- ============================================================
+
+ALTER TABLE public.admin_users
+  ALTER COLUMN password_hash DROP NOT NULL;
+
+
+-- ============================================================
+-- 2. admin_invite_tokens
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.admin_invite_tokens (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  token_hash  text        NOT NULL,
+  user_id     uuid        NOT NULL REFERENCES public.admin_users(id) ON DELETE CASCADE,
+  expires_at  timestamptz NOT NULL,
+  used_at     timestamptz,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS admin_invite_tokens_token_hash_unique
+  ON public.admin_invite_tokens (token_hash);
+
+CREATE INDEX IF NOT EXISTS admin_invite_tokens_user_id_idx
+  ON public.admin_invite_tokens (user_id);


### PR DESCRIPTION
## Summary
Super admins can now invite new admin users by email. The invitee gets a branded Resend email from `hello@opsbynoell.com` with a 48-hour magic link, sets their own password on a public page, and logs in. No more shared passwords.

Extends the existing admin auth / `admin_users` / `/admin/users` UI — nothing rewritten.

## Migration
`supabase/migrations/0006_admin_invite_tokens.sql`
- Drops `NOT NULL` from `admin_users.password_hash` (invited users exist before they set a password)
- Creates `admin_invite_tokens (id, token_hash, user_id, expires_at, used_at, created_at)` with a unique index on `token_hash` and an FK → `admin_users(id) ON DELETE CASCADE`
- Stores the SHA-256 hash of the token, never the plaintext

## Endpoints
| Method | Path | Who | Purpose |
| --- | --- | --- | --- |
| POST | `/api/admin/users/invite` | Super admin | Creates user (or reuses an un-passworded one), generates token, emails invite link |
| GET | `/api/admin/accept-invite?token=…` | Public | Validates invite, returns invitee email for the UI |
| POST | `/api/admin/accept-invite` | Public | Sets password via PBKDF2, marks token `used_at` |

Errors are distinct and user-facing: "This invite link is invalid." / "…has already been used." / "…has expired."

## Pages
- `src/app/admin/accept-invite/page.tsx` — public, exempt from the auth proxy. Cream background, Playfair "Welcome aboard" title, wine CTA, 8-char-min + confirm password. Redirects to `/admin/login?invited=1` on success.
- `src/app/admin/users/page.tsx` — existing modal now has an **Invite via email** / **Create with password** toggle. Invite mode hides the password field.

## Email
`src/lib/admin-invite-email.ts` renders branded HTML: cream background (`#FAF5F0`), wine (`#6A2C3E`) CTA button, Playfair Display title, Inter body, 48-hour expiry disclaimer. From `hello@opsbynoell.com` via Resend (already wired up). Falls soft if `RESEND_API_KEY` is missing in dev.

## Tests
`src/lib/admin-invite-handler.test.ts` — all three pass under `npm test`:
1. Returns 403 when caller is not super admin
2. Successful invite → inserts `admin_users` row with `password_hash = null`, inserts `user_clients` rows, inserts `admin_invite_tokens` with a 64-char SHA-256 hash + ~48h `expires_at`, and calls `sendAdminInviteEmail` with the normalized email
3. Returns 409 when the target email already has a password set

## Manual test plan
- [ ] Sign in as super admin, open `/admin/users`, click **+ New user**
- [ ] In the modal, default is **Invite via email**. Enter `test@example.com`, leave password fields absent, submit
- [ ] Email arrives from `hello@opsbynoell.com` with subject "Welcome aboard — set your Ops by Noell password"
- [ ] Click the magic link → lands on `/admin/accept-invite` with "Set your password for test@example.com"
- [ ] Enter matching passwords (8+ chars), submit → redirected to `/admin/login?invited=1`
- [ ] Log in with `test@example.com` + the new password → admin inbox loads
- [ ] Try the same invite link again → "This invite link has already been used."
- [ ] Manually expire a token in Supabase (`UPDATE admin_invite_tokens SET expires_at = now() - interval '1 hour'`) and open the link → "This invite link has expired."
- [ ] Open `/admin/accept-invite?token=garbage` → "This invite link is invalid."
- [ ] Toggle to **Create with password** in the modal → existing password-based create flow still works

## Pre-merge checklist
- [ ] Apply `0006_admin_invite_tokens.sql` to Supabase
- [ ] Confirm `RESEND_API_KEY` and `RESEND_FROM_EMAIL` are set on Vercel (already required by the existing alert path)
- [ ] Optional: set `PUBLIC_SITE_URL` to `https://www.opsbynoell.com` so invite links don't depend on the request `Origin` header

https://claude.ai/code/session_01LjctKLaSYx38VbMqqGxz5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjctKLaSYx38VbMqqGxz5Q)_