### PR TITLE
feat(pci): v1 ingestion helpers + manual signal-generation admin endpoint

### DIFF
--- a/src/app/admin/pci/page.tsx
+++ b/src/app/admin/pci/page.tsx
@@ -77,6 +77,28 @@ function prettyType(t: string): string {
   return t.replaceAll("_", " ");
 }
 
+interface GenerateRuleResult {
+  rule: string;
+  scanned: number;
+  drafts: number;
+  created: number;
+  skipped_existing: number;
+  events_written: number;
+}
+
+interface GenerateResponse {
+  dryRun: boolean;
+  now: string;
+  results: GenerateRuleResult[];
+  totals: {
+    scanned: number;
+    drafts: number;
+    created: number;
+    skipped_existing: number;
+    events_written: number;
+  };
+}
+
 export default function PciDashboard() {
   const router = useRouter();
   const [signals, setSignals] = useState<Signal[]>([]);
@@ -85,6 +107,9 @@ export default function PciDashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [me, setMe] = useState<MeResponse | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [lastGenerate, setLastGenerate] = useState<GenerateResponse | null>(null);
+  const [generateError, setGenerateError] = useState("");
 
   useEffect(() => {
     fetch("/api/admin/me")
@@ -133,6 +158,44 @@ export default function PciDashboard() {
     const interval = setInterval(fetchSignals, 10_000);
     return () => clearInterval(interval);
   }, [fetchSignals, me]);
+
+  const runGenerate = useCallback(
+    async (dryRun: boolean) => {
+      if (generating) return;
+      setGenerating(true);
+      setGenerateError("");
+      try {
+        const body: Record<string, unknown> = { dryRun };
+        if (me?.isSuperAdmin && clientFilter !== "all") {
+          body.clientIds = [clientFilter];
+        }
+        const res = await fetch("/api/admin/pci/generate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (res.status === 401) {
+          router.replace("/admin/login");
+          return;
+        }
+        const data = (await res.json()) as GenerateResponse | { error: string };
+        if (!res.ok || "error" in data) {
+          setGenerateError(
+            "error" in data ? data.error : "Signal generation failed."
+          );
+          return;
+        }
+        setLastGenerate(data);
+        // If we actually persisted, refresh the open-signals list.
+        if (!dryRun) await fetchSignals();
+      } catch {
+        setGenerateError("Signal generation failed.");
+      } finally {
+        setGenerating(false);
+      }
+    },
+    [generating, me, clientFilter, router, fetchSignals]
+  );
 
   const clientIds = me?.isSuperAdmin
     ? Array.from(new Set(signals.map((s) => s.client_id))).sort()
@@ -212,8 +275,68 @@ export default function PciDashboard() {
               ))}
             </select>
           )}
+
+          <div className="flex items-center gap-1.5 pl-2 border-l border-warm-border">
+            <button
+              type="button"
+              onClick={() => runGenerate(true)}
+              disabled={generating}
+              className="text-xs px-2.5 py-1.5 rounded-lg border border-warm-border bg-white hover:bg-cream text-charcoal disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              title="Preview what signals would be created without writing to the database."
+            >
+              {generating ? "Scanning…" : "Preview (dry run)"}
+            </button>
+            <button
+              type="button"
+              onClick={() => runGenerate(false)}
+              disabled={generating}
+              className="text-xs px-2.5 py-1.5 rounded-lg bg-wine text-white hover:bg-wine/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              title="Run rules against existing records and persist new signals."
+            >
+              {generating ? "Generating…" : "Generate signals"}
+            </button>
+          </div>
         </div>
       </div>
+
+      {(lastGenerate || generateError) && (
+        <div className="bg-cream/60 border-b border-warm-border px-6 py-2 shrink-0 text-xs">
+          {generateError ? (
+            <p className="text-red-600">{generateError}</p>
+          ) : lastGenerate ? (
+            <div className="flex items-center gap-3 text-charcoal/70">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-charcoal/40">
+                {lastGenerate.dryRun ? "Dry run" : "Generated"}
+              </span>
+              <span>
+                scanned <strong>{lastGenerate.totals.scanned}</strong>
+              </span>
+              <span>
+                drafts <strong>{lastGenerate.totals.drafts}</strong>
+              </span>
+              <span>
+                created <strong>{lastGenerate.totals.created}</strong>
+              </span>
+              <span>
+                skipped{" "}
+                <strong>{lastGenerate.totals.skipped_existing}</strong>
+              </span>
+              <span className="text-charcoal/40">
+                events {lastGenerate.totals.events_written}
+              </span>
+              <div className="flex gap-2 ml-2 text-charcoal/50">
+                {lastGenerate.results
+                  .filter((r) => r.drafts > 0)
+                  .map((r) => (
+                    <span key={r.rule} className="font-mono text-[10px]">
+                      {r.rule}:{r.drafts}
+                    </span>
+                  ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      )}
 
       <div className="flex-1 overflow-y-auto">
         {loading ? (

--- a/src/app/api/admin/pci/generate/route.ts
+++ b/src/app/api/admin/pci/generate/route.ts
@@ -1,0 +1,60 @@
+/**
+ * POST /api/admin/pci/generate
+ *
+ * Operator-triggered PCI signal generation. Reads existing agent
+ * domain tables and upserts `customer_events` + `customer_signals` via
+ * the pure rule functions. This is the **manual** path — no cron is
+ * wired, no outbound messages are sent, no GHL handoff is invoked.
+ *
+ * Authorization:
+ *   - Caller must have a valid admin session cookie (verifyToken).
+ *   - Non-super-admins are scoped to their `accessibleClients`.
+ *   - Super admins may pass `clientIds` explicitly; omitting scans all.
+ *
+ * Body (JSON, all optional):
+ *   {
+ *     "dryRun": boolean,                 // default: true (safe default)
+ *     "rules":   SupportedRule[],        // subset of SUPPORTED_RULES
+ *     "clientIds": string[],             // super-admin only
+ *     "limit":    number                 // 1..500, default 200
+ *   }
+ *
+ * The actual logic lives in src/lib/pci/generate-handler.ts so it is
+ * testable without NextRequest/NextResponse. This file is a thin
+ * adapter.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { verifyToken, COOKIE_NAME } from "@/lib/admin-auth";
+import { handleGenerate } from "@/lib/pci/generate-handler";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const token = req.cookies.get(COOKIE_NAME)?.value;
+  const session = await verifyToken(token);
+
+  let body: unknown = null;
+  try {
+    const raw = await req.text();
+    if (raw.trim().length > 0) body = JSON.parse(raw);
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body." },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const result = await handleGenerate({ session, body });
+    return NextResponse.json(result.body, { status: result.status });
+  } catch (e) {
+    console.error("[admin/pci/generate] failed:", e);
+    return NextResponse.json(
+      { error: "Signal generation failed." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/pci/events.ts
+++ b/src/lib/pci/events.ts
@@ -10,7 +10,7 @@
  * try/catch or fire-and-forget pattern as appropriate.
  */
 
-import { sbInsert, sbSelect } from "@/lib/agents/supabase";
+import { sbInsert, sbSelect } from "../agents/supabase";
 import type { AgentSource, CustomerEvent, CustomerEventType } from "./types";
 
 const TABLE = "customer_events";

--- a/src/lib/pci/generate-handler.test.ts
+++ b/src/lib/pci/generate-handler.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Authorization + input-validation tests for the PCI /generate handler.
+ *
+ * Tests the scope rules:
+ *   - No session     → 401
+ *   - Non-super-admin + clientIds in body → 403
+ *   - Non-super-admin → always scoped to accessibleClients
+ *   - Super admin + no body clientIds → runs with null (all clients)
+ *   - Super admin + body clientIds → runs with that exact list
+ *
+ * And the input validation:
+ *   - dryRun defaults to TRUE
+ *   - unknown rule → 400
+ *   - empty rules[] → 400
+ *   - limit out of range → 400
+ *
+ * The generator is stubbed — we only care that the handler wires the
+ * right arguments through.
+ */
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { handleGenerate } from "./generate-handler.ts";
+import type { GenerateOptions, GenerateResult } from "./ingest.ts";
+import type { AdminTokenPayload } from "../admin-auth.ts";
+
+const EMPTY_RESULT: GenerateResult = {
+  dryRun: true,
+  now: "2026-04-24T12:00:00Z",
+  results: [],
+  totals: {
+    scanned: 0,
+    drafts: 0,
+    created: 0,
+    skipped_existing: 0,
+    events_written: 0,
+  },
+};
+
+function stubRun(): {
+  run: (opts: GenerateOptions) => Promise<GenerateResult>;
+  calls: GenerateOptions[];
+} {
+  const calls: GenerateOptions[] = [];
+  return {
+    calls,
+    run: async (opts: GenerateOptions) => {
+      calls.push(opts);
+      return { ...EMPTY_RESULT, dryRun: opts.dryRun ?? true };
+    },
+  };
+}
+
+function superAdmin(): AdminTokenPayload {
+  return {
+    userId: "u-super",
+    email: "super@example.com",
+    isSuperAdmin: true,
+    accessibleClients: [],
+    exp: Date.now() + 60_000,
+  };
+}
+
+function scopedAdmin(clients: string[]): AdminTokenPayload {
+  return {
+    userId: "u-scoped",
+    email: "scoped@example.com",
+    isSuperAdmin: false,
+    accessibleClients: clients,
+    exp: Date.now() + 60_000,
+  };
+}
+
+// ── Authorization ─────────────────────────────────────────────────
+
+test("handleGenerate: no session → 401", async () => {
+  const { run, calls } = stubRun();
+  const res = await handleGenerate({ session: null, body: {}, run });
+  assert.equal(res.status, 401);
+  assert.equal(calls.length, 0);
+});
+
+test("handleGenerate: non-super trying to pass clientIds → 403", async () => {
+  const { run, calls } = stubRun();
+  const res = await handleGenerate({
+    session: scopedAdmin(["c1"]),
+    body: { clientIds: ["c2"] },
+    run,
+  });
+  assert.equal(res.status, 403);
+  assert.equal(calls.length, 0);
+});
+
+test("handleGenerate: non-super → scope forced to accessibleClients", async () => {
+  const { run, calls } = stubRun();
+  const res = await handleGenerate({
+    session: scopedAdmin(["c1", "c2"]),
+    body: {},
+    run,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0].client_ids, ["c1", "c2"]);
+});
+
+test("handleGenerate: super admin without clientIds → null scope (all clients)", async () => {
+  const { run, calls } = stubRun();
+  const res = await handleGenerate({
+    session: superAdmin(),
+    body: {},
+    run,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(calls[0].client_ids, null);
+});
+
+test("handleGenerate: super admin with clientIds → that exact list", async () => {
+  const { run, calls } = stubRun();
+  const res = await handleGenerate({
+    session: superAdmin(),
+    body: { clientIds: ["c1"] },
+    run,
+  });
+  assert.equal(res.status, 200);
+  assert.deepEqual(calls[0].client_ids, ["c1"]);
+});
+
+test("handleGenerate: super admin + non-array clientIds → 400", async () => {
+  const { run } = stubRun();
+  const res = await handleGenerate({
+    session: superAdmin(),
+    body: { clientIds: "c1" },
+    run,
+  });
+  assert.equal(res.status, 400);
+});
+
+test("handleGenerate: super admin + clientIds with empty string → 400", async () => {
+  const { run } = stubRun();
+  const res = await handleGenerate({
+    session: superAdmin(),
+    body: { clientIds: [""] },
+    run,
+  });
+  assert.equal(res.status, 400);
+});
+
+// ── Input validation ─────────────────────────────────────────────
+
+test("handleGenerate: dryRun defaults TRUE when omitted", async () => {
+  const { run, calls } = stubRun();
+  await handleGenerate({
+    session: superAdmin(),
+    body: {},
+    run,
+  });
+  assert.equal(calls[0].dryRun, true);
+});
+
+test("handleGenerate: dryRun=false is honored", async () => {
+  const { run, calls } = stubRun();
+  await handleGenerate({
+    session: superAdmin(),
+    body: { dryRun: false },
+    run,
+  });
+  assert.equal(calls[0].dryRun, false);
+});
+
+test("handleGenerate: any non-boolean dryRun falls back to safe TRUE", async () => {
+  const { run, calls } = stubRun();
+  await handleGenerate({
+    session: superAdmin(),
+    body: { dryRun: "no" },
+    run,
+  });
+  assert.equal(calls[0].dryRun, true);
+});
+
+test("handleGenerate: unknown rule → 400", async () => {
+  const { run } = stubRun();
+  const res = await handleGenerate({
+    session: superAdmin(),
+    body: { rules: ["bogus_rule"] },
+    run,
+  });
+  assert.equal(res.status, 400);
+});
+
+test("handleGenerate: empty rules[] → 400", async () => {
+  const { run } = stubRun();
+  const res = await handleGenerate({
+    session: superAdmin(),
+    body: { rules: [] },
+    run,
+  });
+  assert.equal(res.status, 400);
+});
+
+test("handleGenerate: valid rules subset propagates", async () => {
+  const { run, calls } = stubRun();
+  await handleGenerate({
+    session: superAdmin(),
+    body: { rules: ["missed_call_unbooked", "no_show_risk"] },
+    run,
+  });
+  assert.deepEqual(calls[0].rules, ["missed_call_unbooked", "no_show_risk"]);
+});
+
+test("handleGenerate: limit out of range → 400", async () => {
+  const { run } = stubRun();
+  const res1 = await handleGenerate({
+    session: superAdmin(),
+    body: { limit: 0 },
+    run,
+  });
+  assert.equal(res1.status, 400);
+  const res2 = await handleGenerate({
+    session: superAdmin(),
+    body: { limit: 501 },
+    run,
+  });
+  assert.equal(res2.status, 400);
+});
+
+test("handleGenerate: limit within range is honored", async () => {
+  const { run, calls } = stubRun();
+  await handleGenerate({
+    session: superAdmin(),
+    body: { limit: 25 },
+    run,
+  });
+  assert.equal(calls[0].limit, 25);
+});

--- a/src/lib/pci/generate-handler.ts
+++ b/src/lib/pci/generate-handler.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure request handler behind POST /api/admin/pci/generate.
+ *
+ * Split out from the Next.js route so the authorization + scoping +
+ * body-validation logic is unit-testable without constructing
+ * NextRequest / NextResponse objects. The route (see
+ * src/app/api/admin/pci/generate/route.ts) is a thin adapter.
+ */
+
+import {
+  generateSignals,
+  isSupportedRule,
+  SUPPORTED_RULES,
+  type GenerateResult,
+  type SupportedRule,
+} from "./ingest";
+import type { AdminTokenPayload } from "../admin-auth";
+
+export interface GenerateHandlerInput {
+  /** Verified admin session payload, or `null` when the caller is unauthenticated. */
+  session: AdminTokenPayload | null;
+  /** Parsed JSON body (or `null` when none). */
+  body: unknown;
+  /**
+   * Injected generator. Tests pass a stub; the route uses the real
+   * `generateSignals`. Must accept the same options shape as ingest.ts.
+   */
+  run?: typeof generateSignals;
+}
+
+export interface GenerateHandlerResponse {
+  status: number;
+  body: GenerateResult | { error: string };
+}
+
+function err(status: number, message: string): GenerateHandlerResponse {
+  return { status, body: { error: message } };
+}
+
+export async function handleGenerate(
+  input: GenerateHandlerInput
+): Promise<GenerateHandlerResponse> {
+  if (!input.session) return err(401, "Unauthorized");
+
+  const raw = input.body as
+    | {
+        dryRun?: unknown;
+        rules?: unknown;
+        clientIds?: unknown;
+        limit?: unknown;
+      }
+    | null
+    | undefined;
+  const body = raw ?? {};
+
+  // dryRun defaults TRUE — explicit `false` required to persist.
+  const dryRun = body.dryRun === false ? false : true;
+
+  // rules — validated subset of SUPPORTED_RULES.
+  let rules: readonly SupportedRule[] = SUPPORTED_RULES;
+  if (body.rules !== undefined) {
+    if (!Array.isArray(body.rules)) return err(400, "rules must be an array.");
+    const cleaned: SupportedRule[] = [];
+    for (const r of body.rules) {
+      if (typeof r !== "string" || !isSupportedRule(r)) {
+        return err(400, `Unsupported rule: ${String(r)}`);
+      }
+      cleaned.push(r);
+    }
+    if (cleaned.length === 0) return err(400, "rules must be non-empty.");
+    rules = cleaned;
+  }
+
+  // limit — 1..500, default 200.
+  let limit = 200;
+  if (body.limit !== undefined) {
+    const n =
+      typeof body.limit === "number"
+        ? body.limit
+        : parseInt(String(body.limit), 10);
+    if (!Number.isFinite(n) || n < 1 || n > 500) {
+      return err(400, "limit must be a number between 1 and 500.");
+    }
+    limit = Math.floor(n);
+  }
+
+  // Scope:
+  //   super admin → may pass clientIds; omitting means "all clients" (null).
+  //   non-super   → forced to accessibleClients; clientIds body is forbidden.
+  let client_ids: string[] | null;
+  if (input.session.isSuperAdmin) {
+    if (body.clientIds === undefined) {
+      client_ids = null;
+    } else {
+      if (!Array.isArray(body.clientIds)) {
+        return err(400, "clientIds must be an array of strings.");
+      }
+      const ids: string[] = [];
+      for (const id of body.clientIds) {
+        if (typeof id !== "string" || id.length === 0) {
+          return err(400, "clientIds must be an array of non-empty strings.");
+        }
+        ids.push(id);
+      }
+      client_ids = ids;
+    }
+  } else {
+    if (body.clientIds !== undefined) {
+      return err(403, "Only super admins may set clientIds.");
+    }
+    client_ids = input.session.accessibleClients;
+  }
+
+  const runner = input.run ?? generateSignals;
+  const result = await runner({ client_ids, rules, limit, dryRun });
+  return { status: 200, body: result };
+}

--- a/src/lib/pci/ingest.test.ts
+++ b/src/lib/pci/ingest.test.ts
@@ -1,0 +1,542 @@
+/**
+ * Tests for PCI v1 ingestion:
+ *   1. Pure mappers from agent rows → EventDraft / SignalDraft
+ *   2. generateSignals() with mocked sbSelect/sbInsert — the DB-backed
+ *      runner's scoping, dryRun behavior, and duplicate handling
+ *
+ * The mock strategy matches the pattern used in
+ * admin-invite-handler.test.ts: mock the supabase module *before*
+ * importing the module under test, then re-import fresh state per test.
+ */
+
+import { strict as assert } from "node:assert";
+import { mock, test } from "node:test";
+
+// ── DB stubs shared across tests ───────────────────────────────────
+
+type SelectCall = { table: string; params: Record<string, unknown> };
+type InsertCall = { table: string; row: Record<string, unknown> };
+
+const selectCalls: SelectCall[] = [];
+const insertCalls: InsertCall[] = [];
+
+// Script each sbSelect call by table → next-rows-to-return.
+let selectQueue: Array<{ table: string; rows: unknown[] }> = [];
+
+mock.module("../agents/supabase.ts", {
+  namedExports: {
+    sbSelect: async (table: string, params: Record<string, unknown>) => {
+      selectCalls.push({ table, params });
+      // Find the first queued response for this table.
+      const idx = selectQueue.findIndex((q) => q.table === table);
+      if (idx >= 0) {
+        const [hit] = selectQueue.splice(idx, 1);
+        return hit.rows;
+      }
+      return [];
+    },
+    sbInsert: async (table: string, row: Record<string, unknown>) => {
+      insertCalls.push({ table, row });
+      return { id: `row-${insertCalls.length}`, ...row };
+    },
+    sbUpdate: async () => [],
+    sbUpsert: async () => ({}),
+    sbRpc: async () => ({}),
+  },
+});
+
+// Module under test (after mocks wired).
+const {
+  frontDeskSessionToEvent,
+  careSessionToEvent,
+  appointmentToEvents,
+  warmLeadDraftFromFrontDesk,
+  missedCallDraftFromFrontDesk,
+  noShowDraftFromAppointment,
+  reviewReadyDraftFromAppointment,
+  rebookDraftFromContact,
+  lapsedDraftFromContact,
+  isSupportedRule,
+  SUPPORTED_RULES,
+  generateSignals,
+} = await import("./ingest.ts");
+
+const NOW = new Date("2026-04-24T12:00:00Z");
+const hoursAgo = (h: number) =>
+  new Date(NOW.getTime() - h * 60 * 60 * 1000).toISOString();
+const daysAgo = (d: number) =>
+  new Date(NOW.getTime() - d * 24 * 60 * 60 * 1000).toISOString();
+const hoursFromNow = (h: number) =>
+  new Date(NOW.getTime() + h * 60 * 60 * 1000).toISOString();
+
+function resetCalls() {
+  selectCalls.length = 0;
+  insertCalls.length = 0;
+  selectQueue = [];
+}
+
+// ──────────────────────────────────────────────────────────────────
+// 1. Pure mapping tests
+// ──────────────────────────────────────────────────────────────────
+
+test("frontDeskSessionToEvent: missed_call → missed_call event", () => {
+  const ev = frontDeskSessionToEvent({
+    id: "sess-1",
+    client_id: "c1",
+    trigger_type: "missed_call",
+    intent: null,
+    visitor_phone: "+15551230000",
+    visitor_email: null,
+    appointment_id: null,
+    created_at: hoursAgo(2),
+  });
+  assert.ok(ev);
+  assert.equal(ev.event_type, "missed_call");
+  assert.equal(ev.event_source, "front_desk_sessions");
+  assert.equal(ev.agent_source, "front_desk");
+  assert.equal(ev.session_id, "sess-1");
+  assert.equal(ev.channel, "voice");
+});
+
+test("frontDeskSessionToEvent: hot intent non-missed-call → lead_intent_detected", () => {
+  const ev = frontDeskSessionToEvent({
+    id: "sess-2",
+    client_id: "c1",
+    trigger_type: "inbound_chat",
+    intent: "hot",
+    visitor_phone: null,
+    visitor_email: null,
+    appointment_id: null,
+    created_at: hoursAgo(1),
+  });
+  assert.ok(ev);
+  assert.equal(ev.event_type, "lead_intent_detected");
+});
+
+test("frontDeskSessionToEvent: low intent non-missed-call → null", () => {
+  const ev = frontDeskSessionToEvent({
+    id: "sess-3",
+    client_id: "c1",
+    trigger_type: "inbound_text",
+    intent: "low",
+    visitor_phone: null,
+    visitor_email: null,
+    appointment_id: null,
+    created_at: hoursAgo(1),
+  });
+  assert.equal(ev, null);
+});
+
+test("careSessionToEvent: warm intent → lead_intent_detected", () => {
+  const ev = careSessionToEvent({
+    id: "care-1",
+    client_id: "c1",
+    contact_id: "contact-1",
+    trigger_type: "website_chat",
+    intent: "warm",
+    created_at: hoursAgo(5),
+  });
+  assert.ok(ev);
+  assert.equal(ev.event_type, "lead_intent_detected");
+  assert.equal(ev.agent_source, "care");
+  assert.equal(ev.contact_id, "contact-1");
+});
+
+test("appointmentToEvents: confirmed appt emits booked + confirmed", () => {
+  const events = appointmentToEvents({
+    id: "appt-1",
+    client_id: "c1",
+    visitor_phone: null,
+    visitor_email: null,
+    scheduled_at: hoursFromNow(10),
+    status: "confirmed",
+    service_type: null,
+    updated_at: hoursAgo(1),
+  });
+  const types = events.map((e) => e.event_type).sort();
+  assert.deepEqual(types, ["appointment_booked", "appointment_confirmed"]);
+});
+
+test("appointmentToEvents: completed appt emits booked + completed", () => {
+  const events = appointmentToEvents({
+    id: "appt-2",
+    client_id: "c1",
+    visitor_phone: null,
+    visitor_email: null,
+    scheduled_at: hoursAgo(24),
+    status: "completed",
+    service_type: null,
+    updated_at: hoursAgo(23),
+  });
+  const types = events.map((e) => e.event_type).sort();
+  assert.deepEqual(types, ["appointment_booked", "appointment_completed"]);
+});
+
+test("warmLeadDraftFromFrontDesk: hot w/ no booking past window → draft", () => {
+  const draft = warmLeadDraftFromFrontDesk(
+    {
+      id: "sess-1",
+      client_id: "c1",
+      trigger_type: "inbound_chat",
+      intent: "hot",
+      visitor_phone: null,
+      visitor_email: null,
+      appointment_id: null,
+      created_at: hoursAgo(30),
+    },
+    "contact-1",
+    NOW
+  );
+  assert.ok(draft);
+  assert.equal(draft.signal_type, "warm_lead_risk");
+  assert.equal(draft.severity, "high");
+  assert.equal(draft.contact_id, "contact-1");
+  assert.equal(draft.source_table, "front_desk_sessions");
+});
+
+test("warmLeadDraftFromFrontDesk: booking present → null", () => {
+  const draft = warmLeadDraftFromFrontDesk(
+    {
+      id: "sess-1",
+      client_id: "c1",
+      trigger_type: "inbound_chat",
+      intent: "hot",
+      visitor_phone: null,
+      visitor_email: null,
+      appointment_id: "appt-1",
+      created_at: hoursAgo(30),
+    },
+    null,
+    NOW
+  );
+  assert.equal(draft, null);
+});
+
+test("missedCallDraftFromFrontDesk: unbooked past window → draft", () => {
+  const draft = missedCallDraftFromFrontDesk(
+    {
+      id: "sess-1",
+      client_id: "c1",
+      trigger_type: "missed_call",
+      intent: null,
+      visitor_phone: null,
+      visitor_email: null,
+      appointment_id: null,
+      created_at: hoursAgo(6),
+    },
+    null,
+    NOW
+  );
+  assert.ok(draft);
+  assert.equal(draft.signal_type, "missed_call_unbooked");
+});
+
+test("noShowDraftFromAppointment: unconfirmed appt in window → draft", () => {
+  const draft = noShowDraftFromAppointment(
+    {
+      id: "appt-1",
+      client_id: "c1",
+      visitor_phone: null,
+      visitor_email: null,
+      scheduled_at: hoursFromNow(6),
+      status: "pending",
+      service_type: null,
+      updated_at: hoursAgo(1),
+    },
+    null,
+    false,
+    NOW
+  );
+  assert.ok(draft);
+  assert.equal(draft.signal_type, "no_show_risk");
+});
+
+test("noShowDraftFromAppointment: confirmed appt → null", () => {
+  const draft = noShowDraftFromAppointment(
+    {
+      id: "appt-1",
+      client_id: "c1",
+      visitor_phone: null,
+      visitor_email: null,
+      scheduled_at: hoursFromNow(6),
+      status: "confirmed",
+      service_type: null,
+      updated_at: hoursAgo(1),
+    },
+    null,
+    true,
+    NOW
+  );
+  assert.equal(draft, null);
+});
+
+test("reviewReadyDraftFromAppointment: completed, no prior review → draft", () => {
+  const draft = reviewReadyDraftFromAppointment(
+    {
+      id: "appt-1",
+      client_id: "c1",
+      visitor_phone: null,
+      visitor_email: null,
+      scheduled_at: hoursAgo(30),
+      status: "completed",
+      service_type: null,
+      updated_at: daysAgo(2),
+    },
+    null,
+    false,
+    NOW
+  );
+  assert.ok(draft);
+  assert.equal(draft.signal_type, "review_ready");
+});
+
+test("rebookDraftFromContact: past cadence → draft", () => {
+  const draft = rebookDraftFromContact(
+    {
+      id: "contact-1",
+      client_id: "c1",
+      phone: "+1555",
+      email: null,
+      last_visit_at: daysAgo(50),
+      usual_rebook_cadence_days: 30,
+    },
+    false,
+    NOW
+  );
+  assert.ok(draft);
+  assert.equal(draft.signal_type, "rebook_due");
+});
+
+test("lapsedDraftFromContact: past default threshold → draft", () => {
+  const draft = lapsedDraftFromContact(
+    {
+      id: "contact-1",
+      client_id: "c1",
+      phone: "+1555",
+      email: null,
+      last_visit_at: daysAgo(90),
+      usual_rebook_cadence_days: null,
+    },
+    60,
+    false,
+    NOW
+  );
+  assert.ok(draft);
+  assert.equal(draft.signal_type, "lapsed_client");
+});
+
+test("isSupportedRule: accepts known, rejects unknown", () => {
+  assert.ok(isSupportedRule("warm_lead_risk"));
+  assert.ok(isSupportedRule("review_ready"));
+  assert.ok(!isSupportedRule("bogus_rule"));
+  assert.ok(!isSupportedRule("owner_followup_needed"));
+});
+
+test("SUPPORTED_RULES covers the v1 rule set", () => {
+  assert.deepEqual([...SUPPORTED_RULES].sort(), [
+    "lapsed_client",
+    "missed_call_unbooked",
+    "no_show_risk",
+    "rebook_due",
+    "review_ready",
+    "warm_lead_risk",
+  ]);
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 2. generateSignals() — DB-backed runner with mocked sbSelect
+// ──────────────────────────────────────────────────────────────────
+
+test("generateSignals: empty client_ids list short-circuits every rule", async () => {
+  resetCalls();
+  const result = await generateSignals({
+    client_ids: [],
+    rules: SUPPORTED_RULES,
+    now: NOW,
+    dryRun: true,
+  });
+  assert.equal(result.totals.scanned, 0);
+  assert.equal(result.totals.drafts, 0);
+  assert.equal(result.totals.created, 0);
+  assert.equal(selectCalls.length, 0);
+  assert.equal(insertCalls.length, 0);
+});
+
+test("generateSignals: dryRun=true does not insert even with firing drafts", async () => {
+  resetCalls();
+  // Queue the single SELECT that missed_call_unbooked will fire.
+  selectQueue = [
+    {
+      table: "front_desk_sessions",
+      rows: [
+        {
+          id: "sess-1",
+          client_id: "c1",
+          trigger_type: "missed_call",
+          intent: null,
+          visitor_phone: "+15551230000",
+          visitor_email: null,
+          appointment_id: null,
+          created_at: hoursAgo(6),
+        },
+      ],
+    },
+    // findContactIdByPhoneEmail → no match
+    { table: "client_contacts", rows: [] },
+  ];
+
+  const result = await generateSignals({
+    client_ids: ["c1"],
+    rules: ["missed_call_unbooked"],
+    now: NOW,
+    dryRun: true,
+  });
+
+  assert.equal(result.dryRun, true);
+  assert.equal(result.results.length, 1);
+  assert.equal(result.results[0].rule, "missed_call_unbooked");
+  assert.equal(result.results[0].scanned, 1);
+  assert.equal(result.results[0].drafts, 1);
+  assert.equal(result.results[0].created, 0);
+  assert.equal(
+    insertCalls.length,
+    0,
+    "dryRun must never insert into the database"
+  );
+});
+
+test("generateSignals: dryRun=false writes signals via upsert path", async () => {
+  resetCalls();
+  selectQueue = [
+    {
+      table: "front_desk_sessions",
+      rows: [
+        {
+          id: "sess-1",
+          client_id: "c1",
+          trigger_type: "missed_call",
+          intent: null,
+          visitor_phone: null,
+          visitor_email: null,
+          appointment_id: null,
+          created_at: hoursAgo(6),
+        },
+      ],
+    },
+    // upsertSignalFromDraft → openSignalFor does a select; return empty.
+    { table: "customer_signals", rows: [] },
+  ];
+
+  const result = await generateSignals({
+    client_ids: ["c1"],
+    rules: ["missed_call_unbooked"],
+    now: NOW,
+    dryRun: false,
+  });
+
+  assert.equal(result.dryRun, false);
+  assert.equal(result.results[0].drafts, 1);
+  // We expect at least one event write and one signal insert when not dryRun.
+  const signalInserts = insertCalls.filter((c) => c.table === "customer_signals");
+  const eventInserts = insertCalls.filter((c) => c.table === "customer_events");
+  assert.equal(signalInserts.length, 1);
+  assert.equal(eventInserts.length, 1);
+  assert.equal(result.results[0].created, 1);
+});
+
+test("generateSignals: scopes selects with client_id IN filter for non-null allowlist", async () => {
+  resetCalls();
+  selectQueue = [
+    { table: "front_desk_sessions", rows: [] }, // missed_call
+  ];
+
+  await generateSignals({
+    client_ids: ["c1", "c2"],
+    rules: ["missed_call_unbooked"],
+    now: NOW,
+    dryRun: true,
+  });
+
+  // First select should target front_desk_sessions and carry the IN filter.
+  const firstSelect = selectCalls[0];
+  assert.ok(firstSelect);
+  assert.equal(firstSelect.table, "front_desk_sessions");
+  assert.equal(firstSelect.params.client_id, "in.(c1,c2)");
+  assert.equal(firstSelect.params.trigger_type, "eq.missed_call");
+});
+
+test("generateSignals: null client_ids means no client filter (super admin)", async () => {
+  resetCalls();
+  selectQueue = [{ table: "front_desk_sessions", rows: [] }];
+
+  await generateSignals({
+    client_ids: null,
+    rules: ["missed_call_unbooked"],
+    now: NOW,
+    dryRun: true,
+  });
+
+  const firstSelect = selectCalls[0];
+  assert.ok(firstSelect);
+  assert.equal(firstSelect.params.client_id, undefined);
+});
+
+test("generateSignals: existing open signal is counted as skipped_existing, not created", async () => {
+  resetCalls();
+  selectQueue = [
+    {
+      table: "front_desk_sessions",
+      rows: [
+        {
+          id: "sess-1",
+          client_id: "c1",
+          trigger_type: "missed_call",
+          intent: null,
+          visitor_phone: null,
+          visitor_email: null,
+          appointment_id: null,
+          created_at: hoursAgo(6),
+        },
+      ],
+    },
+    // upsertSignalFromDraft → openSignalFor returns an existing row.
+    {
+      table: "customer_signals",
+      rows: [
+        {
+          id: "existing-1",
+          client_id: "c1",
+          contact_id: null,
+          signal_type: "missed_call_unbooked",
+          severity: "high",
+          confidence: 0.8,
+          status: "open",
+          reason: "...",
+          recommended_action: "...",
+          estimated_value: 120,
+          source_event_ids: [],
+          source_table: "front_desk_sessions",
+          source_record_id: "sess-1",
+          expires_at: null,
+          created_at: hoursAgo(5),
+          updated_at: hoursAgo(5),
+          resolved_at: null,
+        },
+      ],
+    },
+  ];
+
+  const result = await generateSignals({
+    client_ids: ["c1"],
+    rules: ["missed_call_unbooked"],
+    now: NOW,
+    dryRun: false,
+  });
+
+  assert.equal(result.results[0].drafts, 1);
+  assert.equal(result.results[0].created, 0);
+  assert.equal(result.results[0].skipped_existing, 1);
+  // No new customer_signals insert because an open one existed.
+  const signalInserts = insertCalls.filter((c) => c.table === "customer_signals");
+  assert.equal(signalInserts.length, 0);
+});

--- a/src/lib/pci/ingest.ts
+++ b/src/lib/pci/ingest.ts
@@ -1,0 +1,936 @@
+/**
+ * PCI v1 — ingestion & manual signal-generation.
+ *
+ * Reads existing agent domain tables (front_desk_sessions, care_sessions,
+ * appointments, client_contacts, reactivation_campaigns, review_requests,
+ * reminders) and produces:
+ *
+ *   1. `customer_events` rows that normalize the operational history
+ *      into the PCI stream.
+ *   2. `customer_signals` rows derived from the pure rule functions in
+ *      `rules.ts`.
+ *
+ * This module is the **manual / operator-triggered** path. No cron is
+ * wired here — it runs when an authorized admin asks for it. No outbound
+ * messages are sent and no GHL handoff is invoked. The execution layer
+ * stays on its own seam (see `handoff.ts`).
+ *
+ * Every generator function supports `dryRun` — it returns the drafts
+ * that *would* be written without touching the database. The calling
+ * API route surfaces that option to the admin UI so the operator can
+ * preview before committing.
+ *
+ * Scoping: each generator takes an explicit `client_ids` allowlist. The
+ * API route must derive this from the admin session (accessibleClients
+ * for non-super-admins). Passing `null` scans all clients — only super
+ * admins should be able to do that.
+ */
+
+import { recordEvent } from "./events";
+import {
+  evalLapsedClient,
+  evalMissedCallUnbooked,
+  evalNoShowRisk,
+  evalRebookDue,
+  evalReviewReady,
+  evalWarmLeadRisk,
+} from "./rules";
+import { upsertSignalFromDraft } from "./signals";
+import { sbSelect } from "../agents/supabase";
+import type {
+  AgentSource,
+  CustomerEventType,
+  SignalDraft,
+  SignalType,
+} from "./types";
+
+// ───────────────────────────────────────────────────────────────────
+// Row shapes (narrow — only the columns each mapper actually reads)
+// ───────────────────────────────────────────────────────────────────
+
+export interface FrontDeskSessionRow {
+  id: string;
+  client_id: string;
+  trigger_type: string;
+  intent: "hot" | "warm" | "low" | "unknown" | null;
+  visitor_phone: string | null;
+  visitor_email: string | null;
+  appointment_id: string | null;
+  created_at: string;
+}
+
+export interface CareSessionRow {
+  id: string;
+  client_id: string;
+  contact_id: string | null;
+  trigger_type: string;
+  intent: "hot" | "warm" | "low" | "unknown" | null;
+  created_at: string;
+}
+
+export interface AppointmentRow {
+  id: string;
+  client_id: string;
+  visitor_phone: string | null;
+  visitor_email: string | null;
+  scheduled_at: string;
+  status: string;
+  service_type: string | null;
+  updated_at: string;
+}
+
+export interface ReminderRow {
+  appointment_id: string;
+  type: string;
+  status: string;
+  sent_at: string | null;
+}
+
+export interface ReviewRequestRow {
+  appointment_id: string;
+  status: string;
+}
+
+export interface ClientContactRow {
+  id: string;
+  client_id: string;
+  phone: string | null;
+  email: string | null;
+  last_visit_at: string | null;
+  usual_rebook_cadence_days: number | null;
+}
+
+export interface ReactivationCampaignRow {
+  contact_id: string | null;
+  status: string;
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Event mapping helpers (pure)
+// ───────────────────────────────────────────────────────────────────
+
+interface EventDraft {
+  client_id: string;
+  event_type: CustomerEventType;
+  event_source: string;
+  agent_source: AgentSource | null;
+  session_id?: string | null;
+  appointment_id?: string | null;
+  contact_id?: string | null;
+  occurred_at: string;
+  metadata: Record<string, unknown>;
+  channel?: string | null;
+}
+
+/**
+ * Map a front_desk_sessions row into the event it corresponds to. Pure
+ * — no DB reads, no writes. Returns null when the row should not emit
+ * an event.
+ */
+export function frontDeskSessionToEvent(
+  row: FrontDeskSessionRow
+): EventDraft | null {
+  if (row.trigger_type === "missed_call") {
+    return {
+      client_id: row.client_id,
+      event_type: "missed_call",
+      event_source: "front_desk_sessions",
+      agent_source: "front_desk",
+      session_id: row.id,
+      appointment_id: row.appointment_id,
+      occurred_at: row.created_at,
+      metadata: {
+        trigger_type: row.trigger_type,
+        visitor_phone: row.visitor_phone,
+      },
+      channel: "voice",
+    };
+  }
+  if (row.intent === "hot" || row.intent === "warm") {
+    return {
+      client_id: row.client_id,
+      event_type: "lead_intent_detected",
+      event_source: "front_desk_sessions",
+      agent_source: "front_desk",
+      session_id: row.id,
+      appointment_id: row.appointment_id,
+      occurred_at: row.created_at,
+      metadata: { intent: row.intent, trigger_type: row.trigger_type },
+    };
+  }
+  return null;
+}
+
+export function careSessionToEvent(row: CareSessionRow): EventDraft | null {
+  if (row.intent === "hot" || row.intent === "warm") {
+    return {
+      client_id: row.client_id,
+      event_type: "lead_intent_detected",
+      event_source: "care_sessions",
+      agent_source: "care",
+      session_id: row.id,
+      contact_id: row.contact_id,
+      occurred_at: row.created_at,
+      metadata: { intent: row.intent, trigger_type: row.trigger_type },
+    };
+  }
+  return null;
+}
+
+/**
+ * Map an appointment row into whichever event (if any) reflects its
+ * current status. `booked` always fires; `confirmed`, `completed`,
+ * `canceled` fire when status matches.
+ */
+export function appointmentToEvents(row: AppointmentRow): EventDraft[] {
+  const out: EventDraft[] = [];
+  const base = {
+    client_id: row.client_id,
+    event_source: "appointments",
+    agent_source: "front_desk" as AgentSource,
+    appointment_id: row.id,
+    metadata: {
+      status: row.status,
+      scheduled_at: row.scheduled_at,
+      service_type: row.service_type,
+    },
+  };
+  // Booked — always present as long as the appointment exists.
+  out.push({
+    ...base,
+    event_type: "appointment_booked",
+    occurred_at: row.updated_at,
+  });
+  if (row.status === "confirmed" || row.status === "reminded") {
+    out.push({
+      ...base,
+      event_type: "appointment_confirmed",
+      occurred_at: row.updated_at,
+    });
+  } else if (row.status === "completed") {
+    out.push({
+      ...base,
+      event_type: "appointment_completed",
+      occurred_at: row.updated_at,
+    });
+  } else if (row.status === "cancelled") {
+    out.push({
+      ...base,
+      event_type: "appointment_canceled",
+      occurred_at: row.updated_at,
+    });
+  }
+  return out;
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Rule wiring (pure)
+// ───────────────────────────────────────────────────────────────────
+
+/**
+ * Which rules we support in v1 manual generation. Exposed so the API
+ * route and admin UI can restrict what a caller requests.
+ */
+export const SUPPORTED_RULES = [
+  "warm_lead_risk",
+  "missed_call_unbooked",
+  "no_show_risk",
+  "rebook_due",
+  "lapsed_client",
+  "review_ready",
+] as const satisfies readonly SignalType[];
+
+export type SupportedRule = (typeof SUPPORTED_RULES)[number];
+
+export function isSupportedRule(v: string): v is SupportedRule {
+  return (SUPPORTED_RULES as readonly string[]).includes(v);
+}
+
+/**
+ * Drive a warm-lead-risk draft from a front-desk session row. Pure.
+ */
+export function warmLeadDraftFromFrontDesk(
+  row: FrontDeskSessionRow,
+  contactId: string | null,
+  now: Date
+): SignalDraft | null {
+  return evalWarmLeadRisk({
+    client_id: row.client_id,
+    contact_id: contactId,
+    session_id: row.id,
+    agent_source: "front_desk",
+    intent: row.intent,
+    started_at: row.created_at,
+    appointment_booked: row.appointment_id !== null,
+    now,
+  });
+}
+
+/**
+ * Drive a warm-lead-risk draft from a care session row. Pure.
+ */
+export function warmLeadDraftFromCare(
+  row: CareSessionRow,
+  now: Date
+): SignalDraft | null {
+  return evalWarmLeadRisk({
+    client_id: row.client_id,
+    contact_id: row.contact_id,
+    session_id: row.id,
+    agent_source: "care",
+    intent: row.intent,
+    started_at: row.created_at,
+    // Care sessions don't carry appointment_id directly — treat as not
+    // booked for the purposes of this rule. A future iteration can
+    // cross-check against appointments.visitor_phone / care_sessions.contact_id.
+    appointment_booked: false,
+    now,
+  });
+}
+
+export function missedCallDraftFromFrontDesk(
+  row: FrontDeskSessionRow,
+  contactId: string | null,
+  now: Date
+): SignalDraft | null {
+  return evalMissedCallUnbooked({
+    client_id: row.client_id,
+    contact_id: contactId,
+    session_id: row.id,
+    trigger_type: row.trigger_type,
+    has_linked_appointment: row.appointment_id !== null,
+    started_at: row.created_at,
+    now,
+  });
+}
+
+export function noShowDraftFromAppointment(
+  row: AppointmentRow,
+  contactId: string | null,
+  reminderSent: boolean,
+  now: Date
+): SignalDraft | null {
+  return evalNoShowRisk({
+    client_id: row.client_id,
+    contact_id: contactId,
+    appointment_id: row.id,
+    status: row.status,
+    scheduled_at: row.scheduled_at,
+    // Domain note: `status in ('confirmed','reminded')` means the visitor
+    // has acknowledged / been reminded. PCI's rule-level input is
+    // confirmation_received — use 'reminded' OR 'confirmed' as evidence.
+    confirmation_received: row.status === "confirmed" || row.status === "reminded",
+    reminder_sent: reminderSent,
+    now,
+  });
+}
+
+export function reviewReadyDraftFromAppointment(
+  row: AppointmentRow,
+  contactId: string | null,
+  reviewAlreadySent: boolean,
+  now: Date
+): SignalDraft | null {
+  return evalReviewReady({
+    client_id: row.client_id,
+    contact_id: contactId,
+    appointment_id: row.id,
+    completed_at: row.updated_at,
+    // v1: we don't surface a negative-sentiment flag yet — treat as
+    // absent so the rule still fires; v2 will wire care_messages
+    // sentiment markers.
+    has_negative_signal: false,
+    review_already_sent: reviewAlreadySent,
+    now,
+  });
+}
+
+export function rebookDraftFromContact(
+  row: ClientContactRow,
+  futureAppointmentExists: boolean,
+  now: Date
+): SignalDraft | null {
+  return evalRebookDue({
+    client_id: row.client_id,
+    contact_id: row.id,
+    last_visit_at: row.last_visit_at,
+    usual_rebook_cadence_days: row.usual_rebook_cadence_days,
+    future_appointment_exists: futureAppointmentExists,
+    now,
+  });
+}
+
+export function lapsedDraftFromContact(
+  row: ClientContactRow,
+  reactivationThresholdDays: number | null,
+  inActiveReactivation: boolean,
+  now: Date
+): SignalDraft | null {
+  return evalLapsedClient({
+    client_id: row.client_id,
+    contact_id: row.id,
+    last_visit_at: row.last_visit_at,
+    reactivation_threshold_days: reactivationThresholdDays,
+    in_active_reactivation: inActiveReactivation,
+    now,
+  });
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Generation runner (DB-backed)
+// ───────────────────────────────────────────────────────────────────
+
+export interface GenerateOptions {
+  /** Allowlist of client_id values to scan. `null` = all clients (super admin). */
+  client_ids: string[] | null;
+  /** Which rules to execute. Defaults to all SUPPORTED_RULES. */
+  rules?: readonly SupportedRule[];
+  /** Max source rows per rule, per scan. Keeps one operator click bounded. */
+  limit?: number;
+  /** Clock injection for tests. */
+  now?: Date;
+  /**
+   * Dry run — returns the would-be signal drafts and event counts without
+   * writing anything. Default false.
+   */
+  dryRun?: boolean;
+}
+
+export interface RuleResult {
+  rule: SupportedRule;
+  scanned: number;
+  drafts: number;
+  created: number;
+  skipped_existing: number;
+  events_written: number;
+}
+
+export interface GenerateResult {
+  dryRun: boolean;
+  now: string;
+  results: RuleResult[];
+  totals: {
+    scanned: number;
+    drafts: number;
+    created: number;
+    skipped_existing: number;
+    events_written: number;
+  };
+}
+
+/**
+ * Run the requested rules against existing records and persist any new
+ * signals (unless dryRun). The caller is responsible for passing the
+ * correct `client_ids` scope for the admin session.
+ *
+ * Generator-level errors are caught so one rule failing does not stop
+ * the rest — individual rule scans will surface non-zero `scanned` with
+ * zero `drafts` if a query fails. The result always returns even on
+ * partial failure; logs are emitted via console.warn for observability.
+ */
+export async function generateSignals(
+  opts: GenerateOptions
+): Promise<GenerateResult> {
+  const now = opts.now ?? new Date();
+  const limit = opts.limit ?? 200;
+  const rules = opts.rules ?? SUPPORTED_RULES;
+  const dryRun = opts.dryRun ?? false;
+
+  const results: RuleResult[] = [];
+  for (const rule of rules) {
+    const r = await runRule(rule, opts.client_ids, limit, now, dryRun);
+    results.push(r);
+  }
+
+  const totals = results.reduce(
+    (acc, r) => ({
+      scanned: acc.scanned + r.scanned,
+      drafts: acc.drafts + r.drafts,
+      created: acc.created + r.created,
+      skipped_existing: acc.skipped_existing + r.skipped_existing,
+      events_written: acc.events_written + r.events_written,
+    }),
+    { scanned: 0, drafts: 0, created: 0, skipped_existing: 0, events_written: 0 }
+  );
+
+  return { dryRun, now: now.toISOString(), results, totals };
+}
+
+async function runRule(
+  rule: SupportedRule,
+  clientIds: string[] | null,
+  limit: number,
+  now: Date,
+  dryRun: boolean
+): Promise<RuleResult> {
+  try {
+    switch (rule) {
+      case "warm_lead_risk":
+        return await runWarmLead(clientIds, limit, now, dryRun);
+      case "missed_call_unbooked":
+        return await runMissedCall(clientIds, limit, now, dryRun);
+      case "no_show_risk":
+        return await runNoShow(clientIds, limit, now, dryRun);
+      case "review_ready":
+        return await runReviewReady(clientIds, limit, now, dryRun);
+      case "rebook_due":
+        return await runRebook(clientIds, limit, now, dryRun);
+      case "lapsed_client":
+        return await runLapsed(clientIds, limit, now, dryRun);
+    }
+  } catch (e) {
+    console.warn(`[pci.generateSignals] rule ${rule} failed:`, e);
+    return emptyResult(rule);
+  }
+}
+
+function emptyResult(rule: SupportedRule): RuleResult {
+  return {
+    rule,
+    scanned: 0,
+    drafts: 0,
+    created: 0,
+    skipped_existing: 0,
+    events_written: 0,
+  };
+}
+
+function clientFilter(
+  clientIds: string[] | null
+): Record<string, string> | null {
+  if (clientIds === null) return {};
+  if (clientIds.length === 0) return null;
+  return { client_id: `in.(${clientIds.map(encodeURIComponent).join(",")})` };
+}
+
+async function persistDraft(
+  draft: SignalDraft,
+  dryRun: boolean
+): Promise<"created" | "existed"> {
+  if (dryRun) return "existed";
+  const { created } = await upsertSignalFromDraft(draft);
+  return created ? "created" : "existed";
+}
+
+async function persistEvent(
+  ev: EventDraft,
+  dryRun: boolean
+): Promise<boolean> {
+  if (dryRun) return false;
+  try {
+    await recordEvent({
+      client_id: ev.client_id,
+      event_type: ev.event_type,
+      event_source: ev.event_source,
+      agent_source: ev.agent_source,
+      session_id: ev.session_id ?? null,
+      appointment_id: ev.appointment_id ?? null,
+      contact_id: ev.contact_id ?? null,
+      occurred_at: ev.occurred_at,
+      metadata: ev.metadata,
+      channel: ev.channel ?? null,
+    });
+    return true;
+  } catch (e) {
+    console.warn("[pci.generateSignals] event write failed:", e);
+    return false;
+  }
+}
+
+// ── per-rule runners ─────────────────────────────────────────────────
+
+async function findContactIdByPhoneEmail(
+  clientId: string,
+  phone: string | null,
+  email: string | null
+): Promise<string | null> {
+  if (phone) {
+    const rows = await sbSelect<{ id: string }>(
+      "client_contacts",
+      { client_id: `eq.${clientId}`, phone: `eq.${phone}` },
+      { limit: 1, select: "id" }
+    );
+    if (rows[0]?.id) return rows[0].id;
+  }
+  if (email) {
+    const rows = await sbSelect<{ id: string }>(
+      "client_contacts",
+      { client_id: `eq.${clientId}`, email: `eq.${email}` },
+      { limit: 1, select: "id" }
+    );
+    if (rows[0]?.id) return rows[0].id;
+  }
+  return null;
+}
+
+async function runWarmLead(
+  clientIds: string[] | null,
+  limit: number,
+  now: Date,
+  dryRun: boolean
+): Promise<RuleResult> {
+  const filter = clientFilter(clientIds);
+  if (filter === null) return emptyResult("warm_lead_risk");
+
+  const fdRows = await sbSelect<FrontDeskSessionRow>(
+    "front_desk_sessions",
+    { ...filter, intent: "in.(hot,warm)" },
+    { order: "created_at.desc", limit }
+  );
+  const careRows = await sbSelect<CareSessionRow>(
+    "care_sessions",
+    { ...filter, intent: "in.(hot,warm)" },
+    { order: "created_at.desc", limit }
+  );
+
+  let drafts = 0;
+  let created = 0;
+  let skipped = 0;
+  let events = 0;
+
+  for (const row of fdRows) {
+    const contactId = await findContactIdByPhoneEmail(
+      row.client_id,
+      row.visitor_phone,
+      row.visitor_email
+    );
+    const ev = frontDeskSessionToEvent(row);
+    if (ev && (await persistEvent(ev, dryRun))) events++;
+
+    const draft = warmLeadDraftFromFrontDesk(row, contactId, now);
+    if (!draft) continue;
+    drafts++;
+    const outcome = await persistDraft(draft, dryRun);
+    if (outcome === "created") created++;
+    else skipped++;
+  }
+  for (const row of careRows) {
+    const ev = careSessionToEvent(row);
+    if (ev && (await persistEvent(ev, dryRun))) events++;
+    const draft = warmLeadDraftFromCare(row, now);
+    if (!draft) continue;
+    drafts++;
+    const outcome = await persistDraft(draft, dryRun);
+    if (outcome === "created") created++;
+    else skipped++;
+  }
+
+  return {
+    rule: "warm_lead_risk",
+    scanned: fdRows.length + careRows.length,
+    drafts,
+    created,
+    skipped_existing: skipped,
+    events_written: events,
+  };
+}
+
+async function runMissedCall(
+  clientIds: string[] | null,
+  limit: number,
+  now: Date,
+  dryRun: boolean
+): Promise<RuleResult> {
+  const filter = clientFilter(clientIds);
+  if (filter === null) return emptyResult("missed_call_unbooked");
+
+  const rows = await sbSelect<FrontDeskSessionRow>(
+    "front_desk_sessions",
+    { ...filter, trigger_type: "eq.missed_call", appointment_id: "is.null" },
+    { order: "created_at.desc", limit }
+  );
+
+  let drafts = 0;
+  let created = 0;
+  let skipped = 0;
+  let events = 0;
+
+  for (const row of rows) {
+    const contactId = await findContactIdByPhoneEmail(
+      row.client_id,
+      row.visitor_phone,
+      row.visitor_email
+    );
+    const ev = frontDeskSessionToEvent(row);
+    if (ev && (await persistEvent(ev, dryRun))) events++;
+
+    const draft = missedCallDraftFromFrontDesk(row, contactId, now);
+    if (!draft) continue;
+    drafts++;
+    const outcome = await persistDraft(draft, dryRun);
+    if (outcome === "created") created++;
+    else skipped++;
+  }
+
+  return {
+    rule: "missed_call_unbooked",
+    scanned: rows.length,
+    drafts,
+    created,
+    skipped_existing: skipped,
+    events_written: events,
+  };
+}
+
+async function runNoShow(
+  clientIds: string[] | null,
+  limit: number,
+  now: Date,
+  dryRun: boolean
+): Promise<RuleResult> {
+  const filter = clientFilter(clientIds);
+  if (filter === null) return emptyResult("no_show_risk");
+
+  // Window: scheduled between now and now+24h and not cancelled/completed.
+  const in24h = new Date(now.getTime() + 24 * 60 * 60 * 1000).toISOString();
+  const rows = await sbSelect<AppointmentRow>(
+    "appointments",
+    {
+      ...filter,
+      scheduled_at: `gte.${now.toISOString()}`,
+      // Second constraint goes via a separate param — PostgREST supports
+      // per-column comparator keys; for lte we inline as an "and" hack
+      // using a second fetch filter. Instead we just filter in JS below.
+    },
+    { order: "scheduled_at.asc", limit }
+  );
+
+  let drafts = 0;
+  let created = 0;
+  let skipped = 0;
+  let events = 0;
+
+  for (const row of rows) {
+    if (new Date(row.scheduled_at).getTime() > new Date(in24h).getTime()) continue;
+    if (row.status === "cancelled" || row.status === "completed") continue;
+
+    const reminders = await sbSelect<ReminderRow>(
+      "reminders",
+      { appointment_id: `eq.${row.id}`, status: "eq.sent" },
+      { limit: 1, select: "appointment_id,type,status,sent_at" }
+    );
+    const reminderSent = reminders.length > 0;
+
+    const contactId = await findContactIdByPhoneEmail(
+      row.client_id,
+      row.visitor_phone,
+      row.visitor_email
+    );
+
+    for (const ev of appointmentToEvents(row)) {
+      if (await persistEvent(ev, dryRun)) events++;
+    }
+
+    const draft = noShowDraftFromAppointment(row, contactId, reminderSent, now);
+    if (!draft) continue;
+    drafts++;
+    const outcome = await persistDraft(draft, dryRun);
+    if (outcome === "created") created++;
+    else skipped++;
+  }
+
+  return {
+    rule: "no_show_risk",
+    scanned: rows.length,
+    drafts,
+    created,
+    skipped_existing: skipped,
+    events_written: events,
+  };
+}
+
+async function runReviewReady(
+  clientIds: string[] | null,
+  limit: number,
+  now: Date,
+  dryRun: boolean
+): Promise<RuleResult> {
+  const filter = clientFilter(clientIds);
+  if (filter === null) return emptyResult("review_ready");
+
+  const cutoff = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const rows = await sbSelect<AppointmentRow>(
+    "appointments",
+    {
+      ...filter,
+      status: "eq.completed",
+      updated_at: `gte.${cutoff}`,
+    },
+    { order: "updated_at.desc", limit }
+  );
+
+  let drafts = 0;
+  let created = 0;
+  let skipped = 0;
+  let events = 0;
+
+  for (const row of rows) {
+    const reviewReqs = await sbSelect<ReviewRequestRow>(
+      "review_requests",
+      {
+        appointment_id: `eq.${row.id}`,
+        status: "in.(sent,completed)",
+      },
+      { limit: 1, select: "appointment_id,status" }
+    );
+    const alreadySent = reviewReqs.length > 0;
+
+    const contactId = await findContactIdByPhoneEmail(
+      row.client_id,
+      row.visitor_phone,
+      row.visitor_email
+    );
+
+    for (const ev of appointmentToEvents(row)) {
+      if (await persistEvent(ev, dryRun)) events++;
+    }
+
+    const draft = reviewReadyDraftFromAppointment(row, contactId, alreadySent, now);
+    if (!draft) continue;
+    drafts++;
+    const outcome = await persistDraft(draft, dryRun);
+    if (outcome === "created") created++;
+    else skipped++;
+  }
+
+  return {
+    rule: "review_ready",
+    scanned: rows.length,
+    drafts,
+    created,
+    skipped_existing: skipped,
+    events_written: events,
+  };
+}
+
+async function runRebook(
+  clientIds: string[] | null,
+  limit: number,
+  now: Date,
+  dryRun: boolean
+): Promise<RuleResult> {
+  const filter = clientFilter(clientIds);
+  if (filter === null) return emptyResult("rebook_due");
+
+  const rows = await sbSelect<ClientContactRow>(
+    "client_contacts",
+    { ...filter, last_visit_at: "not.is.null" },
+    { order: "last_visit_at.asc", limit }
+  );
+
+  let drafts = 0;
+  let created = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    // Look for any future appointment for this contact's phone/email.
+    let futureExists = false;
+    if (row.phone || row.email) {
+      const params: Record<string, string> = {
+        client_id: `eq.${row.client_id}`,
+        scheduled_at: `gte.${now.toISOString()}`,
+        status: "in.(confirmed,reminded)",
+      };
+      // PostgREST doesn't easily OR across columns — do two quick checks.
+      if (row.phone) {
+        const appts = await sbSelect<{ id: string }>(
+          "appointments",
+          { ...params, visitor_phone: `eq.${row.phone}` },
+          { limit: 1, select: "id" }
+        );
+        if (appts.length > 0) futureExists = true;
+      }
+      if (!futureExists && row.email) {
+        const appts = await sbSelect<{ id: string }>(
+          "appointments",
+          { ...params, visitor_email: `eq.${row.email}` },
+          { limit: 1, select: "id" }
+        );
+        if (appts.length > 0) futureExists = true;
+      }
+    }
+
+    const draft = rebookDraftFromContact(row, futureExists, now);
+    if (!draft) continue;
+    drafts++;
+    const outcome = await persistDraft(draft, dryRun);
+    if (outcome === "created") created++;
+    else skipped++;
+  }
+
+  return {
+    rule: "rebook_due",
+    scanned: rows.length,
+    drafts,
+    created,
+    skipped_existing: skipped,
+    events_written: 0,
+  };
+}
+
+async function runLapsed(
+  clientIds: string[] | null,
+  limit: number,
+  now: Date,
+  dryRun: boolean
+): Promise<RuleResult> {
+  const filter = clientFilter(clientIds);
+  if (filter === null) return emptyResult("lapsed_client");
+
+  const rows = await sbSelect<ClientContactRow>(
+    "client_contacts",
+    { ...filter, last_visit_at: "not.is.null" },
+    { order: "last_visit_at.asc", limit }
+  );
+
+  // Fetch per-client reactivation_threshold_days in one pass.
+  const clientIdSet = Array.from(new Set(rows.map((r) => r.client_id)));
+  const thresholds = new Map<string, number | null>();
+  if (clientIdSet.length > 0) {
+    const clients = await sbSelect<{
+      client_id: string;
+      reactivation_threshold_days: number | null;
+    }>(
+      "clients",
+      { client_id: `in.(${clientIdSet.map(encodeURIComponent).join(",")})` },
+      { select: "client_id,reactivation_threshold_days", limit: 500 }
+    );
+    for (const c of clients) {
+      thresholds.set(c.client_id, c.reactivation_threshold_days);
+    }
+  }
+
+  let drafts = 0;
+  let created = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    const active = await sbSelect<ReactivationCampaignRow>(
+      "reactivation_campaigns",
+      {
+        client_id: `eq.${row.client_id}`,
+        contact_id: `eq.${row.id}`,
+        status: "in.(pending,sent)",
+      },
+      { limit: 1, select: "contact_id,status" }
+    );
+    const inActive = active.length > 0;
+    const threshold = thresholds.get(row.client_id) ?? null;
+
+    const draft = lapsedDraftFromContact(row, threshold, inActive, now);
+    if (!draft) continue;
+    drafts++;
+    const outcome = await persistDraft(draft, dryRun);
+    if (outcome === "created") created++;
+    else skipped++;
+  }
+
+  return {
+    rule: "lapsed_client",
+    scanned: rows.length,
+    drafts,
+    created,
+    skipped_existing: skipped,
+    events_written: 0,
+  };
+}

--- a/src/lib/pci/signals.ts
+++ b/src/lib/pci/signals.ts
@@ -11,7 +11,7 @@
  * relying on an insert conflict.
  */
 
-import { sbInsert, sbSelect } from "@/lib/agents/supabase";
+import { sbInsert, sbSelect } from "../agents/supabase";
 import type {
   CustomerSignal,
   SignalDraft,
@@ -128,6 +128,6 @@ export async function updateSignalStatus(args: {
   // can't accidentally rewrite severity/reason.
   const patch: Record<string, unknown> = { status: args.status };
   if (args.status === "resolved") patch.resolved_at = new Date().toISOString();
-  const { sbUpdate } = await import("@/lib/agents/supabase");
+  const { sbUpdate } = await import("../agents/supabase");
   await sbUpdate(TABLE, { id: `eq.${args.id}` }, patch);
 }


### PR DESCRIPTION
## Summary

PCI v1 adds the ingestion + operator-triggered signal generation layer on top of the v0 schema. No cron, no outbound messaging, no GHL handoff — this is a safe, reviewable next step toward wiring PCI end-to-end.

- **`src/lib/pci/ingest.ts`** — pure mappers from existing agent rows (`front_desk_sessions`, `care_sessions`, `appointments`, `client_contacts`, `reminders`, `review_requests`, `reactivation_campaigns`) into `customer_events` drafts + `SignalDraft`s, plus a `generateSignals()` DB-backed runner that wires the v0 rules to real tables.
- **`src/lib/pci/generate-handler.ts`** — authorization + input-validation handler, split out so the scope / `dryRun` / `rules` / `limit` / `clientIds` rules are unit-testable.
- **`src/app/api/admin/pci/generate/route.ts`** — protected `POST` endpoint. Uses the same `admin_session` cookie flow as the rest of `/admin`.
- **`src/app/admin/pci/page.tsx`** — “Preview (dry run)” and “Generate signals” buttons in the existing internal dashboard, with a scanned/drafts/created/skipped summary banner.
- Tests: `ingest.test.ts` (pure mappers + DB-backed runner with mocked `sbSelect`/`sbInsert`) and `generate-handler.test.ts` (authorization + input validation).

## Scope & safety

- `dryRun` defaults to **TRUE**. Callers must explicitly pass `dryRun: false` to persist signals.
- Non-super-admins are always scoped to `accessibleClients`; passing `clientIds` in the body returns **403**.
- **No cron is wired.** **No outbound SMS/email.** **No GHL handoff.** Execution stays on the `handoff.ts` seam (still a v0 stub).
- No public copy changes. No forbidden public terms (GHL / Supabase / HIPAA / etc.) appear in any public-facing file — changes are confined to `src/lib/pci/*`, `src/app/api/admin/pci/*`, and `src/app/admin/pci/page.tsx`.

Internal imports inside `src/lib/pci/*` for the supabase REST helper were switched from the `@/` path alias to relative paths so the `node --test` loader can exercise them under `mock.module()`. No Next.js route behavior changes.

## Rules covered in v1 manual generation

`warm_lead_risk`, `missed_call_unbooked`, `no_show_risk`, `rebook_due`, `lapsed_client`, `review_ready`. The `owner_followup_needed` and `slow_week_fill` rules are intentionally **not** covered here — they fire from in-line agent events and vertical logic respectively, not from scan-the-database backfill.

## Test plan

- [x] `npm test` — 84/84 pass (54 in `src/lib/pci`, 30 from pre-existing suites).
- [x] `tsc --noEmit` — clean on all non-test sources. Test files emit the same pre-existing TS5097 `.ts`-extension warnings as other `*.test.ts` files.
- [x] `npm run build` — passes.
- [x] `npx eslint src/lib/pci/ src/app/api/admin/pci/ src/app/admin/pci/` — clean.
- [ ] Manual admin verification (post-merge, in staging — see below).

## Manual verification steps (post-merge, staging)

1. Log in to `/admin` as a super admin. Navigate to `/admin/pci`.
2. Click **Preview (dry run)** with no client filter. The banner should show non-zero `scanned` and may show `drafts > 0`; `created` MUST be `0`.
3. Confirm `customer_signals` row count in the database is unchanged after the preview click.
4. Click **Generate signals**. The banner should show `created > 0` if any drafts fired; the open-signals list should update with the new rows.
5. Click **Generate signals** again. `created` should now be `0` and `skipped_existing` should match the prior `created` (duplicate suppression working).
6. As a non-super-admin, confirm `/admin/pci` scopes results to `accessibleClients` only and that a direct `POST /api/admin/pci/generate` with a `clientIds` body field returns **403**.
7. `POST /api/admin/pci/generate` with no session cookie → **401**.

## Risks

- **Query shape**: the `no_show_risk` runner uses a single PostgREST `gte` filter on `scheduled_at` and filters the 24h upper bound client-side. Fine for `limit ≤ 500`; revisit if we raise the cap.
- **Contact resolution for front-desk sessions** is by exact `client_contacts.phone`/`email` match. If a front-desk row's phone is a normalized variant, the draft will have `contact_id: null` and a second run against the same session won't dedupe across contact assignments. Acceptable for v1; v2 should introduce phone normalization.
- **0007 migration still not applied in production**. The endpoint will 500 until the migration runs — the existing `/admin/pci` dashboard already has this dependency, so this does not add a new deploy gate.