### PR TITLE
chore(analytics): instrument homepage → /book conversion funnel

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,147 @@
+# Conversion analytics
+
+This site instruments the marketing funnel from the first CTA impression
+through to the `/book` audit request. The goal is to be able to answer, from
+the analytics tool, questions like:
+
+- How many audit CTA clicks came from the homepage hero vs. the final CTA band?
+- Which vertical pages convert best into audit requests?
+- Which comparison page drives the most audit-CTA clicks?
+- What fraction of pricing-tier clicks convert into `/book` views?
+
+## Provider assumption
+
+The only analytics provider currently wired up is **Meta Pixel**
+(`src/components/meta-pixel.tsx`). It is enabled when
+`NEXT_PUBLIC_META_PIXEL_ID` is set. All events described here route through
+`trackMetaCustomEvent` (and, for the core `audit_cta_click` / worksheet
+events, also through the Meta standard `Contact` / `Lead` events for
+compatibility with existing Pixel audiences).
+
+Helpers live in:
+
+- `src/lib/analytics.ts` — conversion event names + `trackConversion` +
+  `trackAuditCtaClick` convenience wrapper. Use these rather than importing
+  `trackMetaCustomEvent` directly.
+- `src/lib/meta-pixel-track.ts` — low-level Meta Pixel adapter.
+
+Every helper no-ops safely when the pixel script hasn't loaded.
+
+## Adding a second analytics provider
+
+All conversion events are centralized in `trackConversion` in
+`src/lib/analytics.ts`. To add GA4, PostHog, Segment, etc., forward the
+same `(eventName, context)` call into their SDK inside `trackConversion` —
+one file change, no component edits required.
+
+Alternatively, every primary CTA in the app carries DOM attributes:
+
+- `data-event="<event_name>"`
+- `data-source-page="<source_page>"`
+- `data-source-section="<source_section>"`
+
+A future provider can attach one delegated click listener on `document` that
+filters on `target.closest("[data-event]")`, reads the three attributes, and
+emits its own event — no per-component changes. This is the low-risk hook
+for trying a new provider without modifying JS call sites.
+
+## Event map
+
+Event names are declared in `ConversionEvents` in `src/lib/analytics.ts`.
+Do not hardcode event-name strings in components — import the constant.
+
+### Conversion events
+
+| Event name | Fires when | Important params |
+| --- | --- | --- |
+| `audit_cta_click` | A CTA whose destination is `/book` is clicked. | `source_page`, `source_section`, `destination`, `cta_label` |
+| `audit_page_view` | The `/book` page mounts (funnel-entry marker). | `source_page: "book"` |
+| `audit_exit_intent_shown` | The desktop exit-intent modal on `/book` opens. | `source_page: "book"`, `source_section: "book_exit_intent"` |
+| `audit_worksheet_request` | The exit-intent worksheet email form submits successfully. | — |
+| `booking_fallback_email_click` | The manual-scheduling email CTA on `/book` is clicked (the fallback shown when no live scheduler URL is configured). | `source_page: "book"` |
+| `tier_card_click` | A pricing tier CTA is clicked anywhere on the site. Already emitted pre-this-pass. | `tier`, `source_page` |
+| `vertical_pricing_shown` | The vertical pricing section scrolls into view. Emitted by `VerticalPricingSection`. | `vertical` |
+| `vertical_card_click` | A vertical card on `/verticals` is clicked. | `source_page`, `source_section`, `vertical` |
+| `agents_founding_cta_click` | The Noell Agents founding member CTA is clicked. Emits `InitiateCheckout` too. | — |
+| `comparison_audit_cta_click` | Reserved for a comparison-specific CTA distinct from the default audit CTA. Not yet emitted; the current comparison CTA uses `audit_cta_click` with `source_page: "compare_*"`. | — |
+| `faq_open` | An FAQ accordion item opens. Emitted by `FAQ`. | `question` |
+
+### Standard Meta events (compatibility)
+
+`trackConversion` also emits the following standard events so existing
+Pixel audiences keep working:
+
+| Standard event | Fires alongside |
+| --- | --- |
+| `Contact` | Every `audit_cta_click` |
+| `Lead` | `audit_worksheet_request` and existing booking-confirmation postMessage handler |
+| `InitiateCheckout` | `agents_founding_cta_click` (in `agents-founding-cta.tsx`) |
+| `ViewContent` | `/agents` page view (in `agents-page-analytics.tsx`) |
+| `PageView` | Every client-side navigation (in `meta-pixel.tsx`) |
+
+## Source attribution taxonomy
+
+### `source_page` values
+
+One per top-level page. Values live in the `SourcePage` type in
+`src/lib/analytics.ts`.
+
+`home`, `pricing`, `book`, `agents`, `systems`, `about`, `contact`, `roi`,
+`noell_support`, `noell_front_desk`, `noell_care`,
+`verticals_index`, `verticals_{dental|med_spas|salons|massage|estheticians|hvac}`,
+`compare_index`, `compare_{my_ai_front_desk|podium|ai_front_desk_alternatives|diy_ai_receptionist|human_answering_services|local_business_messaging_platforms}`,
+`case_studies`, `resources`, `navbar`, `footer`, `global_chat`.
+
+### `source_section` values
+
+The within-page region where the click originated. Values live in the
+`SourceSection` type.
+
+`hero`, `final_cta`, `pick_your_path`, `systems_grid`, `pricing_cards`,
+`pricing_tier_cta`, `comparison_cta`, `vertical_card`,
+`vertical_agents_callout`, `navbar_primary`, `navbar_mobile`, `footer`,
+`faq_exit`, `book_exit_intent`, `booking_fallback`, `booking_embed`,
+`audit_request_soft_exit`, `founding_cta`.
+
+## Data attributes on CTAs
+
+Primary CTAs expose stable DOM attributes even when they aren't wrapped in
+a JS click handler. This gives any analytics provider a single delegated
+listener to work with:
+
+- `data-event` — the event name (matches the constants in
+  `ConversionEvents`).
+- `data-source-page` — one of the `SourcePage` values above.
+- `data-source-section` — one of the `SourceSection` values above.
+
+Also used for richer segmentation:
+
+- `data-vertical` — on vertical cards (`/verticals`), the vertical slug.
+- `data-agent` — on agent cards on the homepage, the agent handle.
+
+These attributes are cheap and render-only — they do not affect visuals,
+SEO, or accessibility.
+
+## TODO / follow-ups
+
+- Wire a server-side Meta Conversions API (CAPI) sender for the
+  high-intent events (`audit_cta_click`, `audit_worksheet_request`,
+  booking-confirmation `Lead`). The current pixel-only path loses
+  events to iOS 14+ / ad-blockers.
+- Add GA4 alongside Meta Pixel for session-level journey analysis.
+  Hook point is `trackConversion` in `src/lib/analytics.ts`.
+- Consider a top-of-file `"use client";` sweep to be sure every event
+  call site is in a client boundary — today every site of the helper
+  lives in `"use client"` components already.
+- Once a real scheduler URL is configured via `NEXT_PUBLIC_BOOKING_URL`,
+  confirm the scheduler posts a recognizable `message` payload so the
+  existing `BookingLeadTracker` fires `Lead` on confirmed bookings.
+
+## How to verify events fire (Meta Pixel)
+
+1. Install the Meta Pixel Helper browser extension.
+2. Set `NEXT_PUBLIC_META_PIXEL_ID` in `.env.local`.
+3. Run `npm run dev`, open the homepage, and click any audit CTA.
+4. The helper should show `PageView` on load, then `Contact` +
+   `audit_cta_click` on click, with the `source_page` and
+   `source_section` params visible in the event payload.

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -292,6 +292,7 @@ export default function BookPage() {
         headlineAccent="waiting when you are."
         body="You can always come back. We don't chase, and we don't add you to a list."
         trustLine="Free · focused working call · personally scheduled"
+        sourcePage="book"
       />
     </div>
   );

--- a/src/app/compare/ai-front-desk-alternatives/page.tsx
+++ b/src/app/compare/ai-front-desk-alternatives/page.tsx
@@ -65,6 +65,7 @@ export default function Compare() {
         id="compare-alternatives"
       />
       <CompareLayout
+        sourcePage="compare_ai_front_desk_alternatives"
         alternativeName="Other options"
         title="AI front desk alternatives"
         lead="A short, honest map of the options, and where a done-for-you install fits among them."

--- a/src/app/compare/diy-ai-receptionist/page.tsx
+++ b/src/app/compare/diy-ai-receptionist/page.tsx
@@ -65,6 +65,7 @@ export default function Compare() {
         id="compare-diy-ai"
       />
       <CompareLayout
+        sourcePage="compare_diy_ai_receptionist"
         alternativeName={ALT}
         title={`Ops by Noell vs. ${ALT}`}
         lead="Two ways to bring AI to the front of your business. One is a weekend project. The other is an installed, managed front desk."

--- a/src/app/compare/human-answering-services/page.tsx
+++ b/src/app/compare/human-answering-services/page.tsx
@@ -67,6 +67,7 @@ export default function Compare() {
         id="compare-human-answering"
       />
       <CompareLayout
+        sourcePage="compare_human_answering_services"
         alternativeName={ALT}
         title={`Ops by Noell vs. ${ALT}`}
         lead="Two ways to stop missing the phone. One is a person you&apos;ve never met reading a script. The other is a front desk layer installed in your voice, running 24/7."

--- a/src/app/compare/local-business-messaging-platforms/page.tsx
+++ b/src/app/compare/local-business-messaging-platforms/page.tsx
@@ -68,6 +68,7 @@ export default function Compare() {
         id="compare-lbp"
       />
       <CompareLayout
+        sourcePage="compare_local_business_messaging_platforms"
         alternativeName={ALT}
         title="Ops by Noell vs. broad local-business messaging platforms"
         lead="Two different philosophies. One is a wide platform your team operates. The other is a narrow, managed front desk layer that runs itself."

--- a/src/app/compare/my-ai-front-desk/page.tsx
+++ b/src/app/compare/my-ai-front-desk/page.tsx
@@ -67,6 +67,7 @@ export default function Compare() {
         id={`compare-my-ai-front-desk`}
       />
       <CompareLayout
+        sourcePage="compare_my_ai_front_desk"
         alternativeName={ALT}
         title={`Ops by Noell vs. ${ALT}`}
         lead="One is a done-for-you AI front desk managed by a small team. The other is a DIY AI receptionist product you configure yourself."

--- a/src/app/compare/podium/page.tsx
+++ b/src/app/compare/podium/page.tsx
@@ -67,6 +67,7 @@ export default function Compare() {
         id="compare-podium"
       />
       <CompareLayout
+        sourcePage="compare_podium"
         alternativeName={ALT}
         title={`Ops by Noell vs. ${ALT}`}
         lead="One is a done-for-you AI front desk managed end-to-end. The other is a broad messaging and reviews platform your team runs."

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -74,6 +74,7 @@ export default function Home() {
         headlineAccent="free 30-minute audit."
         body="No pitch. No pressure. A clear map of where leads are falling through, whether you work with us or not."
         trustLine="Free · 30 minutes · Live in 14 days"
+        sourcePage="home"
       />
     </div>
   );

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -246,7 +246,7 @@ export default function PricingPage() {
         faqs={pricingFaqs}
       />
 
-      <CTA />
+      <CTA sourcePage="pricing" />
     </div>
   );
 }

--- a/src/app/verticals/dental/page.tsx
+++ b/src/app/verticals/dental/page.tsx
@@ -290,6 +290,7 @@ export default function DentalVerticalPage() {
         primaryCta={{ label: "Get Your Free Dental Audit", href: "/book" }}
         secondaryCta={{ label: "See how it layers on your PMS", href: "#layers-on-pms" }}
         mockScreen={dentalScreen}
+        sourcePage="verticals_dental"
       />
 
       <VerticalAgentsCallout />
@@ -458,6 +459,7 @@ export default function DentalVerticalPage() {
           href: "/noell-support",
         }}
         trustLine="Free 30-minute audit · Live on your PMS in 14 days · No contracts"
+        sourcePage="verticals_dental"
       />
     </div>
   );

--- a/src/app/verticals/estheticians/page.tsx
+++ b/src/app/verticals/estheticians/page.tsx
@@ -347,6 +347,7 @@ export default function EstheticiansVerticalPage() {
           href: "/noell-support",
         }}
         trustLine="Free 30-minute audit · Live on your booking tool in 14 days · No contracts"
+        sourcePage="verticals_estheticians"
       />
     </div>
   );

--- a/src/app/verticals/hvac/page.tsx
+++ b/src/app/verticals/hvac/page.tsx
@@ -348,6 +348,7 @@ export default function HvacVerticalPage() {
           href: "/noell-support",
         }}
         trustLine="Free 30-minute audit · Live on your FSM in 14 days · No contracts"
+        sourcePage="verticals_hvac"
       />
     </div>
   );

--- a/src/app/verticals/massage/page.tsx
+++ b/src/app/verticals/massage/page.tsx
@@ -355,6 +355,7 @@ export default function MassageVerticalPage() {
           href: "/noell-support",
         }}
         trustLine="Free 30-minute audit · Live in 14 days · No contracts"
+        sourcePage="verticals_massage"
       />
     </div>
   );

--- a/src/app/verticals/med-spas/page.tsx
+++ b/src/app/verticals/med-spas/page.tsx
@@ -342,6 +342,7 @@ export default function MedSpasVerticalPage() {
           href: "/noell-support",
         }}
         trustLine="Free 30-minute audit · Live on your stack in 14 days · No contracts"
+        sourcePage="verticals_med_spas"
       />
     </div>
   );

--- a/src/app/verticals/page.tsx
+++ b/src/app/verticals/page.tsx
@@ -148,6 +148,10 @@ export default function VerticalsHubPage() {
                 key={v.slug}
                 id={v.slug}
                 href={v.href}
+                data-event="vertical_card_click"
+                data-source-page="verticals_index"
+                data-source-section="vertical_card"
+                data-vertical={v.slug}
                 className="block h-full scroll-mt-32"
               >
                 <div className="group relative rounded-[22px] border border-warm-border bg-white p-7 h-full flex flex-col transition-all duration-200 shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)] hover:-translate-y-1 hover:shadow-[0px_44px_24px_0px_rgba(28,25,23,0.06),0px_18px_18px_0px_rgba(28,25,23,0.08),0px_6px_10px_0px_rgba(28,25,23,0.06)]">
@@ -203,6 +207,7 @@ export default function VerticalsHubPage() {
           href: "/noell-support",
         }}
         trustLine="Free 30-minute audit · No contracts · Live in 14 days"
+        sourcePage="verticals_index"
       />
     </div>
   );

--- a/src/app/verticals/salons/page.tsx
+++ b/src/app/verticals/salons/page.tsx
@@ -342,6 +342,7 @@ export default function SalonsVerticalPage() {
           href: "/noell-support",
         }}
         trustLine="Free 30-minute audit · Live on your booking tool in 14 days · No contracts"
+        sourcePage="verticals_salons"
       />
     </div>
   );

--- a/src/components/book-exit-intent.tsx
+++ b/src/components/book-exit-intent.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { IconX } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
+import { trackConversion, ConversionEvents } from "@/lib/analytics";
 
 const STORAGE_KEY = "book-exit-shown";
 
@@ -29,6 +30,10 @@ export function BookExitIntent() {
       if (e.clientY <= 0) {
         setOpen(true);
         sessionStorage.setItem(STORAGE_KEY, "1");
+        trackConversion(ConversionEvents.AUDIT_EXIT_INTENT_SHOWN, {
+          source_page: "book",
+          source_section: "book_exit_intent",
+        });
       }
     };
 
@@ -48,6 +53,10 @@ export function BookExitIntent() {
       });
       if (!res.ok) throw new Error("send failed");
       setState("sent");
+      trackConversion(ConversionEvents.AUDIT_WORKSHEET_REQUEST, {
+        source_page: "book",
+        source_section: "book_exit_intent",
+      });
     } catch {
       setState("error");
     }

--- a/src/components/booking-embed.tsx
+++ b/src/components/booking-embed.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { IconMail, IconArrowRight } from "@tabler/icons-react";
+import { trackConversion, ConversionEvents } from "@/lib/analytics";
 
 /**
  * BookingEmbed, calendar scheduler embed with a branded loading state.
@@ -116,6 +117,15 @@ function BookingFallback() {
         <div className="flex flex-col sm:flex-row gap-3 justify-center max-w-md mx-auto">
           <a
             href="mailto:hello@opsbynoell.com?subject=Free%20audit%20request&body=Hi%20Nikki%2C%20I%27d%20like%20to%20book%20a%20free%20audit.%0A%0AName%3A%20%0ABusiness%3A%20%0APhone%3A%20%0ATimes%20that%20work%3A%20"
+            data-event="booking_fallback_email_click"
+            data-source-page="book"
+            data-source-section="booking_fallback"
+            onClick={() =>
+              trackConversion(ConversionEvents.BOOKING_FALLBACK_EMAIL_CLICK, {
+                source_page: "book",
+                source_section: "booking_fallback",
+              })
+            }
             className="inline-flex h-12 items-center justify-center gap-2 rounded-full bg-wine text-cream text-sm font-medium px-6 hover:bg-wine-dark transition-colors"
           >
             <IconMail size={16} aria-hidden="true" focusable="false" />

--- a/src/components/booking-lead-tracker.tsx
+++ b/src/components/booking-lead-tracker.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import { useEffect } from "react";
+import { trackConversion, ConversionEvents } from "@/lib/analytics";
 
 export function BookingLeadTracker() {
+  useEffect(() => {
+    trackConversion(ConversionEvents.AUDIT_PAGE_VIEW, {
+      source_page: "book",
+    });
+  }, []);
+
   useEffect(() => {
     const handler = (event: MessageEvent) => {
       const data = event.data;

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -9,6 +9,9 @@ type BaseProps = {
   children: React.ReactNode;
   className?: string;
   variant?: ButtonVariant;
+  "data-event"?: string;
+  "data-source-page"?: string;
+  "data-source-section"?: string;
 };
 
 type AnchorProps = BaseProps & {
@@ -61,6 +64,9 @@ const variantStyles: Record<ButtonVariant, string> = {
 
 export function Button(props: AnchorProps | ButtonProps) {
   const { variant = "primary", className, children } = props;
+  const dataEvent = props["data-event"];
+  const dataSourcePage = props["data-source-page"];
+  const dataSourceSection = props["data-source-section"];
   const composedClass = cn(baseStyles, variantStyles[variant], className);
 
   if ("href" in props && props.href !== undefined) {
@@ -74,13 +80,23 @@ export function Button(props: AnchorProps | ButtonProps) {
           onClick={onClick}
           target={href.startsWith("http") ? "_blank" : undefined}
           rel={href.startsWith("http") ? "noopener noreferrer" : undefined}
+          data-event={dataEvent}
+          data-source-page={dataSourcePage}
+          data-source-section={dataSourceSection}
         >
           {children}
         </a>
       );
     }
     return (
-      <NextLink href={href} className={composedClass} onClick={onClick}>
+      <NextLink
+        href={href}
+        className={composedClass}
+        onClick={onClick}
+        data-event={dataEvent}
+        data-source-page={dataSourcePage}
+        data-source-section={dataSourceSection}
+      >
         {children}
       </NextLink>
     );
@@ -88,7 +104,14 @@ export function Button(props: AnchorProps | ButtonProps) {
 
   const { type = "button", onClick } = props as ButtonProps;
   return (
-    <button type={type} className={composedClass} onClick={onClick}>
+    <button
+      type={type}
+      className={composedClass}
+      onClick={onClick}
+      data-event={dataEvent}
+      data-source-page={dataSourcePage}
+      data-source-section={dataSourceSection}
+    >
       {children}
     </button>
   );

--- a/src/components/compare-layout.tsx
+++ b/src/components/compare-layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import React from "react";
 import CTA from "@/components/cta";
+import type { SourcePage } from "@/lib/analytics";
 
 export type CompareRow = {
   capability: string;
@@ -16,6 +17,7 @@ export function CompareLayout({
   rows,
   verdict,
   internalLinks,
+  sourcePage = "compare_index",
 }: {
   alternativeName: string;
   title: string;
@@ -24,6 +26,7 @@ export function CompareLayout({
   rows: CompareRow[];
   verdict: React.ReactNode;
   internalLinks?: { label: string; href: string }[];
+  sourcePage?: SourcePage;
 }) {
   return (
     <div>
@@ -140,6 +143,8 @@ export function CompareLayout({
           href: "/systems",
         }}
         trustLine="Free 30-minute audit · Live in 14 days · No contracts"
+        sourcePage={sourcePage}
+        sourceSection="comparison_cta"
       />
     </div>
   );

--- a/src/components/cta.tsx
+++ b/src/components/cta.tsx
@@ -1,9 +1,13 @@
 "use client";
 import React from "react";
-import Link from "next/link";
 import { motion } from "motion/react";
 import { Button } from "./button";
 import { cn } from "@/lib/utils";
+import {
+  trackAuditCtaClick,
+  type SourcePage,
+  type SourceSection,
+} from "@/lib/analytics";
 
 export default function CTA({
   eyebrow = "The first step",
@@ -14,6 +18,8 @@ export default function CTA({
   secondaryCta = { label: "Talk to Noell Support first", href: "/noell-support" },
   trustLine = "Free 30-minute audit · No contracts required · Live in 14 days",
   accent = "wine",
+  sourcePage,
+  sourceSection = "final_cta",
 }: {
   eyebrow?: string;
   headlineStart?: string;
@@ -23,7 +29,17 @@ export default function CTA({
   secondaryCta?: { label: string; href: string };
   trustLine?: string;
   accent?: "wine" | "lilac";
+  sourcePage?: SourcePage;
+  sourceSection?: SourceSection;
 }) {
+  const handlePrimary = () => {
+    if (primaryCta.href === "/book") {
+      trackAuditCtaClick(sourcePage ?? "home", sourceSection, {
+        destination: primaryCta.href,
+        cta_label: primaryCta.label,
+      });
+    }
+  };
   const gradientBg =
     accent === "wine"
       ? "bg-gradient-to-br from-wine via-wine-light to-wine-dark"
@@ -72,6 +88,10 @@ export default function CTA({
               href={primaryCta.href}
               variant="secondary"
               className="h-12 px-8 bg-white text-charcoal hover:bg-cream"
+              onClick={handlePrimary}
+              data-event={primaryCta.href === "/book" ? "audit_cta_click" : undefined}
+              data-source-page={sourcePage}
+              data-source-section={sourceSection}
             >
               {primaryCta.label}
             </Button>
@@ -79,6 +99,8 @@ export default function CTA({
               href={secondaryCta.href}
               variant="secondary"
               className="h-12 px-8 bg-transparent border border-white/30 text-white hover:bg-white/10"
+              data-source-page={sourcePage}
+              data-source-section={sourceSection}
             >
               {secondaryCta.label}
             </Button>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -3,11 +3,15 @@ import React, { useRef } from "react";
 import { motion } from "motion/react";
 import { cn } from "@/lib/utils";
 import Balancer from "react-wrap-balancer";
-import Link from "next/link";
 import { Button } from "./button";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { IphoneMockup } from "./iphone-mockup";
 import { ProofBar } from "./proof-bar";
+import {
+  trackAuditCtaClick,
+  type SourcePage,
+  type SourceSection,
+} from "@/lib/analytics";
 
 export function Hero({
   eyebrow = "A systems agency · Ops by Noell",
@@ -24,6 +28,8 @@ export function Hero({
   showProofBar = true,
   priceSignal,
   headlineLine2Smaller = false,
+  sourcePage = "home",
+  sourceSection = "hero",
 }: {
   eyebrow?: string;
   variant?: "wine" | "lilac" | "sage";
@@ -39,7 +45,17 @@ export function Hero({
   showProofBar?: boolean;
   priceSignal?: React.ReactNode;
   headlineLine2Smaller?: boolean;
+  sourcePage?: SourcePage;
+  sourceSection?: SourceSection;
 }) {
+  const handlePrimaryCta = () => {
+    if (primaryCta.href === "/book") {
+      trackAuditCtaClick(sourcePage, sourceSection, {
+        destination: primaryCta.href,
+        cta_label: primaryCta.label,
+      });
+    }
+  };
   const parentRef = useRef<HTMLDivElement>(
     null
   ) as React.RefObject<HTMLDivElement>;
@@ -154,6 +170,10 @@ export function Hero({
           href={primaryCta.href}
           variant={variant === "lilac" ? "lilac" : "primary"}
           className="w-full sm:w-auto h-12 px-7"
+          onClick={handlePrimaryCta}
+          data-event={primaryCta.href === "/book" ? "audit_cta_click" : undefined}
+          data-source-page={sourcePage}
+          data-source-section={sourceSection}
         >
           {primaryCta.label}
         </Button>
@@ -161,6 +181,8 @@ export function Hero({
           href={secondaryCta.href}
           variant="secondary"
           className="w-full sm:w-auto h-12 px-7"
+          data-source-page={sourcePage}
+          data-source-section={sourceSection}
         >
           {secondaryCta.label}
         </Button>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import React, { useRef, useState } from "react";
 import { Button } from "./button";
 import { Logo } from "./logo";
+import { trackAuditCtaClick } from "@/lib/analytics";
 
 const VERTICAL_LINKS = [
   { name: "Dental Offices", href: "/verticals/dental" },
@@ -230,7 +231,19 @@ const DesktopNav = ({ navItems, visible }: NavbarProps) => {
             animate={{ opacity: 1, x: 0, transition: { duration: 0.2 } }}
             exit={{ opacity: 0, x: 20, transition: { duration: 0.2 } }}
           >
-            <Button href="/book" variant="primary">
+            <Button
+              href="/book"
+              variant="primary"
+              data-event="audit_cta_click"
+              data-source-page="navbar"
+              data-source-section="navbar_primary"
+              onClick={() =>
+                trackAuditCtaClick("navbar", "navbar_primary", {
+                  destination: "/book",
+                  cta_label: "Get Your Free Audit",
+                })
+              }
+            >
               Get Your Free Audit
             </Button>
           </motion.div>
@@ -323,6 +336,15 @@ const MobileNav = ({ navItems, visible }: NavbarProps) => {
               href="/book"
               variant="primary"
               className="w-full mt-2"
+              data-event="audit_cta_click"
+              data-source-page="navbar"
+              data-source-section="navbar_mobile"
+              onClick={() =>
+                trackAuditCtaClick("navbar", "navbar_mobile", {
+                  destination: "/book",
+                  cta_label: "Get Your Free Audit",
+                })
+              }
             >
               Get Your Free Audit
             </Button>

--- a/src/components/pick-your-path.tsx
+++ b/src/components/pick-your-path.tsx
@@ -1,7 +1,9 @@
+"use client";
 import React from "react";
 import Link from "next/link";
 import { IconCheck } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
+import { trackAuditCtaClick } from "@/lib/analytics";
 
 type CardProps = {
   eyebrow: string;
@@ -105,6 +107,18 @@ function Card({ card }: { card: CardProps }) {
         </p>
         <Link
           href={card.ctaHref}
+          onClick={() => {
+            if (card.ctaHref === "/book") {
+              trackAuditCtaClick("home", "pick_your_path", {
+                destination: card.ctaHref,
+                cta_label: card.ctaLabel,
+                path_choice: card.title,
+              });
+            }
+          }}
+          data-event={card.ctaHref === "/book" ? "audit_cta_click" : "pick_your_path_click"}
+          data-source-page="home"
+          data-source-section="pick_your_path"
           className={cn(
             "inline-flex w-full items-center justify-center rounded-[8px] h-12 px-6 text-sm font-medium transition-colors tap-target",
             card.highlighted

--- a/src/components/systems.tsx
+++ b/src/components/systems.tsx
@@ -75,6 +75,10 @@ export function Systems() {
             <Link
               key={index}
               href={agent.href}
+              data-event="systems_grid_click"
+              data-source-page="home"
+              data-source-section="systems_grid"
+              data-agent={agent.handle.replace(/^@/, "")}
               className={cn(
                 "group relative rounded-[22px] border border-warm-border bg-white",
                 "p-7 md:p-8 transition-all duration-200",

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,168 @@
+/**
+ * Conversion analytics — event names and emission helpers.
+ *
+ * Today these events route through Meta Pixel (the only analytics provider
+ * currently wired up). The helpers no-op safely when the pixel is missing.
+ *
+ * Keep the event name list in sync with docs/analytics.md.
+ *
+ * Why a thin layer on top of meta-pixel-track.ts:
+ *   - One import site for every conversion CTA in the app, so swapping
+ *     providers (GA4, PostHog, Segment, etc.) later is a single-file change.
+ *   - Stable event names + typed source attribution so the journey
+ *     homepage/vertical/comparison/pricing → /book can be rebuilt in any
+ *     analytics tool from a single dimension.
+ *   - Standard DOM `data-event` attribute can be added to elements we don't
+ *     wrap in JS handlers; a future provider can subscribe with a single
+ *     delegated click listener.
+ */
+
+import {
+  trackMetaEvent,
+  trackMetaCustomEvent,
+} from "@/lib/meta-pixel-track";
+
+/**
+ * Pages that originate conversion clicks. When a CTA points at /book (or a
+ * pricing tier CTA, or the support chat), include one of these so we can
+ * rebuild the funnel in the analytics tool.
+ */
+export type SourcePage =
+  | "home"
+  | "pricing"
+  | "book"
+  | "agents"
+  | "systems"
+  | "about"
+  | "contact"
+  | "roi"
+  | "noell_support"
+  | "noell_front_desk"
+  | "noell_care"
+  | "verticals_index"
+  | "verticals_dental"
+  | "verticals_med_spas"
+  | "verticals_salons"
+  | "verticals_massage"
+  | "verticals_estheticians"
+  | "verticals_hvac"
+  | "compare_index"
+  | "compare_my_ai_front_desk"
+  | "compare_podium"
+  | "compare_ai_front_desk_alternatives"
+  | "compare_diy_ai_receptionist"
+  | "compare_human_answering_services"
+  | "compare_local_business_messaging_platforms"
+  | "case_studies"
+  | "resources"
+  | "navbar"
+  | "footer"
+  | "global_chat";
+
+/**
+ * Semantic section where the click happened. Keep values kebab_case and
+ * short — they end up in the analytics UI as segmentation values.
+ */
+export type SourceSection =
+  | "hero"
+  | "final_cta"
+  | "pick_your_path"
+  | "systems_grid"
+  | "pricing_cards"
+  | "pricing_tier_cta"
+  | "comparison_cta"
+  | "vertical_card"
+  | "vertical_agents_callout"
+  | "navbar_primary"
+  | "navbar_mobile"
+  | "footer"
+  | "faq_exit"
+  | "book_exit_intent"
+  | "booking_fallback"
+  | "booking_embed"
+  | "audit_request_soft_exit"
+  | "founding_cta";
+
+/**
+ * The canonical conversion events. Narrow set on purpose — each has a
+ * concrete downstream action so they stay useful in dashboards.
+ */
+export const ConversionEvents = {
+  /** User clicked any CTA that leads to /book (audit request start). */
+  AUDIT_CTA_CLICK: "audit_cta_click",
+  /** User landed on /book page (funnel-entry marker). */
+  AUDIT_PAGE_VIEW: "audit_page_view",
+  /** User clicked a pricing tier CTA (already emitted as tier_card_click today). */
+  PRICING_TIER_CLICK: "tier_card_click",
+  /** Any pricing-page view event for segmentation. */
+  PRICING_PAGE_VIEW: "pricing_page_view",
+  /** User opened the audit worksheet exit-intent modal. */
+  AUDIT_EXIT_INTENT_SHOWN: "audit_exit_intent_shown",
+  /** User submitted the exit-intent worksheet email form. */
+  AUDIT_WORKSHEET_REQUEST: "audit_worksheet_request",
+  /** Booking fallback (manual scheduling) email CTA clicked. */
+  BOOKING_FALLBACK_EMAIL_CLICK: "booking_fallback_email_click",
+  /** Comparison page audit CTA clicked. */
+  COMPARISON_AUDIT_CTA_CLICK: "comparison_audit_cta_click",
+  /** User clicked a vertical card from the verticals hub. */
+  VERTICAL_CARD_CLICK: "vertical_card_click",
+  /** A Noell Agent ($197/mo) founding-member CTA click. */
+  AGENTS_FOUNDING_CTA_CLICK: "agents_founding_cta_click",
+} as const;
+
+export type ConversionEventName =
+  (typeof ConversionEvents)[keyof typeof ConversionEvents];
+
+export interface ConversionContext {
+  source_page?: SourcePage;
+  source_section?: SourceSection;
+  /** Destination href, if the click navigates. Useful for disambiguating /book variants. */
+  destination?: string;
+  /** Free-form extras, e.g. tier id, vertical slug. Keep keys snake_case. */
+  [key: string]: unknown;
+}
+
+/**
+ * Fire a conversion event. Currently sends a Meta Pixel custom event and,
+ * for primary audit CTAs, also fires the Meta standard `Contact` event so
+ * existing pixel-based audiences keep working unchanged.
+ */
+export function trackConversion(
+  event: ConversionEventName,
+  context: ConversionContext = {},
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    trackMetaCustomEvent(event, context);
+    if (event === ConversionEvents.AUDIT_CTA_CLICK) {
+      trackMetaEvent("Contact", {
+        content_name: "audit_request",
+        source_page: context.source_page,
+        source_section: context.source_section,
+      });
+    }
+    if (event === ConversionEvents.AUDIT_WORKSHEET_REQUEST) {
+      trackMetaEvent("Lead", {
+        content_name: "audit_worksheet",
+      });
+    }
+  } catch {
+    // Analytics must never break the UI.
+  }
+}
+
+/**
+ * Emit an audit-CTA click. Convenience wrapper used everywhere a link or
+ * button sends the visitor to /book.
+ */
+export function trackAuditCtaClick(
+  source_page: SourcePage,
+  source_section: SourceSection,
+  extras: Omit<ConversionContext, "source_page" | "source_section"> = {},
+): void {
+  trackConversion(ConversionEvents.AUDIT_CTA_CLICK, {
+    source_page,
+    source_section,
+    ...extras,
+  });
+}


### PR DESCRIPTION
## Summary

Adds non-invasive conversion instrumentation so the journey from homepage / vertical / comparison / pricing pages into `/book` — plus audit-request actions on `/book` itself — is visible in the existing Meta Pixel analytics. No visual changes and no public-copy changes.

- New `src/lib/analytics.ts` with a typed `ConversionEvents` map (`audit_cta_click`, `audit_page_view`, `audit_exit_intent_shown`, `audit_worksheet_request`, `booking_fallback_email_click`, alongside the already-emitted `tier_card_click` / `vertical_pricing_shown` / `faq_open`) and a `SourcePage` / `SourceSection` attribution taxonomy.
- `Button` forwards `data-event` / `data-source-page` / `data-source-section` to the rendered element so a future analytics provider can attach one delegated click listener without component edits.
- `CTA`, `Hero`, `PickYourPath`, `Systems`, `Navbar` (desktop + mobile) and the `CompareLayout` CTA now attach the attributes and fire `audit_cta_click` (plus Meta `Contact`) on clicks to `/book`, with attribution included.
- Every compare page and vertical page passes its `sourcePage` so the funnel can be segmented by entry surface.
- `/book` now fires `audit_page_view` on mount, `audit_exit_intent_shown` when the desktop exit modal opens, and `audit_worksheet_request` on successful worksheet submit. The manual booking fallback email link fires `booking_fallback_email_click`.
- `docs/analytics.md` documents the full event map, attribution taxonomy, Meta standard-event compatibility, the delegated-listener hook point for a future provider, and TODOs (server-side CAPI, optional GA4/PostHog).

### Provider assumption

Meta Pixel (`src/components/meta-pixel.tsx`, `NEXT_PUBLIC_META_PIXEL_ID`) is the only analytics provider currently wired up; all new events route through `trackMetaCustomEvent`, which no-ops safely when the pixel is absent. No new third-party integration is added — the docs note how to add one in a single-file change.

## Test plan

- [x] `npm run build` — succeeds, all routes compile, no TS errors.
- [x] `npx eslint` on every changed file — clean. (The 2 pre-existing `react/no-unescaped-entities` warnings in `hero.tsx:319-320` are unrelated, inside the Santa mock text.)
- [ ] `npm test` — blocked in this environment (Node 20; the test runner uses `--experimental-strip-types`, which needs Node 22). No test files were changed.
- [ ] After merge: verify in the Meta Pixel Helper that `audit_cta_click` fires on a hero CTA click with the expected `source_page` / `source_section` payload.