### PR TITLE
feat(pci): Predictive Customer Intelligence v0 — schema, rules, internal dashboard

### DIFF
--- a/docs/PCI.md
+++ b/docs/PCI.md
@@ -1,0 +1,105 @@
+# Predictive Customer Intelligence (PCI) — internal
+
+Internal engineering reference. **Do not link from public pages or marketing copy.** The public site must never mention the backend stack, the intelligence/execution split, or any of the table/tag names in this document.
+
+PCI is the shared intelligence layer behind Noell Support, Noell Front Desk, and Noell Care. It normalizes operational events, derives durable signals, rolls them into weekly briefs, and hands execution off to the CRM/automation layer via a narrow seam.
+
+## Layering
+
+| Layer | Where it lives | Job |
+|---|---|---|
+| Agent event sources | `support_sessions`/`support_messages`, `front_desk_sessions`/`front_desk_messages`, `care_sessions`/`care_messages`, plus `appointments`, `reminders`, `review_requests`, `reactivation_campaigns`, `chatLeads` | Write their own domain tables. **PCI does not replace them.** |
+| Event stream | `customer_events` | Normalized operational history across all three agents. |
+| Signal store | `customer_signals` | "Who needs attention next, and why." |
+| Rollup | `weekly_intelligence_briefs` | Owner-facing weekly summary. |
+| Enrichment | `client_contacts` (new columns) | Cached follow-up context per contact. |
+| Handoff | `src/lib/pci/handoff.ts` | Applies tag/task/workflow in the execution layer. **v0 is a stub.** |
+
+## Schema
+
+See `supabase/migrations/0007_pci_v0_intelligence_layer.sql`. Key properties:
+
+- All three new tables have **RLS enabled** with an explicit deny-all policy for `anon` + `authenticated`. The agent backend uses the service-role key and bypasses RLS.
+- `customer_signals` has a **partial unique index** on `(client_id, contact_id, signal_type) WHERE status IN ('open', 'in_progress')`. Rule runs cannot create duplicate open signals for the same contact. A companion index covers the `contact_id IS NULL` case.
+- The 0007 migration also adds indexes for the unindexed foreign keys Supabase's performance advisor flagged: `appointments.session_id`, `front_desk_sessions.appointment_id`, `reminders.appointment_id`, `review_requests.appointment_id`.
+- Column shapes match the MVP spec in `/home/user/workspace/ops-by-noell-predictive-customer-intelligence-mvp-spec.md`.
+
+### Event types
+
+Authoritative list lives in `src/lib/pci/types.ts` under `CUSTOMER_EVENT_TYPES`. Adding a new type: update that tuple, then update the rule consumer that should read it.
+
+### Signal taxonomy
+
+| Signal type | Trigger (summary) | GHL tag |
+|---|---|---|
+| `warm_lead_risk` | Hot/warm lead with no booking past follow-up window | `pci_hot_lead` |
+| `missed_call_unbooked` | Missed-call session with no appointment past window | `pci_missed_call_unbooked` |
+| `no_show_risk` | Unconfirmed appointment inside the confirmation window | `pci_no_show_risk` |
+| `rebook_due` | Past usual rebook cadence with no future appointment | `pci_rebook_due` |
+| `lapsed_client` | Past client's reactivation threshold with no active campaign | `pci_lapsed_client` |
+| `review_ready` | Completed appointment, no negative signal, no request sent | `pci_review_ready` |
+| `owner_followup_needed` | Human takeover / VIP / negative sentiment / repeated cancel / high-value / low-confidence | `pci_owner_followup` |
+| `slow_week_fill` | Reserved for v2 vertical logic | `pci_slow_week_fill` |
+
+## Application-layer code
+
+```
+src/lib/pci/
+├── types.ts      — type enums and shared interfaces
+├── rules.ts      — pure deterministic signal rules (no I/O)
+├── rules.test.ts — rule-boundary tests (node --test)
+├── events.ts     — recordEvent() and event readers
+├── signals.ts    — upsertSignalFromDraft() with duplicate control
+└── handoff.ts    — typed seam to the execution layer (v0 is a stub)
+
+src/app/api/admin/pci/signals/route.ts — internal read API
+src/app/admin/pci/page.tsx             — internal dashboard
+```
+
+### Where rules should run
+
+- **Synchronous triggers**: call `recordEvent()` and (optionally) the matching rule function from the agent handler at the moment the underlying action happens (e.g. `evalMissedCallUnbooked` when a front-desk session is created with `trigger_type = 'missed_call'`).
+- **Scheduled scan**: a cron-driven route (see `src/app/api/cron/`) should re-run time-based rules (`warm_lead_risk`, `missed_call_unbooked` after the window elapses, `no_show_risk` inside 24h, `rebook_due`, `lapsed_client`, `review_ready` after completion). v0 ships the rule primitives; wiring the cron job is v1.
+- Rule functions are pure — the `now` field is injectable so scheduled runs can be tested against fixed clocks.
+
+### Duplicate control
+
+`upsertSignalFromDraft()` reads `openSignalFor()` first and short-circuits when an open row already exists. The partial unique index in the migration is a belt-and-suspenders — any race that slips past the read will be caught at insert time.
+
+## Handoff to the execution layer
+
+The intelligence layer (this codebase + Supabase) is authoritative for signal state. The execution layer (CRM/automation) applies tags, creates tasks, and drives SMS/email sequences.
+
+`src/lib/pci/handoff.ts` defines the typed seam. **v0 returns the tag that would be applied but does not call out.** v1 will wire this to `src/lib/agents/integrations/ghl.ts` using each client's stored `calendar_config` / `sms_config` to resolve the right destination.
+
+Signal lifecycle:
+
+1. Rule produces a `SignalDraft`.
+2. `upsertSignalFromDraft()` writes it (or returns the existing open row).
+3. A separate process calls `handoffToExecution(signal)` and records the `external_ref` back onto the signal.
+4. When execution resolves the situation (booking made, review left, contact reactivated), the corresponding event is written and the signal moves to `resolved`.
+
+## Internal dashboard
+
+`/admin/pci` lists open signals. It is protected by the same middleware as the rest of `/admin` (`src/proxy.ts`) and is scoped to the caller's `accessibleClients`. Super admins see everything and can filter by client. This is an **operator view**, not a client-facing product — PCI v3 is when a client-facing dashboard ships.
+
+## Public copy policy
+
+Public pages may describe what PCI *does* for the business (revenue leaks, warm leads going cold, unconfirmed appointments, rebooks, review moments, lapsed clients). They must **never** mention:
+
+- The database, Supabase, PostgREST, RLS, or any schema names
+- GHL / GoHighLevel / CRM backend / automation stack / white-label platform
+- "Machine learning" or "guaranteed prediction"
+- Clinical / medical risk scoring, diagnosis, patient analytics, or HIPAA decisioning
+
+Framing must stay operational: booking behavior, follow-up timing, confirmation, rebooking cadence, review timing, communication.
+
+## Production deploy — still needs approval
+
+The `0007_pci_v0_intelligence_layer.sql` migration is **not yet applied** to the production Supabase project (`clipzfkbzupjctherijz`). It is idempotent and the commented rollback at the bottom is the reverse path, but applying it needs an explicit deploy window. The pre-existing RLS-without-policy advisories on `clients`, the three session/message pairs, `client_contacts`, `appointments`, `reminders`, `review_requests`, `reactivation_campaigns`, `chatLeads`, and admin tables are **out of scope for this PR** — they should be addressed before PCI becomes production-critical, but they predate this work.
+
+## v1 / v2 / v3 — what's deferred
+
+- **v1**: cron wiring for scheduled rule scans; real GHL handoff in `handoff.ts`; `weekly_intelligence_briefs` generator; owner notifications for urgent signals.
+- **v2**: vertical-specific rule modules (massage rebook cadence, med spa consult follow-through, dental recall/hygiene, salon rebooking, HVAC urgency).
+- **v3**: client-facing dashboard, cross-account benchmarks, service-level opportunity scoring, exportable briefs.

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -161,6 +161,12 @@ export default function AdminInbox() {
                   Users
                 </a>
               )}
+              <a
+                href="/admin/pci"
+                className="text-xs text-charcoal/40 hover:text-charcoal transition-colors"
+              >
+                Intelligence
+              </a>
             </div>
           )}
           <button

--- a/src/app/admin/pci/page.tsx
+++ b/src/app/admin/pci/page.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+/**
+ * Internal PCI dashboard — open signals by severity.
+ *
+ * Protected by middleware (src/proxy.ts) like the rest of /admin.
+ * This is an internal operator view only. Do not link to it from
+ * public navigation.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+type SignalSeverity = "low" | "medium" | "high" | "urgent";
+type SignalStatus = "open" | "in_progress" | "resolved" | "dismissed" | "expired";
+
+interface Signal {
+  id: string;
+  client_id: string;
+  contact_id: string | null;
+  signal_type: string;
+  severity: SignalSeverity;
+  confidence: number;
+  status: SignalStatus;
+  reason: string;
+  recommended_action: string;
+  estimated_value: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface MeResponse {
+  authenticated: boolean;
+  email?: string;
+  isSuperAdmin?: boolean;
+  accessibleClients?: string[];
+}
+
+const SIGNAL_TYPES = [
+  "warm_lead_risk",
+  "missed_call_unbooked",
+  "no_show_risk",
+  "rebook_due",
+  "lapsed_client",
+  "review_ready",
+  "owner_followup_needed",
+  "slow_week_fill",
+] as const;
+
+type SignalTypeFilter = "all" | (typeof SIGNAL_TYPES)[number];
+
+const SEVERITY_ORDER: Record<SignalSeverity, number> = {
+  urgent: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+const SEVERITY_COLORS: Record<SignalSeverity, string> = {
+  urgent: "bg-red-100 text-red-700",
+  high: "bg-orange-100 text-orange-700",
+  medium: "bg-amber-100 text-amber-700",
+  low: "bg-charcoal/10 text-charcoal/60",
+};
+
+function relativeTime(ts: string): string {
+  const diff = Date.now() - new Date(ts).getTime();
+  const m = Math.floor(diff / 60000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+function prettyType(t: string): string {
+  return t.replaceAll("_", " ");
+}
+
+export default function PciDashboard() {
+  const router = useRouter();
+  const [signals, setSignals] = useState<Signal[]>([]);
+  const [typeFilter, setTypeFilter] = useState<SignalTypeFilter>("all");
+  const [clientFilter, setClientFilter] = useState<string>("all");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [me, setMe] = useState<MeResponse | null>(null);
+
+  useEffect(() => {
+    fetch("/api/admin/me")
+      .then((r) => r.json())
+      .then((d: MeResponse) => {
+        if (!d.authenticated) router.replace("/admin/login");
+        else setMe(d);
+      })
+      .catch(() => router.replace("/admin/login"));
+  }, [router]);
+
+  const fetchSignals = useCallback(async () => {
+    if (!me) return;
+    try {
+      const params = new URLSearchParams();
+      if (typeFilter !== "all") params.set("type", typeFilter);
+      if (me.isSuperAdmin && clientFilter !== "all") {
+        params.set("clientId", clientFilter);
+      }
+      const url = `/api/admin/pci/signals${params.size ? "?" + params.toString() : ""}`;
+      const res = await fetch(url);
+      if (res.status === 401) {
+        router.replace("/admin/login");
+        return;
+      }
+      const data = await res.json();
+      if (data.signals) {
+        const sorted = [...(data.signals as Signal[])].sort(
+          (a, b) =>
+            SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] ||
+            new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+        );
+        setSignals(sorted);
+      }
+      setError("");
+    } catch {
+      setError("Failed to load signals");
+    } finally {
+      setLoading(false);
+    }
+  }, [typeFilter, clientFilter, me, router]);
+
+  useEffect(() => {
+    if (!me) return;
+    fetchSignals();
+    const interval = setInterval(fetchSignals, 10_000);
+    return () => clearInterval(interval);
+  }, [fetchSignals, me]);
+
+  const clientIds = me?.isSuperAdmin
+    ? Array.from(new Set(signals.map((s) => s.client_id))).sort()
+    : [];
+
+  const bySeverity = signals.reduce<Record<SignalSeverity, number>>(
+    (acc, s) => {
+      acc[s.severity] = (acc[s.severity] ?? 0) + 1;
+      return acc;
+    },
+    { urgent: 0, high: 0, medium: 0, low: 0 }
+  );
+
+  return (
+    <div className="flex flex-col h-screen">
+      <header className="bg-white border-b border-warm-border px-6 py-3 flex items-center justify-between shrink-0">
+        <div className="flex items-center gap-3">
+          <span className="font-serif text-lg font-semibold text-charcoal">
+            Ops by Noell
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-widest text-charcoal/40">
+            Intelligence · Open signals
+          </span>
+        </div>
+        <div className="flex items-center gap-4">
+          <a
+            href="/admin"
+            className="text-xs text-charcoal/50 hover:text-charcoal transition-colors"
+          >
+            ← Inbox
+          </a>
+          {me?.email && (
+            <span className="text-xs text-charcoal/50">{me.email}</span>
+          )}
+        </div>
+      </header>
+
+      <div className="bg-white border-b border-warm-border px-6 py-3 flex items-center justify-between shrink-0 gap-4">
+        <div className="flex gap-4 text-xs">
+          {(["urgent", "high", "medium", "low"] as SignalSeverity[]).map((sev) => (
+            <div key={sev} className="flex items-center gap-1.5">
+              <span
+                className={`px-1.5 py-0.5 rounded-full text-[10px] font-mono uppercase ${SEVERITY_COLORS[sev]}`}
+              >
+                {sev}
+              </span>
+              <span className="text-charcoal/60">{bySeverity[sev]}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value as SignalTypeFilter)}
+            className="text-xs bg-cream border border-warm-border rounded-lg px-2 py-1.5 text-charcoal focus:outline-none focus:border-wine/50"
+          >
+            <option value="all">All types</option>
+            {SIGNAL_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {prettyType(t)}
+              </option>
+            ))}
+          </select>
+
+          {me?.isSuperAdmin && clientIds.length > 0 && (
+            <select
+              value={clientFilter}
+              onChange={(e) => setClientFilter(e.target.value)}
+              className="text-xs bg-cream border border-warm-border rounded-lg px-2 py-1.5 text-charcoal focus:outline-none focus:border-wine/50"
+            >
+              <option value="all">All clients</option>
+              {clientIds.map((id) => (
+                <option key={id} value={id}>
+                  {id}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <div className="flex items-center justify-center h-32">
+            <div className="w-5 h-5 border-2 border-wine/30 border-t-wine rounded-full animate-spin" />
+          </div>
+        ) : error ? (
+          <p className="text-center text-sm text-red-500 py-8">{error}</p>
+        ) : signals.length === 0 ? (
+          <div className="text-center py-16">
+            <p className="text-sm text-charcoal/50">No open signals.</p>
+            <p className="text-xs text-charcoal/35 mt-1">
+              Signals appear here as the intelligence layer generates them.
+            </p>
+          </div>
+        ) : (
+          <div>
+            {signals.map((s) => (
+              <div
+                key={s.id}
+                className="w-full text-left px-6 py-4 border-b border-warm-border hover:bg-cream/60 transition-colors"
+              >
+                <div className="flex items-center justify-between gap-2 mb-1">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span
+                      className={`shrink-0 text-[10px] font-mono uppercase tracking-wider px-1.5 py-0.5 rounded-full ${SEVERITY_COLORS[s.severity]}`}
+                    >
+                      {s.severity}
+                    </span>
+                    <span className="font-medium text-sm text-charcoal truncate">
+                      {prettyType(s.signal_type)}
+                    </span>
+                    {me?.isSuperAdmin && (
+                      <span className="shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded-full bg-charcoal/5 text-charcoal/50">
+                        {s.client_id}
+                      </span>
+                    )}
+                    <span className="shrink-0 text-[10px] font-mono text-charcoal/35">
+                      conf {(s.confidence * 100).toFixed(0)}%
+                    </span>
+                  </div>
+                  <span className="shrink-0 text-[10px] text-charcoal/40">
+                    {relativeTime(s.created_at)}
+                  </span>
+                </div>
+
+                <p className="text-xs text-charcoal/70 mb-1">{s.reason}</p>
+                <p className="text-xs text-charcoal/50">
+                  <span className="text-charcoal/35">→ </span>
+                  {s.recommended_action}
+                  {s.estimated_value !== null && (
+                    <span className="ml-2 text-charcoal/35">
+                      (est. ${s.estimated_value.toFixed(0)})
+                    </span>
+                  )}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/pci/signals/route.ts
+++ b/src/app/api/admin/pci/signals/route.ts
@@ -55,8 +55,9 @@ export async function GET(req: NextRequest): Promise<Response> {
     const signals = await listOpenSignals({ client_ids, signal_type, limit });
     return NextResponse.json({ signals });
   } catch (e) {
+    console.error("[admin/pci/signals] list failed:", e);
     return NextResponse.json(
-      { error: (e as Error).message },
+      { error: "Failed to load signals." },
       { status: 500 }
     );
   }

--- a/src/app/api/admin/pci/signals/route.ts
+++ b/src/app/api/admin/pci/signals/route.ts
@@ -1,0 +1,63 @@
+/**
+ * GET /api/admin/pci/signals
+ *
+ * Returns open/in-progress PCI signals scoped to the caller's
+ * accessible clients (super admins see all).
+ *
+ * Internal only — the intelligence layer is not exposed to public site
+ * copy or to unauthenticated requests. See docs/PCI.md.
+ *
+ * Query params:
+ *   ?type=<signal_type>    optional filter
+ *   ?clientId=<id>         super admin only
+ *   ?limit=<n>             default 200
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { verifyToken, COOKIE_NAME } from "@/lib/admin-auth";
+import { listOpenSignals } from "@/lib/pci/signals";
+import { SIGNAL_TYPES, type SignalType } from "@/lib/pci/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const token = req.cookies.get(COOKIE_NAME)?.value;
+  const payload = await verifyToken(token);
+  if (!payload) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const url = req.nextUrl;
+  const typeParam = url.searchParams.get("type");
+  const signal_type =
+    typeParam && (SIGNAL_TYPES as readonly string[]).includes(typeParam)
+      ? (typeParam as SignalType)
+      : undefined;
+
+  const clientIdParam = url.searchParams.get("clientId");
+  const limitRaw = url.searchParams.get("limit");
+  const limit = limitRaw ? Math.min(Math.max(parseInt(limitRaw, 10) || 0, 1), 500) : 200;
+
+  // Same scoping rule as /api/admin/sessions:
+  //   - super admin + no clientId → null (no filter)
+  //   - super admin + clientId    → single-element filter
+  //   - non-super-admin           → always scoped to accessibleClients
+  let client_ids: string[] | null;
+  if (payload.isSuperAdmin) {
+    client_ids = clientIdParam ? [clientIdParam] : null;
+  } else {
+    client_ids = payload.accessibleClients;
+  }
+
+  try {
+    const signals = await listOpenSignals({ client_ids, signal_type, limit });
+    return NextResponse.json({ signals });
+  } catch (e) {
+    return NextResponse.json(
+      { error: (e as Error).message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/pci/events.ts
+++ b/src/lib/pci/events.ts
@@ -1,0 +1,72 @@
+/**
+ * PCI v0 — event stream helpers.
+ *
+ * `recordEvent()` is the single entry point the agent backend should
+ * use to normalize an operational action into the PCI stream. The
+ * three agent handlers call this alongside their existing writes.
+ *
+ * Intentionally tolerant: failure to record an event must not break
+ * the agent's primary flow. Callers should `await` but wrap in a
+ * try/catch or fire-and-forget pattern as appropriate.
+ */
+
+import { sbInsert, sbSelect } from "@/lib/agents/supabase";
+import type { AgentSource, CustomerEvent, CustomerEventType } from "./types";
+
+const TABLE = "customer_events";
+
+export interface RecordEventArgs {
+  client_id: string;
+  event_type: CustomerEventType;
+  event_source: string;
+  agent_source?: AgentSource | null;
+  contact_id?: string | null;
+  session_id?: string | null;
+  appointment_id?: string | null;
+  conversation_message_id?: string | null;
+  service_interest?: string | null;
+  channel?: string | null;
+  occurred_at?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export async function recordEvent(
+  args: RecordEventArgs
+): Promise<CustomerEvent> {
+  return sbInsert<CustomerEvent>(TABLE, {
+    client_id: args.client_id,
+    contact_id: args.contact_id ?? null,
+    event_type: args.event_type,
+    event_source: args.event_source,
+    agent_source: args.agent_source ?? null,
+    session_id: args.session_id ?? null,
+    appointment_id: args.appointment_id ?? null,
+    conversation_message_id: args.conversation_message_id ?? null,
+    service_interest: args.service_interest ?? null,
+    channel: args.channel ?? null,
+    occurred_at: args.occurred_at ?? new Date().toISOString(),
+    metadata: args.metadata ?? {},
+  });
+}
+
+export async function recentEventsForContact(
+  contact_id: string,
+  limit = 50
+): Promise<CustomerEvent[]> {
+  return sbSelect<CustomerEvent>(
+    TABLE,
+    { contact_id: `eq.${contact_id}` },
+    { order: "occurred_at.desc", limit }
+  );
+}
+
+export async function recentEventsForClient(
+  client_id: string,
+  limit = 100
+): Promise<CustomerEvent[]> {
+  return sbSelect<CustomerEvent>(
+    TABLE,
+    { client_id: `eq.${client_id}` },
+    { order: "occurred_at.desc", limit }
+  );
+}

--- a/src/lib/pci/handoff.ts
+++ b/src/lib/pci/handoff.ts
@@ -1,0 +1,42 @@
+/**
+ * PCI v0 — execution handoff interface.
+ *
+ * The intelligence layer (Supabase) creates and resolves signals.
+ * The execution layer (GHL) applies tags, creates tasks, and drives
+ * SMS/email sequences. This file is the seam between them.
+ *
+ * v0 intentionally ships this as a typed no-op interface. v1 wires
+ * the GHL API calls. Keeping the shape defined now prevents rule
+ * code from accidentally reaching into GHL primitives.
+ */
+
+import type { CustomerSignal } from "./types";
+import { SIGNAL_GHL_TAG } from "./types";
+
+export interface HandoffResult {
+  ok: boolean;
+  /** Matches the enum in the SIGNAL_GHL_TAG table in types.ts. */
+  tag_applied: string;
+  /** Opaque execution-side identifier once v1 is implemented. */
+  external_ref?: string;
+  error?: string;
+}
+
+/**
+ * v0 stub: returns the tag that WOULD be applied and logs the signal.
+ * Rule runners may call this during backfill/dry-run to verify
+ * downstream routing without actually touching GHL.
+ *
+ * TODO(v1): wire this to src/lib/agents/integrations/ghl.ts using
+ * `clients.calendar_config` / `clients.sms_config` to resolve the
+ * right GHL location, then POST tag + task per signal_type.
+ */
+export async function handoffToExecution(
+  signal: CustomerSignal
+): Promise<HandoffResult> {
+  const tag = SIGNAL_GHL_TAG[signal.signal_type];
+  return {
+    ok: true,
+    tag_applied: tag,
+  };
+}

--- a/src/lib/pci/rules.test.ts
+++ b/src/lib/pci/rules.test.ts
@@ -1,0 +1,294 @@
+/**
+ * PCI v0 signal-rule unit tests.
+ *
+ * Pure functions, no mocks required. The goal is to pin the rule
+ * boundaries so a future edit that silently changes firing behavior
+ * trips a test.
+ */
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import {
+  PCI_DEFAULTS,
+  evalLapsedClient,
+  evalMissedCallUnbooked,
+  evalNoShowRisk,
+  evalOwnerFollowup,
+  evalRebookDue,
+  evalReviewReady,
+  evalWarmLeadRisk,
+} from "./rules";
+
+const NOW = new Date("2026-04-24T12:00:00Z");
+
+function hoursAgo(h: number): string {
+  return new Date(NOW.getTime() - h * 60 * 60 * 1000).toISOString();
+}
+function daysAgo(d: number): string {
+  return new Date(NOW.getTime() - d * 24 * 60 * 60 * 1000).toISOString();
+}
+function hoursFromNow(h: number): string {
+  return new Date(NOW.getTime() + h * 60 * 60 * 1000).toISOString();
+}
+
+// ──────────────────────────────────────────────────────────────────
+// warm_lead_risk
+// ──────────────────────────────────────────────────────────────────
+
+test("warm_lead_risk: hot lead past follow-up window fires as high severity", () => {
+  const draft = evalWarmLeadRisk({
+    client_id: "c1",
+    contact_id: "contact-1",
+    session_id: "sess-1",
+    agent_source: "support",
+    intent: "hot",
+    started_at: hoursAgo(PCI_DEFAULTS.warmLeadFollowupHours + 1),
+    appointment_booked: false,
+    now: NOW,
+  });
+  assert.ok(draft);
+  assert.equal(draft.signal_type, "warm_lead_risk");
+  assert.equal(draft.severity, "high");
+  assert.equal(draft.source_table, "support_sessions");
+});
+
+test("warm_lead_risk: warm lead still inside window does not fire", () => {
+  const draft = evalWarmLeadRisk({
+    client_id: "c1",
+    contact_id: null,
+    session_id: "sess-1",
+    agent_source: "front_desk",
+    intent: "warm",
+    started_at: hoursAgo(1),
+    appointment_booked: false,
+    now: NOW,
+  });
+  assert.equal(draft, null);
+});
+
+test("warm_lead_risk: skipped when an appointment was booked", () => {
+  const draft = evalWarmLeadRisk({
+    client_id: "c1",
+    contact_id: null,
+    session_id: "sess-1",
+    agent_source: "support",
+    intent: "hot",
+    started_at: hoursAgo(48),
+    appointment_booked: true,
+    now: NOW,
+  });
+  assert.equal(draft, null);
+});
+
+// ──────────────────────────────────────────────────────────────────
+// missed_call_unbooked
+// ──────────────────────────────────────────────────────────────────
+
+test("missed_call_unbooked: fires when no linked appointment past window", () => {
+  const draft = evalMissedCallUnbooked({
+    client_id: "c1",
+    contact_id: null,
+    session_id: "s1",
+    trigger_type: "missed_call",
+    has_linked_appointment: false,
+    started_at: hoursAgo(PCI_DEFAULTS.missedCallUnbookedHours + 0.5),
+    now: NOW,
+  });
+  assert.ok(draft);
+  assert.equal(draft.signal_type, "missed_call_unbooked");
+  assert.equal(draft.severity, "high");
+});
+
+test("missed_call_unbooked: skipped when session has an appointment", () => {
+  const draft = evalMissedCallUnbooked({
+    client_id: "c1",
+    contact_id: null,
+    session_id: "s1",
+    trigger_type: "missed_call",
+    has_linked_appointment: true,
+    started_at: hoursAgo(24),
+    now: NOW,
+  });
+  assert.equal(draft, null);
+});
+
+test("missed_call_unbooked: ignores non-missed-call triggers", () => {
+  const draft = evalMissedCallUnbooked({
+    client_id: "c1",
+    contact_id: null,
+    session_id: "s1",
+    trigger_type: "inbound_text",
+    has_linked_appointment: false,
+    started_at: hoursAgo(24),
+    now: NOW,
+  });
+  assert.equal(draft, null);
+});
+
+// ──────────────────────────────────────────────────────────────────
+// no_show_risk
+// ──────────────────────────────────────────────────────────────────
+
+test("no_show_risk: unconfirmed high-value appointment inside window is urgent", () => {
+  const draft = evalNoShowRisk({
+    client_id: "c1",
+    contact_id: "contact-2",
+    appointment_id: "appt-1",
+    status: "scheduled",
+    scheduled_at: hoursFromNow(6),
+    confirmation_received: false,
+    reminder_sent: false,
+    service_value_usd: 400,
+    now: NOW,
+  });
+  assert.ok(draft);
+  assert.equal(draft.severity, "urgent");
+});
+
+test("no_show_risk: skipped when confirmation received", () => {
+  const draft = evalNoShowRisk({
+    client_id: "c1",
+    contact_id: "contact-2",
+    appointment_id: "appt-1",
+    status: "scheduled",
+    scheduled_at: hoursFromNow(6),
+    confirmation_received: true,
+    reminder_sent: true,
+    now: NOW,
+  });
+  assert.equal(draft, null);
+});
+
+test("no_show_risk: skipped when appointment is already past", () => {
+  const draft = evalNoShowRisk({
+    client_id: "c1",
+    contact_id: "contact-2",
+    appointment_id: "appt-1",
+    status: "scheduled",
+    scheduled_at: hoursAgo(1),
+    confirmation_received: false,
+    reminder_sent: false,
+    now: NOW,
+  });
+  assert.equal(draft, null);
+});
+
+// ──────────────────────────────────────────────────────────────────
+// rebook_due
+// ──────────────────────────────────────────────────────────────────
+
+test("rebook_due: past cadence with no future appt fires", () => {
+  const draft = evalRebookDue({
+    client_id: "c1",
+    contact_id: "contact-3",
+    last_visit_at: daysAgo(50),
+    usual_rebook_cadence_days: 30,
+    future_appointment_exists: false,
+    now: NOW,
+  });
+  assert.ok(draft);
+  assert.equal(draft.signal_type, "rebook_due");
+  assert.equal(draft.severity, "high");
+});
+
+test("rebook_due: skipped when future appointment exists", () => {
+  const draft = evalRebookDue({
+    client_id: "c1",
+    contact_id: "contact-3",
+    last_visit_at: daysAgo(50),
+    usual_rebook_cadence_days: 30,
+    future_appointment_exists: true,
+    now: NOW,
+  });
+  assert.equal(draft, null);
+});
+
+// ──────────────────────────────────────────────────────────────────
+// lapsed_client
+// ──────────────────────────────────────────────────────────────────
+
+test("lapsed_client: past threshold fires at medium severity", () => {
+  const draft = evalLapsedClient({
+    client_id: "c1",
+    contact_id: "contact-4",
+    last_visit_at: daysAgo(120),
+    reactivation_threshold_days: 60,
+    in_active_reactivation: false,
+    now: NOW,
+  });
+  assert.ok(draft);
+  assert.equal(draft.severity, "medium");
+});
+
+test("lapsed_client: skipped when reactivation already active", () => {
+  const draft = evalLapsedClient({
+    client_id: "c1",
+    contact_id: "contact-4",
+    last_visit_at: daysAgo(120),
+    reactivation_threshold_days: 60,
+    in_active_reactivation: true,
+    now: NOW,
+  });
+  assert.equal(draft, null);
+});
+
+// ──────────────────────────────────────────────────────────────────
+// review_ready
+// ──────────────────────────────────────────────────────────────────
+
+test("review_ready: completed appointment with no negative signal fires", () => {
+  const draft = evalReviewReady({
+    client_id: "c1",
+    contact_id: "contact-5",
+    appointment_id: "appt-2",
+    completed_at: daysAgo(2),
+    has_negative_signal: false,
+    review_already_sent: false,
+    now: NOW,
+  });
+  assert.ok(draft);
+  assert.equal(draft.signal_type, "review_ready");
+});
+
+test("review_ready: skipped when negative signal present", () => {
+  const draft = evalReviewReady({
+    client_id: "c1",
+    contact_id: "contact-5",
+    appointment_id: "appt-2",
+    completed_at: daysAgo(2),
+    has_negative_signal: true,
+    review_already_sent: false,
+    now: NOW,
+  });
+  assert.equal(draft, null);
+});
+
+test("review_ready: skipped past the review window", () => {
+  const draft = evalReviewReady({
+    client_id: "c1",
+    contact_id: "contact-5",
+    appointment_id: "appt-2",
+    completed_at: daysAgo(PCI_DEFAULTS.reviewReadyWindowDays + 1),
+    has_negative_signal: false,
+    review_already_sent: false,
+    now: NOW,
+  });
+  assert.equal(draft, null);
+});
+
+// ──────────────────────────────────────────────────────────────────
+// owner_followup_needed
+// ──────────────────────────────────────────────────────────────────
+
+test("owner_followup_needed: negative sentiment produces urgent signal", () => {
+  const draft = evalOwnerFollowup({
+    client_id: "c1",
+    contact_id: "contact-6",
+    session_id: "s-9",
+    reason: "negative_sentiment",
+    context: "Visitor threatened to dispute charge",
+  });
+  assert.equal(draft.severity, "urgent");
+  assert.equal(draft.signal_type, "owner_followup_needed");
+});

--- a/src/lib/pci/rules.ts
+++ b/src/lib/pci/rules.ts
@@ -1,0 +1,361 @@
+/**
+ * PCI v0 signal rules — deterministic, pure functions.
+ *
+ * Each rule takes the minimum inputs it needs and returns either a
+ * SignalDraft or null. These are side-effect free; persistence is
+ * handled separately in src/lib/pci/signals.ts so these functions stay
+ * trivially testable.
+ *
+ * Rules reflect the spec in
+ * /home/user/workspace/ops-by-noell-predictive-customer-intelligence-mvp-spec.md
+ * and the PCI v0 schema in supabase/migrations/0007_pci_v0_intelligence_layer.sql.
+ */
+
+import type {
+  AgentSource,
+  SignalDraft,
+  SignalSeverity,
+} from "./types";
+
+// ------------------------------------------------------------------
+// Thresholds
+// ------------------------------------------------------------------
+// Tunable per deployment; keep as named constants so the intent is
+// obvious in rule bodies. Any change here should be reflected in docs.
+
+export const PCI_DEFAULTS = {
+  /** Warm lead with no appointment booked after this window → at-risk. */
+  warmLeadFollowupHours: 24,
+  /** Missed call with no appointment booked after this window → unbooked. */
+  missedCallUnbookedHours: 4,
+  /** Window before appointment within which it must be confirmed. */
+  noShowConfirmationHours: 24,
+  /** Default reactivation threshold if client config has none. */
+  defaultReactivationThresholdDays: 60,
+  /** Window after completed appointment in which a review is "ready". */
+  reviewReadyWindowDays: 7,
+  /** Lead value defaults used as a rough estimated_value prior. */
+  warmLeadValueUsd: 150,
+  missedCallValueUsd: 120,
+} as const;
+
+// ------------------------------------------------------------------
+// Input shapes (narrow, rule-specific — not full DB rows)
+// ------------------------------------------------------------------
+
+export interface WarmLeadInput {
+  client_id: string;
+  contact_id: string | null;
+  session_id: string;
+  agent_source: AgentSource;
+  intent: "hot" | "warm" | "low" | "unknown" | null;
+  started_at: string;
+  appointment_booked: boolean;
+  service_interest?: string | null;
+  now?: Date;
+}
+
+export interface MissedCallInput {
+  client_id: string;
+  contact_id: string | null;
+  session_id: string;
+  trigger_type: string;
+  has_linked_appointment: boolean;
+  started_at: string;
+  now?: Date;
+}
+
+export interface NoShowInput {
+  client_id: string;
+  contact_id: string | null;
+  appointment_id: string;
+  status: string | null;
+  scheduled_at: string;
+  confirmation_received: boolean;
+  reminder_sent: boolean;
+  service_value_usd?: number | null;
+  now?: Date;
+}
+
+export interface RebookDueInput {
+  client_id: string;
+  contact_id: string;
+  last_visit_at: string | null;
+  usual_rebook_cadence_days: number | null;
+  future_appointment_exists: boolean;
+  now?: Date;
+}
+
+export interface LapsedClientInput {
+  client_id: string;
+  contact_id: string;
+  last_visit_at: string | null;
+  reactivation_threshold_days: number | null;
+  in_active_reactivation: boolean;
+  now?: Date;
+}
+
+export interface ReviewReadyInput {
+  client_id: string;
+  contact_id: string | null;
+  appointment_id: string;
+  completed_at: string;
+  has_negative_signal: boolean;
+  review_already_sent: boolean;
+  now?: Date;
+}
+
+export interface OwnerFollowupInput {
+  client_id: string;
+  contact_id: string | null;
+  session_id: string | null;
+  appointment_id?: string | null;
+  /** One of the escalation reasons. */
+  reason:
+    | "human_takeover"
+    | "vip_contact"
+    | "negative_sentiment"
+    | "repeated_cancellation"
+    | "high_value_inquiry"
+    | "low_confidence_answer";
+  context: string;
+}
+
+// ------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------
+
+function hoursBetween(a: Date, b: Date): number {
+  return Math.abs(a.getTime() - b.getTime()) / (1000 * 60 * 60);
+}
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.abs(a.getTime() - b.getTime()) / (1000 * 60 * 60 * 24);
+}
+
+// ------------------------------------------------------------------
+// Rules
+// ------------------------------------------------------------------
+
+/**
+ * warm_lead_risk — a hot/warm lead with no appointment booked inside
+ * the follow-up window.
+ */
+export function evalWarmLeadRisk(input: WarmLeadInput): SignalDraft | null {
+  if (input.appointment_booked) return null;
+  if (input.intent !== "hot" && input.intent !== "warm") return null;
+
+  const now = input.now ?? new Date();
+  const hours = hoursBetween(now, new Date(input.started_at));
+  if (hours < PCI_DEFAULTS.warmLeadFollowupHours) return null;
+
+  const severity: SignalSeverity = input.intent === "hot" ? "high" : "medium";
+  const confidence = input.intent === "hot" ? 0.85 : 0.7;
+
+  return {
+    client_id: input.client_id,
+    contact_id: input.contact_id,
+    signal_type: "warm_lead_risk",
+    severity,
+    confidence,
+    reason:
+      `${input.intent === "hot" ? "Hot" : "Warm"} lead from ${input.agent_source} ` +
+      `started ${hours.toFixed(0)}h ago with no booking` +
+      (input.service_interest ? ` (interest: ${input.service_interest})` : "") +
+      ".",
+    recommended_action:
+      "Send warm follow-up; create owner task if high-value service interest.",
+    estimated_value: PCI_DEFAULTS.warmLeadValueUsd,
+    source_table: `${input.agent_source}_sessions`,
+    source_record_id: input.session_id,
+  };
+}
+
+/**
+ * missed_call_unbooked — front-desk missed-call session that has not
+ * produced an appointment after the configured window.
+ */
+export function evalMissedCallUnbooked(
+  input: MissedCallInput
+): SignalDraft | null {
+  if (input.trigger_type !== "missed_call") return null;
+  if (input.has_linked_appointment) return null;
+
+  const now = input.now ?? new Date();
+  const hours = hoursBetween(now, new Date(input.started_at));
+  if (hours < PCI_DEFAULTS.missedCallUnbookedHours) return null;
+
+  return {
+    client_id: input.client_id,
+    contact_id: input.contact_id,
+    signal_type: "missed_call_unbooked",
+    severity: "high",
+    confidence: 0.8,
+    reason: `Missed call ${hours.toFixed(0)}h ago with no appointment booked.`,
+    recommended_action: "Send second follow-up or create owner task.",
+    estimated_value: PCI_DEFAULTS.missedCallValueUsd,
+    source_table: "front_desk_sessions",
+    source_record_id: input.session_id,
+  };
+}
+
+/**
+ * no_show_risk — upcoming appointment with no confirmation received.
+ * Escalates severity when the appointment is higher-value.
+ */
+export function evalNoShowRisk(input: NoShowInput): SignalDraft | null {
+  if (input.status === "canceled" || input.status === "completed") return null;
+  if (input.confirmation_received) return null;
+
+  const now = input.now ?? new Date();
+  const scheduled = new Date(input.scheduled_at);
+  const hoursUntil = (scheduled.getTime() - now.getTime()) / (1000 * 60 * 60);
+
+  // Only act inside the confirmation window and before the appointment.
+  if (hoursUntil < 0 || hoursUntil > PCI_DEFAULTS.noShowConfirmationHours) {
+    return null;
+  }
+
+  const highValue = (input.service_value_usd ?? 0) >= 250;
+  const severity: SignalSeverity = highValue ? "urgent" : "high";
+
+  return {
+    client_id: input.client_id,
+    contact_id: input.contact_id,
+    signal_type: "no_show_risk",
+    severity,
+    confidence: input.reminder_sent ? 0.65 : 0.8,
+    reason:
+      `Appointment in ${hoursUntil.toFixed(1)}h is not confirmed` +
+      (input.reminder_sent ? " despite reminder." : "; no reminder sent."),
+    recommended_action:
+      highValue
+        ? "Send confirmation reminder and escalate to owner — high-value service."
+        : "Send confirmation reminder.",
+    estimated_value: input.service_value_usd ?? null,
+    source_table: "appointments",
+    source_record_id: input.appointment_id,
+  };
+}
+
+/**
+ * rebook_due — a returning client past their usual rebook cadence with
+ * no future appointment on the books.
+ */
+export function evalRebookDue(input: RebookDueInput): SignalDraft | null {
+  if (input.future_appointment_exists) return null;
+  if (!input.last_visit_at || !input.usual_rebook_cadence_days) return null;
+
+  const now = input.now ?? new Date();
+  const sinceLast = daysBetween(now, new Date(input.last_visit_at));
+  if (sinceLast < input.usual_rebook_cadence_days) return null;
+
+  const overdueDays = sinceLast - input.usual_rebook_cadence_days;
+
+  // Only escalate severity if they're materially overdue.
+  const severity: SignalSeverity = overdueDays > 14 ? "high" : "medium";
+  const confidence = Math.min(0.9, 0.6 + overdueDays / 60);
+
+  return {
+    client_id: input.client_id,
+    contact_id: input.contact_id,
+    signal_type: "rebook_due",
+    severity,
+    confidence: Number(confidence.toFixed(3)),
+    reason:
+      `Last visit ${sinceLast.toFixed(0)}d ago exceeds ${input.usual_rebook_cadence_days}d ` +
+      `rebook cadence (${overdueDays.toFixed(0)}d overdue).`,
+    recommended_action: "Send warm rebooking message.",
+    source_table: "client_contacts",
+    source_record_id: input.contact_id,
+  };
+}
+
+/**
+ * lapsed_client — past the client's configured reactivation threshold
+ * with no active reactivation campaign in flight.
+ */
+export function evalLapsedClient(
+  input: LapsedClientInput
+): SignalDraft | null {
+  if (input.in_active_reactivation) return null;
+  if (!input.last_visit_at) return null;
+
+  const threshold =
+    input.reactivation_threshold_days ??
+    PCI_DEFAULTS.defaultReactivationThresholdDays;
+  const now = input.now ?? new Date();
+  const sinceLast = daysBetween(now, new Date(input.last_visit_at));
+  if (sinceLast < threshold) return null;
+
+  return {
+    client_id: input.client_id,
+    contact_id: input.contact_id,
+    signal_type: "lapsed_client",
+    severity: "medium",
+    confidence: 0.75,
+    reason:
+      `No visit in ${sinceLast.toFixed(0)}d (threshold ${threshold}d) and no active reactivation.`,
+    recommended_action: "Start reactivation sequence.",
+    source_table: "client_contacts",
+    source_record_id: input.contact_id,
+  };
+}
+
+/**
+ * review_ready — completed appointment with no negative signal and no
+ * review request already sent.
+ */
+export function evalReviewReady(input: ReviewReadyInput): SignalDraft | null {
+  if (input.has_negative_signal) return null;
+  if (input.review_already_sent) return null;
+
+  const now = input.now ?? new Date();
+  const completed = new Date(input.completed_at);
+  const days = daysBetween(now, completed);
+  if (days > PCI_DEFAULTS.reviewReadyWindowDays) return null;
+
+  return {
+    client_id: input.client_id,
+    contact_id: input.contact_id,
+    signal_type: "review_ready",
+    severity: "low",
+    confidence: 0.9,
+    reason: `Completed appointment ${days.toFixed(0)}d ago with no negative signal.`,
+    recommended_action: "Send review request via preferred review platform.",
+    source_table: "appointments",
+    source_record_id: input.appointment_id,
+  };
+}
+
+/**
+ * owner_followup_needed — catch-all for situations that need a human
+ * in the loop. Always produces a signal — caller is responsible for
+ * only invoking when the escalation actually fired.
+ */
+export function evalOwnerFollowup(input: OwnerFollowupInput): SignalDraft {
+  const severityByReason: Record<OwnerFollowupInput["reason"], SignalSeverity> = {
+    human_takeover: "high",
+    vip_contact: "high",
+    negative_sentiment: "urgent",
+    repeated_cancellation: "medium",
+    high_value_inquiry: "high",
+    low_confidence_answer: "medium",
+  };
+
+  return {
+    client_id: input.client_id,
+    contact_id: input.contact_id,
+    signal_type: "owner_followup_needed",
+    severity: severityByReason[input.reason],
+    confidence: 0.95,
+    reason: `Owner follow-up: ${input.reason.replaceAll("_", " ")} — ${input.context}`,
+    recommended_action: "Create owner task with context summary.",
+    source_table: input.appointment_id
+      ? "appointments"
+      : input.session_id
+        ? "sessions"
+        : null,
+    source_record_id: input.appointment_id ?? input.session_id ?? null,
+  };
+}

--- a/src/lib/pci/signals.ts
+++ b/src/lib/pci/signals.ts
@@ -15,6 +15,7 @@ import { sbInsert, sbSelect } from "@/lib/agents/supabase";
 import type {
   CustomerSignal,
   SignalDraft,
+  SignalSeverity,
   SignalStatus,
   SignalType,
 } from "./types";
@@ -73,24 +74,50 @@ export async function upsertSignalFromDraft(
   return { signal: inserted, created: true };
 }
 
+/**
+ * Semantic severity ordering. PostgREST can only sort lexicographically
+ * on the `severity` text column ("high" < "low" < "medium" < "urgent"),
+ * which is not the urgency order we want to surface. We run one query
+ * per severity bucket in semantic order, each bucket fully ordered by
+ * created_at DESC and capped at the caller's limit, then concatenate
+ * and slice. This guarantees the semantic sort is applied BEFORE the
+ * final LIMIT.
+ */
+const SEVERITY_ORDER: readonly SignalSeverity[] = [
+  "urgent",
+  "high",
+  "medium",
+  "low",
+] as const;
+
 export async function listOpenSignals(args: {
   client_ids: string[] | null;
   signal_type?: SignalType;
   limit?: number;
 }): Promise<CustomerSignal[]> {
-  const params: Record<string, string> = {
+  const limit = args.limit ?? 200;
+
+  const baseParams: Record<string, string> = {
     status: "in.(open,in_progress)",
   };
   if (args.client_ids !== null) {
     if (args.client_ids.length === 0) return [];
-    params.client_id = `in.(${args.client_ids.map(encodeURIComponent).join(",")})`;
+    baseParams.client_id = `in.(${args.client_ids.map(encodeURIComponent).join(",")})`;
   }
-  if (args.signal_type) params.signal_type = `eq.${args.signal_type}`;
+  if (args.signal_type) baseParams.signal_type = `eq.${args.signal_type}`;
 
-  return sbSelect<CustomerSignal>(TABLE, params, {
-    order: "severity.asc,created_at.desc",
-    limit: args.limit ?? 200,
-  });
+  const out: CustomerSignal[] = [];
+  for (const severity of SEVERITY_ORDER) {
+    if (out.length >= limit) break;
+    const remaining = limit - out.length;
+    const rows = await sbSelect<CustomerSignal>(
+      TABLE,
+      { ...baseParams, severity: `eq.${severity}` },
+      { order: "created_at.desc", limit: remaining }
+    );
+    out.push(...rows);
+  }
+  return out;
 }
 
 export async function updateSignalStatus(args: {

--- a/src/lib/pci/signals.ts
+++ b/src/lib/pci/signals.ts
@@ -1,0 +1,106 @@
+/**
+ * PCI v0 — signal persistence helpers.
+ *
+ * Thin wrappers over the PostgREST helpers in
+ * src/lib/agents/supabase.ts. Uses the service-role key and bypasses
+ * RLS, matching the rest of the agent backend.
+ *
+ * Duplicate control relies on the partial unique indexes defined in
+ * the 0007 migration. `openSignalFor()` reads before writing so rule
+ * code can skip work when an open signal already exists, rather than
+ * relying on an insert conflict.
+ */
+
+import { sbInsert, sbSelect } from "@/lib/agents/supabase";
+import type {
+  CustomerSignal,
+  SignalDraft,
+  SignalStatus,
+  SignalType,
+} from "./types";
+
+const TABLE = "customer_signals";
+
+export async function openSignalFor(args: {
+  client_id: string;
+  contact_id: string | null;
+  signal_type: SignalType;
+}): Promise<CustomerSignal | null> {
+  const params: Record<string, string> = {
+    client_id: `eq.${args.client_id}`,
+    signal_type: `eq.${args.signal_type}`,
+    status: "in.(open,in_progress)",
+  };
+  params.contact_id =
+    args.contact_id === null ? "is.null" : `eq.${args.contact_id}`;
+
+  const rows = await sbSelect<CustomerSignal>(TABLE, params, {
+    order: "created_at.desc",
+    limit: 1,
+  });
+  return rows[0] ?? null;
+}
+
+/**
+ * Create a new signal from a rule draft, unless an open signal of the
+ * same (client, contact, type) already exists. Returns either the
+ * inserted row or the existing open row.
+ */
+export async function upsertSignalFromDraft(
+  draft: SignalDraft
+): Promise<{ signal: CustomerSignal; created: boolean }> {
+  const existing = await openSignalFor({
+    client_id: draft.client_id,
+    contact_id: draft.contact_id,
+    signal_type: draft.signal_type,
+  });
+  if (existing) return { signal: existing, created: false };
+
+  const inserted = await sbInsert<CustomerSignal>(TABLE, {
+    client_id: draft.client_id,
+    contact_id: draft.contact_id,
+    signal_type: draft.signal_type,
+    severity: draft.severity,
+    confidence: draft.confidence,
+    reason: draft.reason,
+    recommended_action: draft.recommended_action,
+    estimated_value: draft.estimated_value ?? null,
+    source_event_ids: draft.source_event_ids ?? [],
+    source_table: draft.source_table ?? null,
+    source_record_id: draft.source_record_id ?? null,
+    expires_at: draft.expires_at ?? null,
+  });
+  return { signal: inserted, created: true };
+}
+
+export async function listOpenSignals(args: {
+  client_ids: string[] | null;
+  signal_type?: SignalType;
+  limit?: number;
+}): Promise<CustomerSignal[]> {
+  const params: Record<string, string> = {
+    status: "in.(open,in_progress)",
+  };
+  if (args.client_ids !== null) {
+    if (args.client_ids.length === 0) return [];
+    params.client_id = `in.(${args.client_ids.map(encodeURIComponent).join(",")})`;
+  }
+  if (args.signal_type) params.signal_type = `eq.${args.signal_type}`;
+
+  return sbSelect<CustomerSignal>(TABLE, params, {
+    order: "severity.asc,created_at.desc",
+    limit: args.limit ?? 200,
+  });
+}
+
+export async function updateSignalStatus(args: {
+  id: string;
+  status: SignalStatus;
+}): Promise<void> {
+  // Minimal update — kept separate from sbUpdate generic so callers
+  // can't accidentally rewrite severity/reason.
+  const patch: Record<string, unknown> = { status: args.status };
+  if (args.status === "resolved") patch.resolved_at = new Date().toISOString();
+  const { sbUpdate } = await import("@/lib/agents/supabase");
+  await sbUpdate(TABLE, { id: `eq.${args.id}` }, patch);
+}

--- a/src/lib/pci/types.ts
+++ b/src/lib/pci/types.ts
@@ -1,0 +1,161 @@
+/**
+ * Predictive Customer Intelligence (PCI) — shared type definitions.
+ *
+ * These mirror the database schema introduced in
+ * supabase/migrations/0007_pci_v0_intelligence_layer.sql.
+ *
+ * Internal use only. Never surface these strings in public copy.
+ */
+
+export type AgentSource = "support" | "front_desk" | "care";
+
+/**
+ * Normalized event types written to `customer_events`. This list is the
+ * authoritative enumeration used by rule code. If you add a value here,
+ * update docs/PCI.md and the rule consumers.
+ */
+export const CUSTOMER_EVENT_TYPES = [
+  "support_chat_started",
+  "lead_intent_detected",
+  "form_submitted",
+  "missed_call",
+  "front_desk_reply_sent",
+  "appointment_requested",
+  "appointment_booked",
+  "appointment_confirmed",
+  "appointment_unconfirmed",
+  "appointment_canceled",
+  "appointment_completed",
+  "review_requested",
+  "review_completed",
+  "reactivation_sent",
+  "reactivation_responded",
+  "care_handoff",
+  "owner_escalation",
+] as const;
+
+export type CustomerEventType = (typeof CUSTOMER_EVENT_TYPES)[number];
+
+export interface CustomerEvent {
+  id: string;
+  client_id: string;
+  contact_id: string | null;
+  event_type: CustomerEventType;
+  event_source: string;
+  agent_source: AgentSource | null;
+  session_id: string | null;
+  appointment_id: string | null;
+  conversation_message_id: string | null;
+  service_interest: string | null;
+  channel: string | null;
+  occurred_at: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+/**
+ * Signal taxonomy. Each value maps 1:1 to a GHL tag (see docs/PCI.md
+ * for the handoff table) and to a rule in src/lib/pci/rules.ts.
+ */
+export const SIGNAL_TYPES = [
+  "warm_lead_risk",
+  "missed_call_unbooked",
+  "no_show_risk",
+  "rebook_due",
+  "lapsed_client",
+  "review_ready",
+  "owner_followup_needed",
+  "slow_week_fill",
+] as const;
+
+export type SignalType = (typeof SIGNAL_TYPES)[number];
+
+export const SIGNAL_SEVERITIES = ["low", "medium", "high", "urgent"] as const;
+export type SignalSeverity = (typeof SIGNAL_SEVERITIES)[number];
+
+export const SIGNAL_STATUSES = [
+  "open",
+  "in_progress",
+  "resolved",
+  "dismissed",
+  "expired",
+] as const;
+export type SignalStatus = (typeof SIGNAL_STATUSES)[number];
+
+export interface CustomerSignal {
+  id: string;
+  client_id: string;
+  contact_id: string | null;
+  signal_type: SignalType;
+  severity: SignalSeverity;
+  /** 0..1, three-decimal precision in the DB. */
+  confidence: number;
+  status: SignalStatus;
+  reason: string;
+  recommended_action: string;
+  estimated_value: number | null;
+  source_event_ids: string[];
+  source_table: string | null;
+  source_record_id: string | null;
+  expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+  resolved_at: string | null;
+}
+
+/**
+ * The draft shape rule code produces before it is persisted. Omits
+ * server-generated columns (id, timestamps, status) and confirms the
+ * fields the rule must fill in.
+ */
+export interface SignalDraft {
+  client_id: string;
+  contact_id: string | null;
+  signal_type: SignalType;
+  severity: SignalSeverity;
+  confidence: number;
+  reason: string;
+  recommended_action: string;
+  estimated_value?: number | null;
+  source_event_ids?: string[];
+  source_table?: string | null;
+  source_record_id?: string | null;
+  expires_at?: string | null;
+}
+
+export interface WeeklyIntelligenceBrief {
+  id: string;
+  client_id: string;
+  week_start: string;
+  week_end: string;
+  missed_calls_recovered: number;
+  missed_calls_unbooked: number;
+  hot_leads_at_risk: number;
+  appointments_unconfirmed: number;
+  likely_no_show_count: number;
+  clients_due_to_rebook: number;
+  lapsed_clients_flagged: number;
+  reviews_requested: number;
+  reviews_captured: number;
+  estimated_revenue_recovered: number | null;
+  estimated_revenue_at_risk: number | null;
+  recommended_actions: Array<Record<string, unknown>>;
+  summary: string | null;
+  created_at: string;
+}
+
+/**
+ * GHL tag used to route execution for a given signal. These are the
+ * only strings that should ever leave the intelligence layer toward the
+ * execution layer. Public copy must not mention them.
+ */
+export const SIGNAL_GHL_TAG: Record<SignalType, string> = {
+  warm_lead_risk: "pci_hot_lead",
+  missed_call_unbooked: "pci_missed_call_unbooked",
+  no_show_risk: "pci_no_show_risk",
+  rebook_due: "pci_rebook_due",
+  lapsed_client: "pci_lapsed_client",
+  review_ready: "pci_review_ready",
+  owner_followup_needed: "pci_owner_followup",
+  slow_week_fill: "pci_slow_week_fill",
+};

--- a/supabase/migrations/0007_pci_v0_intelligence_layer.sql
+++ b/supabase/migrations/0007_pci_v0_intelligence_layer.sql
@@ -1,0 +1,262 @@
+-- ============================================================
+-- 0007_pci_v0_intelligence_layer.sql
+--
+-- Predictive Customer Intelligence (PCI) v0 — durable schema.
+--
+-- Adds the intelligence layer on top of the existing agent tables.
+-- PCI is the shared layer behind Noell Support, Noell Front Desk, and
+-- Noell Care. It normalizes operational actions into `customer_events`,
+-- derives durable `customer_signals`, rolls into `weekly_intelligence_briefs`,
+-- and enriches `client_contacts` with follow-up context.
+--
+-- Public-facing site copy must NEVER mention this schema, the backend
+-- stack, or the intelligence/execution split. See docs/PCI.md.
+--
+-- This migration is reviewable only. Do NOT apply to production until
+-- a separate deploy window covers the application side and RLS posture
+-- on the existing tables.
+--
+-- Run AFTER: 0006_admin_invite_tokens.sql / 0006_admin_password_resets.sql
+-- Idempotent — safe to re-run.
+-- ============================================================
+
+
+-- ============================================================
+-- 1. customer_events — normalized event stream
+-- ============================================================
+--
+-- One row per operationally meaningful thing that happened across any
+-- of the three agents. Keeps the raw operational history needed for
+-- signal derivation without hard-coding every agent table into rule
+-- logic. The `session_id` is intentionally unconstrained (not a FK)
+-- because it can point to any of support_sessions / front_desk_sessions
+-- / care_sessions / chatSessions depending on agent_source.
+
+CREATE TABLE IF NOT EXISTS public.customer_events (
+  id                       uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id                text        NOT NULL,
+  contact_id               uuid        NULL REFERENCES public.client_contacts(id) ON DELETE SET NULL,
+  event_type               text        NOT NULL,
+  event_source             text        NOT NULL,
+  agent_source             text        NULL CHECK (agent_source IN ('support', 'front_desk', 'care') OR agent_source IS NULL),
+  session_id               uuid        NULL,
+  appointment_id           uuid        NULL REFERENCES public.appointments(id) ON DELETE SET NULL,
+  conversation_message_id  uuid        NULL,
+  service_interest         text        NULL,
+  channel                  text        NULL,
+  occurred_at              timestamptz NOT NULL DEFAULT now(),
+  metadata                 jsonb       NOT NULL DEFAULT '{}'::jsonb,
+  created_at               timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS customer_events_client_time_idx
+  ON public.customer_events (client_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS customer_events_contact_time_idx
+  ON public.customer_events (contact_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS customer_events_type_time_idx
+  ON public.customer_events (event_type, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS customer_events_appointment_idx
+  ON public.customer_events (appointment_id);
+
+CREATE INDEX IF NOT EXISTS customer_events_session_idx
+  ON public.customer_events (session_id);
+
+
+-- ============================================================
+-- 2. customer_signals — active/historical intelligence
+-- ============================================================
+--
+-- A signal is "someone needs attention next, and here is why." The
+-- service-role agent backend creates and resolves these. GHL is the
+-- execution layer — a separate sync path reads open signals and
+-- applies tags/tasks/workflows.
+
+CREATE TABLE IF NOT EXISTS public.customer_signals (
+  id                 uuid           PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id          text           NOT NULL,
+  contact_id         uuid           NULL REFERENCES public.client_contacts(id) ON DELETE SET NULL,
+  signal_type        text           NOT NULL,
+  severity           text           NOT NULL DEFAULT 'medium'
+                                    CHECK (severity IN ('low', 'medium', 'high', 'urgent')),
+  confidence         numeric(4,3)   NOT NULL DEFAULT 0.700
+                                    CHECK (confidence >= 0 AND confidence <= 1),
+  status             text           NOT NULL DEFAULT 'open'
+                                    CHECK (status IN ('open', 'in_progress', 'resolved', 'dismissed', 'expired')),
+  reason             text           NOT NULL,
+  recommended_action text           NOT NULL,
+  estimated_value    numeric(12,2)  NULL,
+  source_event_ids   uuid[]         NOT NULL DEFAULT '{}',
+  source_table       text           NULL,
+  source_record_id   uuid           NULL,
+  expires_at         timestamptz    NULL,
+  created_at         timestamptz    NOT NULL DEFAULT now(),
+  updated_at         timestamptz    NOT NULL DEFAULT now(),
+  resolved_at        timestamptz    NULL
+);
+
+CREATE INDEX IF NOT EXISTS customer_signals_open_client_idx
+  ON public.customer_signals (client_id, status, severity, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS customer_signals_contact_idx
+  ON public.customer_signals (contact_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS customer_signals_type_idx
+  ON public.customer_signals (signal_type, status, created_at DESC);
+
+-- Partial unique index: one open/in-progress signal of a given type
+-- per client+contact. This is what prevents duplicate signals from
+-- piling up on repeated rule runs.
+CREATE UNIQUE INDEX IF NOT EXISTS customer_signals_open_unique_idx
+  ON public.customer_signals (client_id, contact_id, signal_type)
+  WHERE status IN ('open', 'in_progress');
+
+-- Some signals (slow_week_fill, owner_followup_needed for a session
+-- with no contact) have NULL contact_id. Ensure we don't create
+-- duplicate contact-less open signals of the same type either.
+CREATE UNIQUE INDEX IF NOT EXISTS customer_signals_open_unique_no_contact_idx
+  ON public.customer_signals (client_id, signal_type, source_record_id)
+  WHERE status IN ('open', 'in_progress') AND contact_id IS NULL;
+
+-- Keep updated_at fresh. set_updated_at() already exists (see
+-- 0001_agents_schema.sql).
+DROP TRIGGER IF EXISTS customer_signals_set_updated_at ON public.customer_signals;
+CREATE TRIGGER customer_signals_set_updated_at
+  BEFORE UPDATE ON public.customer_signals
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+-- ============================================================
+-- 3. weekly_intelligence_briefs — rollup for owner-facing brief
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.weekly_intelligence_briefs (
+  id                           uuid           PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id                    text           NOT NULL,
+  week_start                   date           NOT NULL,
+  week_end                     date           NOT NULL,
+  missed_calls_recovered       integer        NOT NULL DEFAULT 0,
+  missed_calls_unbooked        integer        NOT NULL DEFAULT 0,
+  hot_leads_at_risk            integer        NOT NULL DEFAULT 0,
+  appointments_unconfirmed     integer        NOT NULL DEFAULT 0,
+  likely_no_show_count         integer        NOT NULL DEFAULT 0,
+  clients_due_to_rebook        integer        NOT NULL DEFAULT 0,
+  lapsed_clients_flagged       integer        NOT NULL DEFAULT 0,
+  reviews_requested            integer        NOT NULL DEFAULT 0,
+  reviews_captured             integer        NOT NULL DEFAULT 0,
+  estimated_revenue_recovered  numeric(12,2)  NULL,
+  estimated_revenue_at_risk    numeric(12,2)  NULL,
+  recommended_actions          jsonb          NOT NULL DEFAULT '[]'::jsonb,
+  summary                      text           NULL,
+  created_at                   timestamptz    NOT NULL DEFAULT now(),
+  UNIQUE (client_id, week_start, week_end)
+);
+
+CREATE INDEX IF NOT EXISTS weekly_intelligence_briefs_client_week_idx
+  ON public.weekly_intelligence_briefs (client_id, week_start DESC);
+
+
+-- ============================================================
+-- 4. client_contacts enrichment
+-- ============================================================
+
+ALTER TABLE public.client_contacts
+  ADD COLUMN IF NOT EXISTS usual_rebook_cadence_days integer,
+  ADD COLUMN IF NOT EXISTS last_service_booked       text,
+  ADD COLUMN IF NOT EXISTS last_inbound_intent       text,
+  ADD COLUMN IF NOT EXISTS last_contacted_at         timestamptz,
+  ADD COLUMN IF NOT EXISTS last_review_status        text,
+  ADD COLUMN IF NOT EXISTS risk_summary              text,
+  ADD COLUMN IF NOT EXISTS next_best_follow_up       text,
+  ADD COLUMN IF NOT EXISTS next_best_follow_up_at    timestamptz;
+
+
+-- ============================================================
+-- 5. Unindexed-foreign-key advisories flagged by Supabase
+-- ============================================================
+--
+-- PCI rules query across these FKs frequently. The advisory was open
+-- before PCI; adding the indexes here so PCI's cross-table lookups
+-- don't do seq scans.
+
+CREATE INDEX IF NOT EXISTS appointments_session_id_idx
+  ON public.appointments (session_id);
+
+CREATE INDEX IF NOT EXISTS front_desk_sessions_appointment_id_idx
+  ON public.front_desk_sessions (appointment_id);
+
+CREATE INDEX IF NOT EXISTS reminders_appointment_id_idx
+  ON public.reminders (appointment_id);
+
+CREATE INDEX IF NOT EXISTS review_requests_appointment_id_idx
+  ON public.review_requests (appointment_id);
+
+
+-- ============================================================
+-- 6. RLS — default deny, service-role bypass
+-- ============================================================
+--
+-- PCI tables are service-role only. The agent backend (API routes in
+-- src/app/api/**) uses SUPABASE_SERVICE_ROLE_KEY and bypasses RLS. No
+-- anon/authenticated client should ever touch these tables directly.
+-- Enable RLS and create explicit "deny all" policies so the Supabase
+-- advisor does not flag these tables the way it did for 0001.
+
+ALTER TABLE public.customer_events             ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.customer_signals            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.weekly_intelligence_briefs  ENABLE ROW LEVEL SECURITY;
+
+-- customer_events
+DROP POLICY IF EXISTS customer_events_deny_anon ON public.customer_events;
+CREATE POLICY customer_events_deny_anon
+  ON public.customer_events
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);
+
+-- customer_signals
+DROP POLICY IF EXISTS customer_signals_deny_anon ON public.customer_signals;
+CREATE POLICY customer_signals_deny_anon
+  ON public.customer_signals
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);
+
+-- weekly_intelligence_briefs
+DROP POLICY IF EXISTS weekly_intelligence_briefs_deny_anon ON public.weekly_intelligence_briefs;
+CREATE POLICY weekly_intelligence_briefs_deny_anon
+  ON public.weekly_intelligence_briefs
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);
+
+
+-- ============================================================
+-- 7. Down-migration reference (manual, do NOT auto-run)
+-- ============================================================
+--
+-- To roll back this migration, run the statements below against the
+-- target project. They are commented out so this file stays idempotent
+-- and safe to apply; they exist here so the rollback is reviewable.
+--
+--   DROP TABLE IF EXISTS public.weekly_intelligence_briefs;
+--   DROP TABLE IF EXISTS public.customer_signals;
+--   DROP TABLE IF EXISTS public.customer_events;
+--   ALTER TABLE public.client_contacts
+--     DROP COLUMN IF EXISTS usual_rebook_cadence_days,
+--     DROP COLUMN IF EXISTS last_service_booked,
+--     DROP COLUMN IF EXISTS last_inbound_intent,
+--     DROP COLUMN IF EXISTS last_contacted_at,
+--     DROP COLUMN IF EXISTS last_review_status,
+--     DROP COLUMN IF EXISTS risk_summary,
+--     DROP COLUMN IF EXISTS next_best_follow_up,
+--     DROP COLUMN IF EXISTS next_best_follow_up_at;
+--   DROP INDEX IF EXISTS public.appointments_session_id_idx;
+--   DROP INDEX IF EXISTS public.front_desk_sessions_appointment_id_idx;
+--   DROP INDEX IF EXISTS public.reminders_appointment_id_idx;
+--   DROP INDEX IF EXISTS public.review_requests_appointment_id_idx;

--- a/supabase/migrations/0007_pci_v0_intelligence_layer.sql
+++ b/supabase/migrations/0007_pci_v0_intelligence_layer.sql
@@ -106,18 +106,40 @@ CREATE INDEX IF NOT EXISTS customer_signals_contact_idx
 CREATE INDEX IF NOT EXISTS customer_signals_type_idx
   ON public.customer_signals (signal_type, status, created_at DESC);
 
--- Partial unique index: one open/in-progress signal of a given type
--- per client+contact. This is what prevents duplicate signals from
--- piling up on repeated rule runs.
+-- Partial unique indexes: prevent duplicate open signals from piling up
+-- on repeated rule runs. Two keys are needed because Postgres unique
+-- indexes treat NULLs as distinct by default — without the NULL-safe
+-- second index, contact-less signals (slow_week_fill, owner_followup
+-- without an attached contact) could be inserted repeatedly.
+--
+-- We use COALESCE-based expression indexes (portable across all
+-- supported Postgres versions) instead of `NULLS NOT DISTINCT` (PG 15+
+-- only) so this migration stays compatible with older targets. The
+-- zero-UUID sentinel is safe: `gen_random_uuid()` never produces it,
+-- so no real row can collide with the NULL-coalesced value.
+
+-- Primary key: one open/in-progress signal per (client, contact, type)
+-- when contact is known. Matches the contract in openSignalFor().
+-- Scoped to contact_id IS NOT NULL so the NULL-contact case is handled
+-- by the secondary index below (distinct sources must stay separate).
 CREATE UNIQUE INDEX IF NOT EXISTS customer_signals_open_unique_idx
   ON public.customer_signals (client_id, contact_id, signal_type)
-  WHERE status IN ('open', 'in_progress');
+  WHERE status IN ('open', 'in_progress') AND contact_id IS NOT NULL;
 
--- Some signals (slow_week_fill, owner_followup_needed for a session
--- with no contact) have NULL contact_id. Ensure we don't create
--- duplicate contact-less open signals of the same type either.
+-- Secondary key: when contact_id IS NULL, dedupe on
+-- (client, type, source_record_id) so distinct contactless signals
+-- attached to different sessions/appointments (e.g. owner_followup
+-- for unrelated escalations) remain separate, while repeated rule
+-- runs for the same source are collapsed. NULL source_record_id
+-- coalesces to a zero-UUID sentinel so fully-unattached contactless
+-- signals (one per client+type) are also deduped — gen_random_uuid()
+-- never produces the sentinel, so real rows cannot collide with it.
 CREATE UNIQUE INDEX IF NOT EXISTS customer_signals_open_unique_no_contact_idx
-  ON public.customer_signals (client_id, signal_type, source_record_id)
+  ON public.customer_signals (
+    client_id,
+    signal_type,
+    COALESCE(source_record_id, '00000000-0000-0000-0000-000000000000'::uuid)
+  )
   WHERE status IN ('open', 'in_progress') AND contact_id IS NULL;
 
 -- Keep updated_at fresh. set_updated_at() already exists (see


### PR DESCRIPTION
## Summary

PCI v0 intelligence layer — durable schema, deterministic rule primitives, internal-only operator dashboard. Implements the next-sprint scope from `ops-by-noell-predictive-customer-intelligence-mvp-spec.md`. No public copy changes.

- **Migration `0007_pci_v0_intelligence_layer.sql`** — `customer_events`, `customer_signals`, `weekly_intelligence_briefs`, `client_contacts` enrichment columns. Ships with RLS + deny-all policies for `anon`/`authenticated` (service-role bypasses), a partial unique index that prevents duplicate open signals per `(client_id, contact_id, signal_type)`, and backfill indexes for the unindexed FKs the Supabase advisor already flagged.
- **`src/lib/pci/`** — typed event + signal enums, eight pure rule functions (`warm_lead_risk`, `missed_call_unbooked`, `no_show_risk`, `rebook_due`, `lapsed_client`, `review_ready`, `owner_followup_needed`), `recordEvent()` + `upsertSignalFromDraft()` persistence helpers, and a typed `handoffToExecution()` seam (v0 is a stub — v1 wires GHL).
- **Internal dashboard** — `/admin/pci` + `/api/admin/pci/signals`, protected by the existing middleware and scoped to the caller's `accessibleClients`. Linked from the admin inbox header. Not in public navigation.
- **`docs/PCI.md`** — internal reference; covers layering, signal taxonomy, where rules should run, handoff contract, public-copy policy, and deferred v1/v2/v3 scope.

## Does not include

- **Migration is NOT applied to production Supabase.** Needs a separate deploy window. Rollback statements are in the migration footer.
- Cron wiring for scheduled rule scans (deferred to v1).
- Real GHL handoff — `handoffToExecution()` is a typed stub.
- Weekly brief generator.
- Fixes for the pre-existing RLS-without-policy advisories on the legacy tables (out of scope; flagged in the doc).

## Testing

- [x] PCI rule unit tests — 17 pass (`npx tsx --test src/lib/pci/rules.test.ts`). Sandbox Node is 20 so `npm test` (needs `--experimental-strip-types`, Node 22+) is the same pre-existing block that affects `main`; CI has the right Node.
- [x] `npm run build` — passes; `/admin/pci` and `/api/admin/pci/signals` show in the route manifest.
- [x] `eslint src/lib/pci src/app/admin/pci src/app/api/admin/pci` — clean.
- [x] `tsc --noEmit` — no new errors from the PCI files (the five pre-existing `.ts`-extension errors in legacy `.test.ts` files are unchanged on `main`).
- [x] Grep confirms no forbidden terms (`supabase`, `gohighlevel`, `ghl`) in public marketing routes (`/`, `/noell-*`, `/pricing`, `/verticals`, `/resources`, `/compare`, `src/components`).

## Reviewer checklist

- [ ] Migration columns/indexes/RLS policies match the spec and the existing migration style.
- [ ] `/admin/pci` route is correctly scoped by `accessibleClients` (check `api/admin/pci/signals/route.ts`).
- [ ] Rule thresholds in `PCI_DEFAULTS` are sensible defaults pre-tuning.
- [ ] Confirm production Supabase deploy window before merging + applying 0007.