### PR TITLE
Hotfix: align book metadata with manual scheduling

### DIFF
--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -22,7 +22,7 @@ export const metadata = pageMetadata({
   path: "/book",
   title: "Book Your Free Audit",
   description:
-    "Pick a 30-minute audit slot on Nikki's calendar. No pitch, no pressure. A clear map of where leads are falling through and what a system could recover.",
+    "Request a focused Ops by Noell audit. Nikki schedules every audit personally and confirms a time by email or text.",
 });
 
 const steps = [


### PR DESCRIPTION
## Summary

Metadata-only hotfix for `/book`.

- Updates the `/book` meta description to match the manual/personal scheduling flow
- Does not change body copy, layout, routes, sitemap, schema architecture, pricing, or PCI copy

## Verification

Claude Code reported:
- Rendered `<meta name="description">` confirmed as the new copy
- `/book` grep clean for all four forbidden phrases
- Build, typecheck, and 30/30 tests green

This clean branch was created from current `main` and cherry-picked only the one metadata-line change from Claude commit `94cb1eb`.