### PR TITLE
feat(ghl): inbound visitor-SMS bridge with outbound reply

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,9 +32,11 @@ GHL_API_KEY=
 # the `x-vercel-cron` header must send Authorization: Bearer <CRON_SECRET>)
 CRON_SECRET=
 
-# Two-way SMS reply bridge — webhook secret for POST /api/ghl/inbound-sms
+# Two-way SMS reply bridge — webhook secret used by BOTH GHL inbound routes:
+#   - POST /api/ghl/inbound-sms           (owner replies to alert SMS)
+#   - POST /api/ghl/inbound-visitor-sms   (leads/customers texting the LC Phone)
 # Generate with: openssl rand -hex 32
-# Paste the same value as the ?secret= query param in the LC workflow webhook URL.
+# Paste the same value as the ?secret= query param in each LC workflow webhook URL.
 GHL_WEBHOOK_SECRET=
 
 # Meta Pixel (client-side analytics for Facebook / Instagram ads)

--- a/docs/inbound-visitor-sms.md
+++ b/docs/inbound-visitor-sms.md
@@ -1,0 +1,136 @@
+# Inbound Visitor-SMS Bridge
+
+When a lead or customer texts a client's LC Phone number, this bridge:
+
+1. Receives the inbound via a GHL webhook
+2. Resolves which client owns the destination LC Phone
+3. Stores the message in `front_desk_messages` and generates a reply via
+   the shared runner (escalation rules, Telegram alert, owner SMS alert
+   still fire normally)
+4. Sends the bot's reply back to the visitor over the client's
+   configured messaging integration (GHL SMS, GHL WhatsApp, or generic)
+
+This is distinct from [`docs/two-way-sms.md`](./two-way-sms.md), which
+handles the **owner's** reply to an alert SMS, not new inbound from
+leads.
+
+---
+
+## Endpoint
+
+```
+POST /api/ghl/inbound-visitor-sms?secret=<GHL_WEBHOOK_SECRET>
+```
+
+Accepted request bodies (same aliases as the owner-reply route):
+
+```json
+{
+  "phone":          "+17145550123",    // visitor / lead
+  "toNumber":       "+19499973915",    // the client's LC Phone
+  "body":           "hi, any openings today?",
+  "contactId":      "<optional>",
+  "conversationId": "<optional>"
+}
+```
+
+LC workflow aliases `from` / `to` / `message` are also accepted.
+
+---
+
+## Client resolution
+
+Each client that accepts inbound visitor SMS must have
+`clients.sms_config.fromNumber` set to the LC Phone in E.164 format.
+The route queries:
+
+```
+clients?sms_config->>fromNumber=eq.<toNumber>&active=eq.true
+```
+
+If no active client matches, the route returns `{ok:false,reason:"no_client_for_to_phone"}`
+with HTTP 200 (so GHL does not retry-storm).
+
+---
+
+## Response shape
+
+```json
+{
+  "ok": true,
+  "sessionId": "<uuid>",
+  "reply": "<bot reply text>",
+  "replySent": true,
+  "replyMessageId": "<provider message id>",
+  "replyError": null,
+  "escalated": false,
+  "intent": "warm"
+}
+```
+
+Non-2xx is avoided so GHL's retry logic does not loop.
+
+---
+
+## GHL dashboard / webhook config (still required)
+
+These steps are NOT automated by the code — they must be performed in
+the GHL dashboard before inbound visitor SMS will route to the bot:
+
+1. **Automations → Workflows → New Workflow**
+2. **Trigger:** *Customer Reply* → filter `Channel = SMS` and
+   `Direction = Inbound` (the direction filter is **critical** — without
+   it, outbound bot replies will loop back into the webhook)
+3. **Action: Webhook**
+   - Method: `POST`
+   - URL: `https://www.opsbynoell.com/api/ghl/inbound-visitor-sms?secret=<GHL_WEBHOOK_SECRET>`
+   - Body format: `application/json`
+   - Body:
+     ```json
+     {
+       "phone":          "{{contact.phone}}",
+       "toNumber":       "{{message.to_number}}",
+       "body":           "{{message.body}}",
+       "contactId":      "{{contact.id}}",
+       "conversationId": "{{conversation.id}}"
+     }
+     ```
+4. Save and **Publish**.
+
+**Important:** This workflow must be published per-client sub-account
+(Healing Hands, Ops by Noell, etc.) — each has its own LC Phone. The
+same `GHL_WEBHOOK_SECRET` can be reused across sub-accounts because the
+route resolves the client from `toNumber`, not from the secret.
+
+---
+
+## Manual test plan
+
+1. Confirm `clients.sms_config.fromNumber` is populated for the target client.
+2. Text the client's LC Phone from a mobile device.
+3. Expected: bot reply arrives via SMS, and a row appears in
+   `front_desk_sessions` with `trigger_type = 'inbound_text'` and
+   `channel = 'sms'`.
+4. cURL smoke test:
+   ```bash
+   curl -s -X POST \
+     "https://www.opsbynoell.com/api/ghl/inbound-visitor-sms?secret=<SECRET>" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "phone": "+17145550123",
+       "toNumber": "+19499973915",
+       "body": "test from curl"
+     }' | jq .
+   ```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `{ok:false,reason:"unauthorized"}` | Wrong `?secret=` — mismatch between Vercel env var and webhook URL |
+| `{ok:false,reason:"no_client_for_to_phone"}` | `clients.sms_config.fromNumber` is missing or a different number |
+| `{ok:true,replySent:false,replyError:"empty_reply"}` | Bot returned no text (human_takeover or model refusal) |
+| Bot replies show up in inbox but visitor never receives them | Outbound SMS integration mis-configured — check `sms_provider` + `sms_config` on the `clients` row |
+| Webhook fires in a loop | Direction filter missing — add `Direction = Inbound` to the workflow trigger |

--- a/src/app/api/ghl/inbound-visitor-sms/route.ts
+++ b/src/app/api/ghl/inbound-visitor-sms/route.ts
@@ -1,0 +1,171 @@
+/**
+ * POST /api/ghl/inbound-visitor-sms
+ *
+ * Inbound SMS bridge for LEADS / CUSTOMERS texting a client's LC Phone
+ * number. Distinct from /api/ghl/inbound-sms, which handles the OWNER's
+ * reply to an alert SMS.
+ *
+ * Flow
+ * ----
+ *   1. Visitor sends SMS to client's LC Phone (e.g. +1 949-997-3915)
+ *   2. GHL Conversations webhook POSTs the inbound event to this route
+ *      with ?secret=<GHL_WEBHOOK_SECRET>
+ *   3. We resolve the client by matching the `toNumber` against
+ *      `clients.sms_config.fromNumber`
+ *   4. runTurn() stores the visitor message in front_desk_messages,
+ *      generates a Claude reply, and applies escalation rules
+ *   5. If the reply is non-empty and human_takeover is off, we send the
+ *      reply back to the visitor over the client's configured SMS
+ *      integration
+ *
+ * Auth
+ * ----
+ * Shared secret ?secret=<GHL_WEBHOOK_SECRET> — same scheme as
+ * /api/ghl/inbound-sms. Configure the value in Vercel.
+ *
+ * Webhook body (either shape accepted):
+ *   GHL Conversations:  { phone, toNumber, body, contactId?, conversationId? }
+ *   LC workflow:        { from, to, message }
+ *
+ * Deploy-side config required
+ * ---------------------------
+ *   - `GHL_WEBHOOK_SECRET` env var set in Vercel
+ *   - Each client that accepts inbound visitor SMS must have
+ *     `clients.sms_config.fromNumber` populated with the LC Phone in E.164
+ *   - A GHL workflow or Conversations webhook configured to POST to this
+ *     route when a NEW inbound SMS arrives on the client's LC Phone —
+ *     filtered to Direction = Inbound so outbound sends do not loop back
+ *
+ * This route is intentionally thin — all the logic lives in
+ * src/lib/agents/inbound-visitor-sms-handler.ts (unit-tested).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { env } from "@/lib/agents/env";
+import { getClientConfig } from "@/lib/agents/config";
+import {
+  buildOutboundVisitorReplyPayload,
+  dispatchVisitorReply,
+  extractInboundVisitorPayload,
+  findClientIdByInboundToPhone,
+} from "@/lib/agents/inbound-visitor-sms-handler";
+import { getSmsIntegration } from "@/lib/agents/integrations/registry";
+import { runTurn } from "@/lib/agents/runner";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest): Promise<Response> {
+  // ── Auth ──────────────────────────────────────────────────────────────────
+  const expectedSecret = env.ghlWebhookSecret();
+  const providedSecret = req.nextUrl.searchParams.get("secret");
+
+  if (!expectedSecret || providedSecret !== expectedSecret) {
+    console.warn("[inbound-visitor-sms] rejected — bad or missing secret");
+    // 200 so GHL does not retry storm on auth misconfig.
+    return NextResponse.json(
+      { ok: false, reason: "unauthorized" },
+      { status: 200 }
+    );
+  }
+
+  // ── Parse body ────────────────────────────────────────────────────────────
+  let rawBody: Record<string, unknown>;
+  try {
+    rawBody = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json(
+      { ok: false, reason: "bad_json" },
+      { status: 200 }
+    );
+  }
+
+  const payload = extractInboundVisitorPayload(rawBody);
+  if (!payload) {
+    console.warn(
+      "[inbound-visitor-sms] missing phones in payload — ignoring",
+      rawBody
+    );
+    return NextResponse.json(
+      { ok: false, reason: "missing_phones" },
+      { status: 200 }
+    );
+  }
+
+  // ── Resolve client by LC Phone (toNumber) ─────────────────────────────────
+  let clientId: string | null;
+  try {
+    clientId = await findClientIdByInboundToPhone(payload.toPhone);
+  } catch (err) {
+    console.error("[inbound-visitor-sms] client lookup failed:", err);
+    return NextResponse.json(
+      { ok: false, reason: "db_error" },
+      { status: 200 }
+    );
+  }
+  if (!clientId) {
+    console.warn(
+      `[inbound-visitor-sms] no client configured for toPhone=${payload.toPhone} — ignoring`
+    );
+    return NextResponse.json(
+      { ok: false, reason: "no_client_for_to_phone" },
+      { status: 200 }
+    );
+  }
+
+  // ── Generate the reply via the shared runner ──────────────────────────────
+  let runResult;
+  try {
+    runResult = await runTurn({
+      agent: "frontDesk",
+      payload: {
+        clientId,
+        agent: "frontDesk",
+        channel: "sms",
+        from: { phone: payload.fromPhone },
+        message: payload.messageText,
+      },
+      tables: {
+        sessions: "front_desk_sessions",
+        messages: "front_desk_messages",
+      },
+      defaultTriggerType: "inbound_text",
+    });
+  } catch (err) {
+    console.error("[inbound-visitor-sms] runTurn failed:", err);
+    return NextResponse.json(
+      { ok: false, reason: "run_turn_failed" },
+      { status: 200 }
+    );
+  }
+
+  // ── Dispatch outbound reply (when appropriate) ────────────────────────────
+  const cfg = await getClientConfig(clientId);
+  const out = buildOutboundVisitorReplyPayload({
+    cfg,
+    agent: "frontDesk",
+    sessionId: runResult.sessionId,
+    visitorPhone: payload.fromPhone,
+    replyText: runResult.reply,
+  });
+
+  // An empty reply means human_takeover was on OR the model produced no
+  // text. Either way — do not send anything back.
+  const dispatch = out.body
+    ? await dispatchVisitorReply(out, cfg, { getSms: getSmsIntegration })
+    : { sent: false, error: "empty_reply" as const };
+
+  return NextResponse.json(
+    {
+      ok: true,
+      sessionId: runResult.sessionId,
+      reply: runResult.reply,
+      replySent: dispatch.sent,
+      replyMessageId: dispatch.messageId,
+      replyError: dispatch.error,
+      escalated: runResult.escalated,
+      intent: runResult.intent,
+    },
+    { status: 200 }
+  );
+}

--- a/src/lib/agents/inbound-visitor-sms-handler.test.ts
+++ b/src/lib/agents/inbound-visitor-sms-handler.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for the inbound-visitor-SMS bridge (pure logic).
+ *
+ * Covers:
+ *   - extractInboundVisitorPayload  — normalises GHL + LC webhook shapes
+ *   - findClientIdByInboundToPhone  — resolves client by sms_config.fromNumber
+ *   - buildOutboundVisitorReplyPayload — shape of the outbound send
+ *   - dispatchVisitorReply  — fail-soft around the SMS integration
+ */
+
+import { strict as assert } from "node:assert";
+import { mock, test } from "node:test";
+
+// ── Supabase mocks ─────────────────────────────────────────────────────────
+
+const sbSelectCalls: Array<{
+  table: string;
+  params: Record<string, unknown>;
+  options: Record<string, unknown> | undefined;
+}> = [];
+
+let mockClientRows: Array<Record<string, unknown>> = [];
+
+mock.module("./supabase.ts", {
+  namedExports: {
+    sbSelect: async (
+      table: string,
+      params: Record<string, unknown>,
+      options?: Record<string, unknown>
+    ) => {
+      sbSelectCalls.push({ table, params, options });
+      if (table === "clients") return mockClientRows;
+      return [];
+    },
+    sbInsert: async (_t: string, row: Record<string, unknown>) => ({
+      id: "x",
+      ...row,
+    }),
+    sbUpdate: async () => [],
+    sbUpsert: async () => ({}),
+  },
+});
+
+const {
+  extractInboundVisitorPayload,
+  findClientIdByInboundToPhone,
+  buildOutboundVisitorReplyPayload,
+  dispatchVisitorReply,
+} = await import("./inbound-visitor-sms-handler.ts");
+
+import type { ClientConfig, MessagingIntegration } from "./types.ts";
+
+// ── extractInboundVisitorPayload ───────────────────────────────────────────
+
+test("extractInboundVisitorPayload: GHL Conversations shape", () => {
+  const p = extractInboundVisitorPayload({
+    phone: "+17145550123",
+    toNumber: "+19499973915",
+    body: "hi, do you have any openings today?",
+    contactId: "ghl_contact_123",
+    conversationId: "ghl_conv_456",
+  });
+  assert.ok(p);
+  assert.equal(p.fromPhone, "+17145550123");
+  assert.equal(p.toPhone, "+19499973915");
+  assert.equal(p.messageText, "hi, do you have any openings today?");
+  assert.equal(p.contactId, "ghl_contact_123");
+  assert.equal(p.conversationId, "ghl_conv_456");
+});
+
+test("extractInboundVisitorPayload: LC workflow aliases", () => {
+  const p = extractInboundVisitorPayload({
+    from: "+17145550123",
+    to: "+19499973915",
+    message: "alias form",
+  });
+  assert.ok(p);
+  assert.equal(p.fromPhone, "+17145550123");
+  assert.equal(p.toPhone, "+19499973915");
+  assert.equal(p.messageText, "alias form");
+  assert.equal(p.contactId, undefined);
+  assert.equal(p.conversationId, undefined);
+});
+
+test("extractInboundVisitorPayload: accepts snake_case id aliases", () => {
+  const p = extractInboundVisitorPayload({
+    phone: "+17145550123",
+    toNumber: "+19499973915",
+    body: "hi",
+    contact_id: "c_123",
+    conversation_id: "conv_456",
+  });
+  assert.ok(p);
+  assert.equal(p.contactId, "c_123");
+  assert.equal(p.conversationId, "conv_456");
+});
+
+test("extractInboundVisitorPayload: null when fromPhone missing", () => {
+  assert.equal(
+    extractInboundVisitorPayload({ toNumber: "+19499973915", body: "x" }),
+    null
+  );
+});
+
+test("extractInboundVisitorPayload: null when toPhone missing", () => {
+  // Unlike owner-reply (which can fall back to recent session), visitor-SMS
+  // routing REQUIRES the destination to locate the client.
+  assert.equal(
+    extractInboundVisitorPayload({ phone: "+17145550123", body: "x" }),
+    null
+  );
+});
+
+test("extractInboundVisitorPayload: messageText defaults to empty string", () => {
+  const p = extractInboundVisitorPayload({
+    phone: "+17145550123",
+    toNumber: "+19499973915",
+  });
+  assert.ok(p);
+  assert.equal(p.messageText, "");
+});
+
+// ── findClientIdByInboundToPhone ───────────────────────────────────────────
+
+test("findClientIdByInboundToPhone: queries by sms_config->>fromNumber and active=true", async () => {
+  sbSelectCalls.length = 0;
+  mockClientRows = [
+    { client_id: "santa", sms_config: { fromNumber: "+19499973915" } },
+  ];
+
+  const id = await findClientIdByInboundToPhone("+19499973915");
+  assert.equal(id, "santa");
+
+  assert.equal(sbSelectCalls.length, 1);
+  const call = sbSelectCalls[0];
+  assert.equal(call.table, "clients");
+  const params = call.params as Record<string, string>;
+  assert.equal(params["sms_config->>fromNumber"], "eq.+19499973915");
+  assert.equal(params.active, "eq.true");
+  assert.equal((call.options as { limit?: number }).limit, 1);
+});
+
+test("findClientIdByInboundToPhone: returns null when no client matches", async () => {
+  sbSelectCalls.length = 0;
+  mockClientRows = [];
+  const id = await findClientIdByInboundToPhone("+10000000000");
+  assert.equal(id, null);
+});
+
+// ── buildOutboundVisitorReplyPayload ───────────────────────────────────────
+
+const stubCfg: ClientConfig = {
+  clientId: "santa",
+  businessName: "Healing Hands by Santa",
+  vertical: "massage",
+  agents: { support: false, frontDesk: true, care: false },
+  active: true,
+};
+
+test("buildOutboundVisitorReplyPayload: returns to/body/agent/sessionId/clientId", () => {
+  const out = buildOutboundVisitorReplyPayload({
+    cfg: stubCfg,
+    agent: "frontDesk",
+    sessionId: "sess-xyz",
+    visitorPhone: "+17145550123",
+    replyText: "Hi! Yes, I have 2pm open today.",
+  });
+  assert.deepEqual(out, {
+    to: "+17145550123",
+    body: "Hi! Yes, I have 2pm open today.",
+    agent: "frontDesk",
+    sessionId: "sess-xyz",
+    clientId: "santa",
+  });
+});
+
+test("buildOutboundVisitorReplyPayload: trims whitespace around reply text", () => {
+  const out = buildOutboundVisitorReplyPayload({
+    cfg: stubCfg,
+    agent: "frontDesk",
+    sessionId: "sess-xyz",
+    visitorPhone: "+17145550123",
+    replyText: "   hello  \n",
+  });
+  assert.equal(out.body, "hello");
+});
+
+test("buildOutboundVisitorReplyPayload: empty reply becomes empty body (caller must skip)", () => {
+  const out = buildOutboundVisitorReplyPayload({
+    cfg: stubCfg,
+    agent: "frontDesk",
+    sessionId: "sess-xyz",
+    visitorPhone: "+17145550123",
+    replyText: "",
+  });
+  assert.equal(out.body, "");
+});
+
+// ── dispatchVisitorReply ───────────────────────────────────────────────────
+
+function stubSms(behavior: {
+  sendSMS: (to: string, body: string) => Promise<{ messageId: string }>;
+}): MessagingIntegration {
+  return {
+    sendSMS: behavior.sendSMS,
+  };
+}
+
+test("dispatchVisitorReply: returns sent:true with messageId on success", async () => {
+  const calls: Array<{ to: string; body: string }> = [];
+  const sms = stubSms({
+    sendSMS: async (to, body) => {
+      calls.push({ to, body });
+      return { messageId: "msg_sent_1" };
+    },
+  });
+  const r = await dispatchVisitorReply(
+    {
+      to: "+17145550123",
+      body: "hi!",
+      agent: "frontDesk",
+      sessionId: "sess-1",
+      clientId: "santa",
+    },
+    stubCfg,
+    { getSms: () => sms }
+  );
+  assert.equal(r.sent, true);
+  assert.equal(r.messageId, "msg_sent_1");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].to, "+17145550123");
+  assert.equal(calls[0].body, "hi!");
+});
+
+test("dispatchVisitorReply: empty body short-circuits with empty_reply", async () => {
+  let called = false;
+  const sms = stubSms({
+    sendSMS: async () => {
+      called = true;
+      return { messageId: "should_not_happen" };
+    },
+  });
+  const r = await dispatchVisitorReply(
+    {
+      to: "+17145550123",
+      body: "",
+      agent: "frontDesk",
+      sessionId: "sess-1",
+      clientId: "santa",
+    },
+    stubCfg,
+    { getSms: () => sms }
+  );
+  assert.equal(r.sent, false);
+  assert.equal(r.error, "empty_reply");
+  assert.equal(called, false, "sendSMS must NOT be called when body is empty");
+});
+
+test("dispatchVisitorReply: fails soft when sendSMS throws", async () => {
+  const sms = stubSms({
+    sendSMS: async () => {
+      throw new Error("ghl sms send failed: 422 boom");
+    },
+  });
+  const r = await dispatchVisitorReply(
+    {
+      to: "+17145550123",
+      body: "hi",
+      agent: "frontDesk",
+      sessionId: "sess-1",
+      clientId: "santa",
+    },
+    stubCfg,
+    { getSms: () => sms }
+  );
+  assert.equal(r.sent, false);
+  assert.match(r.error ?? "", /422 boom/);
+});

--- a/src/lib/agents/inbound-visitor-sms-handler.ts
+++ b/src/lib/agents/inbound-visitor-sms-handler.ts
@@ -1,0 +1,207 @@
+/**
+ * Inbound visitor-SMS bridge — core handler logic.
+ *
+ * Distinct from inbound-sms-handler.ts:
+ *   - inbound-sms-handler      — owner replies to alert SMS (Nikki → LC Phone)
+ *   - inbound-visitor-sms      — a lead / customer texts the LC Phone (new or
+ *                                existing conversation)
+ *
+ * On each inbound visitor SMS we:
+ *   1. Resolve which client owns the LC Phone (by `sms_config.fromNumber`)
+ *   2. Call runTurn() to persist the visitor message and generate a reply
+ *   3. If human_takeover is on OR the reply is empty, skip the outbound
+ *   4. Otherwise, send the bot's reply back to the visitor via the
+ *      configured messaging integration
+ *
+ * This module stays pure — no Next.js imports — so it can be unit tested
+ * with mocks for Supabase / the messaging integration.
+ */
+
+import { sbSelect } from "./supabase";
+import type { AgentKind, ClientConfig, MessagingIntegration } from "./types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface InboundVisitorSmsPayload {
+  /** The visitor / lead phone number (E.164). */
+  fromPhone: string;
+  /** The LC Phone number that received the SMS (E.164) — used to resolve client. */
+  toPhone: string;
+  /** Message body as sent by the visitor. */
+  messageText: string;
+  /** Optional GHL contact id, when the webhook supplies it. */
+  contactId?: string;
+  /** Optional GHL conversation id, when the webhook supplies it. */
+  conversationId?: string;
+}
+
+export interface OutboundVisitorSmsPayload {
+  /** E.164 visitor destination. */
+  to: string;
+  /** Rendered reply text. */
+  body: string;
+  /** Agent kind — drives logging + downstream analytics. */
+  agent: AgentKind;
+  /** Session id for observability. */
+  sessionId: string;
+  /** Client id the send belongs to. */
+  clientId: string;
+}
+
+export type InboundVisitorSmsResult =
+  | {
+      ok: true;
+      sessionId: string;
+      /** The bot reply text (or empty when human_takeover suppressed it). */
+      reply: string;
+      /** True if the reply was actually dispatched over SMS. */
+      replySent: boolean;
+      /** Optional upstream provider message id for the outbound SMS. */
+      replyMessageId?: string;
+      /** Populated when the outbound send failed but message was stored. */
+      replyError?: string;
+    }
+  | { ok: false; reason: string };
+
+// ---------------------------------------------------------------------------
+// Payload extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalise a GHL / LeadConnector Conversations webhook body into the
+ * shape we need.
+ *
+ * GHL Conversations webhook (primary):
+ *   { phone, toNumber, body, contactId?, conversationId? }
+ *
+ * LC workflow action (alternate aliases):
+ *   { from, to, message }
+ *
+ * Returns null when either phone is missing — we can't route without both.
+ */
+export function extractInboundVisitorPayload(
+  body: Record<string, unknown>
+): InboundVisitorSmsPayload | null {
+  const fromPhone =
+    (body.phone as string | undefined) ??
+    (body.from as string | undefined) ??
+    null;
+
+  const toPhone =
+    (body.toNumber as string | undefined) ??
+    (body.to as string | undefined) ??
+    null;
+
+  const messageText =
+    (body.body as string | undefined) ??
+    (body.message as string | undefined) ??
+    "";
+
+  const contactId =
+    (body.contactId as string | undefined) ??
+    (body.contact_id as string | undefined) ??
+    undefined;
+
+  const conversationId =
+    (body.conversationId as string | undefined) ??
+    (body.conversation_id as string | undefined) ??
+    undefined;
+
+  if (!fromPhone || !toPhone) return null;
+  return { fromPhone, toPhone, messageText, contactId, conversationId };
+}
+
+// ---------------------------------------------------------------------------
+// Client resolution by LC Phone number
+// ---------------------------------------------------------------------------
+
+interface ClientSmsIndexRow {
+  client_id: string;
+  sms_config: Record<string, unknown> | null;
+}
+
+/**
+ * Find a client whose `sms_config.fromNumber` matches the destination phone
+ * number. PostgREST JSONB filter syntax: `sms_config->>fromNumber=eq.<E.164>`.
+ *
+ * Returns the `client_id` of the first match, or null when no client is
+ * configured for that LC Phone.
+ *
+ * NOTE: We intentionally select by the narrow pair of fields rather than
+ * pulling the full config — getClientConfig() will fetch + memoize the full
+ * row afterwards.
+ */
+export async function findClientIdByInboundToPhone(
+  toPhone: string
+): Promise<string | null> {
+  const rows = await sbSelect<ClientSmsIndexRow>(
+    "clients",
+    { "sms_config->>fromNumber": `eq.${toPhone}`, active: "eq.true" },
+    { limit: 1, select: "client_id,sms_config" }
+  );
+  return rows[0]?.client_id ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Outbound payload construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the outbound-reply payload that would be handed to the messaging
+ * integration. Extracted as a pure function so tests can assert the exact
+ * shape without touching fetch / network.
+ */
+export function buildOutboundVisitorReplyPayload(params: {
+  cfg: ClientConfig;
+  agent: AgentKind;
+  sessionId: string;
+  visitorPhone: string;
+  replyText: string;
+}): OutboundVisitorSmsPayload {
+  const body = (params.replyText ?? "").trim();
+  return {
+    to: params.visitorPhone,
+    body,
+    agent: params.agent,
+    sessionId: params.sessionId,
+    clientId: params.cfg.clientId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch helper — send the bot's reply over the configured channel.
+// ---------------------------------------------------------------------------
+
+export interface DispatchDeps {
+  /** Factory — returns the messaging integration for a client. Injected for testing. */
+  getSms(cfg: ClientConfig): MessagingIntegration;
+}
+
+/**
+ * Send the outbound reply to the visitor. Fails soft — any error is
+ * returned in `replyError` so the caller can persist a record of it
+ * without propagating a 500 to GHL (which would cause retry storms).
+ */
+export async function dispatchVisitorReply(
+  out: OutboundVisitorSmsPayload,
+  cfg: ClientConfig,
+  deps: DispatchDeps
+): Promise<{ sent: boolean; messageId?: string; error?: string }> {
+  if (!out.body) {
+    return { sent: false, error: "empty_reply" };
+  }
+  try {
+    const sms = deps.getSms(cfg);
+    const { messageId } = await sms.sendSMS(out.to, out.body);
+    return { sent: true, messageId };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[inbound-visitor-sms] outbound reply failed for session=${out.sessionId}:`,
+      message
+    );
+    return { sent: false, error: message };
+  }
+}


### PR DESCRIPTION
## Summary

Completes the GHL inbound/outbound SMS bridge by adding a new webhook for **visitor / lead** inbound texts. Complements the existing owner-reply bridge at `/api/ghl/inbound-sms`.

- `POST /api/ghl/inbound-visitor-sms?secret=<GHL_WEBHOOK_SECRET>`
- Resolves the client by matching `toNumber` against `clients.sms_config.fromNumber` (active clients only)
- Persists the visitor message via the shared `runTurn` path (escalation rules, Telegram / email / owner-alert SMS all fire normally)
- Sends the bot's reply back to the visitor through the client's configured messaging integration (GHL SMS / GHL WhatsApp / generic)
- Fails soft with HTTP 200 and a `reason` field so GHL never retry-storms

### Files
- `src/lib/agents/inbound-visitor-sms-handler.ts` — pure helpers: `extractInboundVisitorPayload`, `findClientIdByInboundToPhone`, `buildOutboundVisitorReplyPayload`, `dispatchVisitorReply`
- `src/lib/agents/inbound-visitor-sms-handler.test.ts` — 14 unit tests (payload extraction across GHL / LC-alias shapes, client resolution PostgREST filter, outbound payload shape + whitespace trim, dispatch fail-soft)
- `src/app/api/ghl/inbound-visitor-sms/route.ts` — thin Next.js route
- `docs/inbound-visitor-sms.md` — workflow setup, response shape, troubleshooting
- `.env.example` — clarifies `GHL_WEBHOOK_SECRET` covers both inbound routes

### Why a second route (instead of extending `/api/ghl/inbound-sms`)
Safety: the owner-reply route looks up `sms_alert_sessions` and on a miss currently no-ops. Silently falling through to AI-replying to any unknown sender could send an AI response to the owner when the mapping row is stale or missing. A dedicated route keeps the two flows explicitly separated.

## Still requires GHL dashboard / webhook config (NOT automated)

These are deliberately NOT touched by this PR — they must be done in the GHL dashboard before visitor inbound routing works:

1. **Set `clients.sms_config.fromNumber`** for every client that should accept inbound visitor SMS — e.g. `'+19499973915'` for Ops by Noell, `'+1...'` for Healing Hands once the LC Phone is provisioned.
2. **Create a GHL workflow per sub-account:**
   - Trigger: Customer Reply → `Channel = SMS` + `Direction = Inbound` (direction filter is critical — without it, outbound bot replies will loop back in)
   - Action: Webhook POST to `https://www.opsbynoell.com/api/ghl/inbound-visitor-sms?secret=<GHL_WEBHOOK_SECRET>` with body `{phone, toNumber, body, contactId, conversationId}`
   - Publish
3. **Set `GHL_WEBHOOK_SECRET`** in Vercel (already required for the existing owner-reply route — same secret works).
4. **Private Integration Token scope check:** existing GHL PIT must have `conversations/message.write` (already needed by `GhlSms`/`GhlWhatsapp`). No new scopes required by this PR.

Full setup in `docs/inbound-visitor-sms.md`.

## Test plan

- [x] `npx tsc --noEmit` — clean for the new source files
- [x] `npx eslint` on the new files — clean
- [x] `npx next build` — new route registered as `ƒ /api/ghl/inbound-visitor-sms`
- [ ] `npm test` — requires Node 22 (`--experimental-strip-types`) which the sandbox lacks; tests follow the exact same pattern as `inbound-sms-webhook.test.ts` and should run cleanly in CI
- [ ] Manual cURL smoke test against a staging deploy after env var + GHL workflow are configured (documented in `docs/inbound-visitor-sms.md`)

## What is intentionally NOT in this PR

- No public site copy changes
- No change to GHL dashboard / webhook config
- No deploys
- No changes to the existing `/api/ghl/inbound-sms` (owner-reply) route — additive only

🤖 Generated with [Claude Code](https://claude.com/claude-code)