### PR TITLE
fix(sms): make toNumber optional in inbound webhook

### DIFF
--- a/src/app/api/ghl/inbound-sms/route.ts
+++ b/src/app/api/ghl/inbound-sms/route.ts
@@ -61,7 +61,7 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   const payload = extractInboundPayload(rawBody);
   if (!payload) {
-    console.warn("[inbound-sms] Missing from/to phone in payload", rawBody);
+    console.warn("[inbound-sms] Missing from phone in payload", rawBody);
     return NextResponse.json(
       { ok: false, reason: "missing_phones" },
       { status: 200 }

--- a/src/lib/agents/inbound-sms-handler.ts
+++ b/src/lib/agents/inbound-sms-handler.ts
@@ -28,8 +28,13 @@ export interface SmsAlertSessionRow {
 export interface InboundSmsPayload {
   /** Sender phone (E.164) — the owner / alertSmsTo. Maps to from_phone in table. */
   fromPhone: string;
-  /** Receiving LC Phone (E.164) — the fromNumber used for outbound. Maps to to_phone. */
-  toPhone: string;
+  /**
+   * Receiving LC Phone (E.164) — the fromNumber used for outbound. Maps to to_phone.
+   * Optional: when absent the handler falls back to the most recent session row
+   * matching from_phone (ORDER BY created_at DESC LIMIT 1). Safe because one owner
+   * phone normally has only one active session at a time.
+   */
+  toPhone: string | null;
   /** The SMS body text sent by the owner. */
   messageText: string;
 }
@@ -103,15 +108,32 @@ export async function handleInboundSms(
   // ── 1. Look up session mapping ───────────────────────────────────────────
   let mapping: SmsAlertSessionRow | null = null;
   try {
-    const rows = await sbSelect<SmsAlertSessionRow>(
-      "sms_alert_sessions",
-      {
-        from_phone: `eq.${fromPhone}`,
-        to_phone:   `eq.${toPhone}`,
-      },
-      { limit: 1 }
-    );
-    mapping = rows[0] ?? null;
+    if (toPhone) {
+      // Exact match when toNumber is provided.
+      const rows = await sbSelect<SmsAlertSessionRow>(
+        "sms_alert_sessions",
+        {
+          from_phone: `eq.${fromPhone}`,
+          to_phone:   `eq.${toPhone}`,
+        },
+        { limit: 1 }
+      );
+      mapping = rows[0] ?? null;
+    } else {
+      // toNumber was absent from the webhook — fall back to most recent session
+      // for this sender. One owner phone normally has only one active session.
+      console.info(
+        `[inbound-sms] toPhone missing for ${fromPhone} — falling back to most recent session`
+      );
+      const rows = await sbSelect<SmsAlertSessionRow>(
+        "sms_alert_sessions",
+        {
+          from_phone: `eq.${fromPhone}`,
+        },
+        { limit: 1, order: "created_at.desc" }
+      );
+      mapping = rows[0] ?? null;
+    }
   } catch (err) {
     console.error("[inbound-sms] Supabase lookup failed:", err);
     return { ok: false, reason: "db_error" };
@@ -204,6 +226,6 @@ export function extractInboundPayload(
     (body.message as string | undefined) ??
     "";
 
-  if (!fromPhone || !toPhone) return null;
-  return { fromPhone, toPhone, messageText };
+  if (!fromPhone) return null;
+  return { fromPhone, toPhone: toPhone ?? null, messageText };
 }

--- a/src/lib/agents/inbound-sms-webhook.test.ts
+++ b/src/lib/agents/inbound-sms-webhook.test.ts
@@ -96,9 +96,17 @@ test("extractInboundPayload: LC workflow alias shape (from / to / message)", () 
   assert.equal(result.messageText, "Using aliases");
 });
 
-test("extractInboundPayload: returns null when phones are missing", () => {
+test("extractInboundPayload: returns null when fromPhone is missing", () => {
   assert.equal(extractInboundPayload({ body: "no phones" }), null);
-  assert.equal(extractInboundPayload({ phone: "+1..." }), null); // missing toPhone
+  assert.equal(extractInboundPayload({ toNumber: "+19499973915", body: "hi" }), null);
+});
+
+test("extractInboundPayload: returns payload with toPhone=null when toNumber is omitted", () => {
+  const result = extractInboundPayload({ phone: "+19497849726", body: "hello" });
+  assert.ok(result, "should return a payload even without toNumber");
+  assert.equal(result.fromPhone, "+19497849726");
+  assert.equal(result.toPhone, null);
+  assert.equal(result.messageText, "hello");
 });
 
 // ── Unit tests: resolveTables ──────────────────────────────────────────────
@@ -275,4 +283,30 @@ test("empty message body is stored as '(empty)'", async () => {
     messageText: "   ", // whitespace only
   });
   assert.equal(sbInsertCalls[0].row.content, "(empty)");
+});
+
+test("falls back to most recent row when toNumber is omitted", async () => {
+  resetCalls();
+  // toPhone is null — no toNumber in the webhook body
+  const result = await handleInboundSms({
+    fromPhone: "+19497849726",
+    toPhone: null,
+    messageText: "Calling without toNumber",
+  });
+
+  assert.equal(result.ok, true);
+  if (!result.ok) throw new Error("expected ok");
+  assert.equal(result.sessionId, "sess-uuid-001");
+
+  // Must query by from_phone only (no to_phone filter).
+  assert.equal(sbSelectCalls.length, 1);
+  const params = sbSelectCalls[0].params as Record<string, string>;
+  assert.equal(params.from_phone, "eq.+19497849726");
+  assert.equal(params.to_phone, undefined, "should NOT filter by to_phone when toPhone is null");
+
+  // Still inserts the human message and flips takeover.
+  assert.equal(sbInsertCalls.length, 1);
+  assert.equal(sbUpdateCalls.length, 1);
+  assert.equal(sbInsertCalls[0].row.content, "Calling without toNumber");
+  assert.equal(sbInsertCalls[0].row.author, "Nikki (human)");
 });


### PR DESCRIPTION
## Problem

The workflow builder does not expose a reliable `{{message.to_number}}` custom value, so the `toNumber` field in inbound webhook payloads is often blank or missing. When `toNumber` was missing the handler returned `missing_phones` and dropped the message silently.

## Solution

Make `toNumber` optional throughout the inbound SMS stack:

- **`extractInboundPayload`** — no longer requires `toPhone`; returns `{ toPhone: null }` when `toNumber` and `to` are both absent (only a missing `phone`/`from` is fatal)
- **`handleInboundSms`** — when `toPhone` is `null`, falls back to the most recent row in `sms_alert_sessions` WHERE `from_phone = <sender>`, ordered by `created_at DESC LIMIT 1`. When `toPhone` is present, the existing exact-match lookup is unchanged.

The fallback is safe: one owner phone normally has only one active session at a time, and even in a collision the most recent session is the correct one to route to.

## Files changed

| File | Change |
|------|--------|
| `src/lib/agents/inbound-sms-handler.ts` | `toPhone: string | null`; conditional lookup branch |
| `src/app/api/ghl/inbound-sms/route.ts` | Updated log message to reflect that only `fromPhone` is required |
| `src/lib/agents/inbound-sms-webhook.test.ts` | Updated existing null-phone test; added fallback integration test |

## Test plan

**Automated (15 tests, all pass):**
```
node --import ./scripts/test-loader.mjs --test ... src/lib/agents/inbound-sms-webhook.test.ts
# tests 15 / pass 15 / fail 0
```

New test: `"falls back to most recent row when toNumber is omitted"` — verifies the `sbSelect` call omits the `to_phone` filter and that the message is still routed correctly.

**Manual smoke test:**
1. Send a webhook with `{ "phone": "+1XXXXXXXXXX", "body": "test" }` (no `toNumber`) and `?secret=<secret>` — should return `{ ok: true, sessionId: "..." }` and post the reply into the visitor chat.
2. Send the same webhook **with** `toNumber` — should behave identically to before.
3. Send a webhook with neither `phone` nor `from` — should return `{ ok: false, reason: "missing_phones" }`.
