### PR TITLE
fix(ghl): allow inbound-visitor-sms webhook without toNumber

### DIFF
--- a/docs/inbound-visitor-sms.md
+++ b/docs/inbound-visitor-sms.md
@@ -22,34 +22,67 @@ leads.
 POST /api/ghl/inbound-visitor-sms?secret=<GHL_WEBHOOK_SECRET>
 ```
 
-Accepted request bodies (same aliases as the owner-reply route):
+### Accepted request bodies
+
+The route works with the smallest possible GHL webhook payload —
+`toNumber` is **optional**, because GHL rejects the
+`{{message.to_number}}` merge field in some workflow triggers. When
+`toNumber` is missing the route falls back to `locationId`, and then to
+the single-active-client shortcut.
+
+**Recommended (GHL workflow body):**
 
 ```json
 {
-  "phone":          "+17145550123",    // visitor / lead
-  "toNumber":       "+19499973915",    // the client's LC Phone
-  "body":           "hi, any openings today?",
-  "contactId":      "<optional>",
-  "conversationId": "<optional>"
+  "phone": "{{contact.phone}}",
+  "body":  "{{message.body}}"
 }
 ```
 
-LC workflow aliases `from` / `to` / `message` are also accepted.
+**Richer shape — pass anything GHL makes available; it is always
+preferred over the fallbacks and gives you unambiguous routing:**
+
+```json
+{
+  "phone":          "{{contact.phone}}",
+  "body":           "{{message.body}}",
+  "toNumber":       "{{message.to_number}}",
+  "locationId":     "{{location.id}}",
+  "contactId":      "{{contact.id}}",
+  "conversationId": "{{conversation.id}}"
+}
+```
+
+LC workflow aliases `from` / `to` / `message` and snake_case
+`location_id` / `contact_id` / `conversation_id` are also accepted.
 
 ---
 
 ## Client resolution
 
-Each client that accepts inbound visitor SMS must have
-`clients.sms_config.fromNumber` set to the LC Phone in E.164 format.
-The route queries:
+The route resolves the owning client in this priority order — the first
+strategy that matches wins:
 
-```
-clients?sms_config->>fromNumber=eq.<toNumber>&active=eq.true
-```
+| Priority | Field in payload | Lookup                                   |
+| -------- | ---------------- | ---------------------------------------- |
+| 1        | `toNumber`       | `clients.sms_config->>fromNumber`        |
+| 2        | `locationId`     | `clients.sms_config->>locationId`        |
+| 3        | *(none)*         | exactly one active client with `sms_config.fromNumber` set |
 
-If no active client matches, the route returns `{ok:false,reason:"no_client_for_to_phone"}`
-with HTTP 200 (so GHL does not retry-storm).
+Strategy (3) is intentionally strict: if two or more active clients have
+`sms_config.fromNumber` configured, the route refuses to guess and
+returns `{ok:false, reason:"ambiguous_client", candidates:[…]}`. That
+keeps single-tenant installs (current state) frictionless while ensuring
+multi-tenant installs are forced to supply `toNumber` or `locationId`.
+
+### Configuration requirements
+
+Each client that accepts inbound visitor SMS must have:
+
+- `clients.sms_config.fromNumber` — LC Phone in E.164 (`+19499973915`)
+- `clients.sms_config.locationId` — GHL sub-account location id (used
+  by the outbound SMS integration AND as a resolution fallback)
+- `clients.active = true`
 
 ---
 
@@ -58,17 +91,43 @@ with HTTP 200 (so GHL does not retry-storm).
 ```json
 {
   "ok": true,
-  "sessionId": "<uuid>",
-  "reply": "<bot reply text>",
-  "replySent": true,
+  "clientId":       "santa",
+  "resolvedVia":    "toPhone",        // "toPhone" | "locationId" | "sole"
+  "sessionId":      "<uuid>",
+  "reply":          "<bot reply text>",
+  "replySent":      true,
   "replyMessageId": "<provider message id>",
-  "replyError": null,
-  "escalated": false,
-  "intent": "warm"
+  "replyError":     null,
+  "escalated":      false,
+  "intent":         "warm"
 }
 ```
 
-Non-2xx is avoided so GHL's retry logic does not loop.
+All failure modes return HTTP 200 so GHL does not retry-storm:
+
+| `reason`                  | Meaning |
+| ------------------------- | ------- |
+| `unauthorized`            | Wrong / missing `?secret=` |
+| `bad_json`                | Body was not valid JSON |
+| `missing_phones`          | Visitor `phone` / `from` was not in the payload |
+| `no_client_for_to_phone`  | No active client matched any resolution strategy |
+| `ambiguous_client`        | ≥2 active clients matched the sole-client fallback — supply `toNumber` or `locationId` |
+| `loop_guard`              | Visitor phone equals our own LC Phone — refuse to reply |
+| `db_error`                | Supabase lookup failed |
+| `run_turn_failed`         | Reply generation threw |
+
+---
+
+## Loop safety
+
+Two layers keep outbound bot replies from re-triggering the webhook:
+
+1. **GHL workflow filter — required.** Add `Direction = Inbound` to the
+   workflow trigger so outbound sends never fire the webhook in the
+   first place.
+2. **Server-side loop guard.** Even if the workflow filter is misset,
+   the route refuses to reply when `fromPhone` equals the client's own
+   `sms_config.fromNumber` (returns `reason:"loop_guard"`).
 
 ---
 
@@ -85,12 +144,19 @@ the GHL dashboard before inbound visitor SMS will route to the bot:
    - Method: `POST`
    - URL: `https://www.opsbynoell.com/api/ghl/inbound-visitor-sms?secret=<GHL_WEBHOOK_SECRET>`
    - Body format: `application/json`
-   - Body:
+   - Body (minimal — works today; GHL rejects `{{message.to_number}}`):
+     ```json
+     {
+       "phone": "{{contact.phone}}",
+       "body":  "{{message.body}}"
+     }
+     ```
+   - Body (preferred — add any fields GHL accepts for unambiguous routing):
      ```json
      {
        "phone":          "{{contact.phone}}",
-       "toNumber":       "{{message.to_number}}",
        "body":           "{{message.body}}",
+       "locationId":     "{{location.id}}",
        "contactId":      "{{contact.id}}",
        "conversationId": "{{conversation.id}}"
      }
@@ -100,7 +166,7 @@ the GHL dashboard before inbound visitor SMS will route to the bot:
 **Important:** This workflow must be published per-client sub-account
 (Healing Hands, Ops by Noell, etc.) — each has its own LC Phone. The
 same `GHL_WEBHOOK_SECRET` can be reused across sub-accounts because the
-route resolves the client from `toNumber`, not from the secret.
+route resolves the client per-request, not from the secret.
 
 ---
 
@@ -111,17 +177,42 @@ route resolves the client from `toNumber`, not from the secret.
 3. Expected: bot reply arrives via SMS, and a row appears in
    `front_desk_sessions` with `trigger_type = 'inbound_text'` and
    `channel = 'sms'`.
-4. cURL smoke test:
+4. cURL smoke tests (use a visitor phone that is NOT the LC Phone itself):
    ```bash
+   # Minimal shape GHL will accept — resolves via the single-client fallback
+   # when only one active client has sms_config.fromNumber set.
    curl -s -X POST \
      "https://www.opsbynoell.com/api/ghl/inbound-visitor-sms?secret=<SECRET>" \
      -H "Content-Type: application/json" \
      -d '{
        "phone": "+17145550123",
+       "body":  "test from curl"
+     }' | jq .
+
+   # Explicit toNumber — resolves via sms_config.fromNumber.
+   curl -s -X POST \
+     "https://www.opsbynoell.com/api/ghl/inbound-visitor-sms?secret=<SECRET>" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "phone":    "+17145550123",
        "toNumber": "+19499973915",
-       "body": "test from curl"
+       "body":     "test from curl"
+     }' | jq .
+
+   # Explicit locationId — resolves via sms_config.locationId.
+   curl -s -X POST \
+     "https://www.opsbynoell.com/api/ghl/inbound-visitor-sms?secret=<SECRET>" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "phone":      "+17145550123",
+       "locationId": "Un5H1b2zXJM3agZ56j7c",
+       "body":       "test from curl"
      }' | jq .
    ```
+
+Inspect the response for `"resolvedVia": "<toPhone|locationId|sole>"` to
+confirm the resolution path. Use the dashboard or a staging LC Phone for
+live tests — do not pound the production inbox with curl runs.
 
 ---
 
@@ -130,7 +221,10 @@ route resolves the client from `toNumber`, not from the secret.
 | Symptom | Likely cause |
 |---|---|
 | `{ok:false,reason:"unauthorized"}` | Wrong `?secret=` — mismatch between Vercel env var and webhook URL |
-| `{ok:false,reason:"no_client_for_to_phone"}` | `clients.sms_config.fromNumber` is missing or a different number |
+| `{ok:false,reason:"missing_phones"}` | No `phone` / `from` in body. Use `"phone":"{{contact.phone}}"` |
+| `{ok:false,reason:"no_client_for_to_phone"}` | `clients.sms_config.fromNumber` is missing or a different number, and no `locationId` fallback matched either |
+| `{ok:false,reason:"ambiguous_client",candidates:[…]}` | Multiple active clients have `sms_config.fromNumber` — add `toNumber` or `locationId` to the webhook body |
+| `{ok:false,reason:"loop_guard"}` | Inbound `phone` equals our own LC Phone. Usually means the workflow is firing on outbound sends — add `Direction = Inbound` |
 | `{ok:true,replySent:false,replyError:"empty_reply"}` | Bot returned no text (human_takeover or model refusal) |
 | Bot replies show up in inbox but visitor never receives them | Outbound SMS integration mis-configured — check `sms_provider` + `sms_config` on the `clients` row |
 | Webhook fires in a loop | Direction filter missing — add `Direction = Inbound` to the workflow trigger |

--- a/src/app/api/ghl/inbound-visitor-sms/route.ts
+++ b/src/app/api/ghl/inbound-visitor-sms/route.ts
@@ -10,8 +10,11 @@
  *   1. Visitor sends SMS to client's LC Phone (e.g. +1 949-997-3915)
  *   2. GHL Conversations webhook POSTs the inbound event to this route
  *      with ?secret=<GHL_WEBHOOK_SECRET>
- *   3. We resolve the client by matching the `toNumber` against
- *      `clients.sms_config.fromNumber`
+ *   3. We resolve the client, in priority order, by:
+ *        a. `toNumber` → `clients.sms_config.fromNumber`
+ *        b. `locationId` → `clients.sms_config.locationId`
+ *        c. the single active client that has `sms_config.fromNumber` set
+ *           (single-tenant fallback; multi-tenant ambiguity is an error)
  *   4. runTurn() stores the visitor message in front_desk_messages,
  *      generates a Claude reply, and applies escalation rules
  *   5. If the reply is non-empty and human_takeover is off, we send the
@@ -23,9 +26,13 @@
  * Shared secret ?secret=<GHL_WEBHOOK_SECRET> — same scheme as
  * /api/ghl/inbound-sms. Configure the value in Vercel.
  *
- * Webhook body (either shape accepted):
- *   GHL Conversations:  { phone, toNumber, body, contactId?, conversationId? }
- *   LC workflow:        { from, to, message }
+ * Webhook body (all shapes accepted):
+ *   GHL Conversations (recommended — GHL rejects {{message.to_number}}):
+ *     { "phone": "{{contact.phone}}", "body": "{{message.body}}" }
+ *   Optional fields that help disambiguate:
+ *     { ..., toNumber, locationId, contactId, conversationId }
+ *   LC workflow aliases:
+ *     { from, to, message, location_id, ... }
  *
  * Deploy-side config required
  * ---------------------------
@@ -47,7 +54,8 @@ import {
   buildOutboundVisitorReplyPayload,
   dispatchVisitorReply,
   extractInboundVisitorPayload,
-  findClientIdByInboundToPhone,
+  isOwnNumberLoop,
+  resolveClientForInboundVisitorSms,
 } from "@/lib/agents/inbound-visitor-sms-handler";
 import { getSmsIntegration } from "@/lib/agents/integrations/registry";
 import { runTurn } from "@/lib/agents/runner";
@@ -83,7 +91,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   const payload = extractInboundVisitorPayload(rawBody);
   if (!payload) {
     console.warn(
-      "[inbound-visitor-sms] missing phones in payload — ignoring",
+      "[inbound-visitor-sms] missing visitor phone in payload — ignoring",
       rawBody
     );
     return NextResponse.json(
@@ -92,10 +100,13 @@ export async function POST(req: NextRequest): Promise<Response> {
     );
   }
 
-  // ── Resolve client by LC Phone (toNumber) ─────────────────────────────────
-  let clientId: string | null;
+  // ── Resolve client ────────────────────────────────────────────────────────
+  let resolution;
   try {
-    clientId = await findClientIdByInboundToPhone(payload.toPhone);
+    resolution = await resolveClientForInboundVisitorSms({
+      toPhone: payload.toPhone,
+      locationId: payload.locationId,
+    });
   } catch (err) {
     console.error("[inbound-visitor-sms] client lookup failed:", err);
     return NextResponse.json(
@@ -103,12 +114,44 @@ export async function POST(req: NextRequest): Promise<Response> {
       { status: 200 }
     );
   }
-  if (!clientId) {
+
+  if (resolution.kind === "ambiguous") {
+    console.error(
+      `[inbound-visitor-sms] ambiguous client resolution — candidates=${resolution.candidates.join(
+        ","
+      )} toPhone=${payload.toPhone ?? "-"} locationId=${payload.locationId ?? "-"}`
+    );
+    return NextResponse.json(
+      {
+        ok: false,
+        reason: "ambiguous_client",
+        candidates: resolution.candidates,
+      },
+      { status: 200 }
+    );
+  }
+  if (resolution.kind === "none") {
     console.warn(
-      `[inbound-visitor-sms] no client configured for toPhone=${payload.toPhone} — ignoring`
+      `[inbound-visitor-sms] no client configured (toPhone=${
+        payload.toPhone ?? "-"
+      } locationId=${payload.locationId ?? "-"}) — ignoring`
     );
     return NextResponse.json(
       { ok: false, reason: "no_client_for_to_phone" },
+      { status: 200 }
+    );
+  }
+
+  const clientId = resolution.clientId;
+
+  // ── Loop guard — refuse if visitor phone equals our own LC Phone ─────────
+  const cfg = await getClientConfig(clientId);
+  if (isOwnNumberLoop(cfg, payload.fromPhone)) {
+    console.warn(
+      `[inbound-visitor-sms] loop guard tripped — fromPhone=${payload.fromPhone} matches own LC Phone for client=${clientId}`
+    );
+    return NextResponse.json(
+      { ok: false, reason: "loop_guard" },
       { status: 200 }
     );
   }
@@ -140,7 +183,6 @@ export async function POST(req: NextRequest): Promise<Response> {
   }
 
   // ── Dispatch outbound reply (when appropriate) ────────────────────────────
-  const cfg = await getClientConfig(clientId);
   const out = buildOutboundVisitorReplyPayload({
     cfg,
     agent: "frontDesk",
@@ -158,6 +200,8 @@ export async function POST(req: NextRequest): Promise<Response> {
   return NextResponse.json(
     {
       ok: true,
+      clientId,
+      resolvedVia: resolution.via,
       sessionId: runResult.sessionId,
       reply: runResult.reply,
       replySent: dispatch.sent,

--- a/src/lib/agents/inbound-visitor-sms-handler.test.ts
+++ b/src/lib/agents/inbound-visitor-sms-handler.test.ts
@@ -2,10 +2,14 @@
  * Tests for the inbound-visitor-SMS bridge (pure logic).
  *
  * Covers:
- *   - extractInboundVisitorPayload  — normalises GHL + LC webhook shapes
- *   - findClientIdByInboundToPhone  — resolves client by sms_config.fromNumber
- *   - buildOutboundVisitorReplyPayload — shape of the outbound send
- *   - dispatchVisitorReply  — fail-soft around the SMS integration
+ *   - extractInboundVisitorPayload           — normalises GHL + LC webhook shapes
+ *   - findClientIdByInboundToPhone           — resolves client by sms_config.fromNumber
+ *   - findClientIdByLocationId               — resolves client by sms_config.locationId
+ *   - findSoleActiveSmsClient                — single-tenant fallback
+ *   - resolveClientForInboundVisitorSms      — priority chain (toPhone → locationId → sole)
+ *   - isOwnNumberLoop                        — loop guard
+ *   - buildOutboundVisitorReplyPayload       — shape of the outbound send
+ *   - dispatchVisitorReply                   — fail-soft around the SMS integration
  */
 
 import { strict as assert } from "node:assert";
@@ -19,7 +23,9 @@ const sbSelectCalls: Array<{
   options: Record<string, unknown> | undefined;
 }> = [];
 
-let mockClientRows: Array<Record<string, unknown>> = [];
+// Per-call queue of rows — each call to sbSelect("clients", ...) pops the
+// next entry so we can script the priority-chain tests precisely.
+let mockClientRowQueue: Array<Array<Record<string, unknown>>> = [];
 
 mock.module("./supabase.ts", {
   namedExports: {
@@ -29,7 +35,9 @@ mock.module("./supabase.ts", {
       options?: Record<string, unknown>
     ) => {
       sbSelectCalls.push({ table, params, options });
-      if (table === "clients") return mockClientRows;
+      if (table === "clients") {
+        return mockClientRowQueue.shift() ?? [];
+      }
       return [];
     },
     sbInsert: async (_t: string, row: Record<string, unknown>) => ({
@@ -44,15 +52,24 @@ mock.module("./supabase.ts", {
 const {
   extractInboundVisitorPayload,
   findClientIdByInboundToPhone,
+  findClientIdByLocationId,
+  findSoleActiveSmsClient,
+  resolveClientForInboundVisitorSms,
+  isOwnNumberLoop,
   buildOutboundVisitorReplyPayload,
   dispatchVisitorReply,
 } = await import("./inbound-visitor-sms-handler.ts");
 
 import type { ClientConfig, MessagingIntegration } from "./types.ts";
 
+function resetMocks() {
+  sbSelectCalls.length = 0;
+  mockClientRowQueue = [];
+}
+
 // ── extractInboundVisitorPayload ───────────────────────────────────────────
 
-test("extractInboundVisitorPayload: GHL Conversations shape", () => {
+test("extractInboundVisitorPayload: GHL Conversations shape with toNumber", () => {
   const p = extractInboundVisitorPayload({
     phone: "+17145550123",
     toNumber: "+19499973915",
@@ -102,13 +119,35 @@ test("extractInboundVisitorPayload: null when fromPhone missing", () => {
   );
 });
 
-test("extractInboundVisitorPayload: null when toPhone missing", () => {
-  // Unlike owner-reply (which can fall back to recent session), visitor-SMS
-  // routing REQUIRES the destination to locate the client.
-  assert.equal(
-    extractInboundVisitorPayload({ phone: "+17145550123", body: "x" }),
-    null
-  );
+test("extractInboundVisitorPayload: canonical GHL shape without toNumber is accepted", () => {
+  // GHL rejects {{message.to_number}} in some workflow triggers, so the
+  // webhook body will commonly arrive with just `phone` + `body`. The
+  // client must be resolved downstream via locationId or the
+  // single-tenant fallback.
+  const p = extractInboundVisitorPayload({
+    phone: "+17145550123",
+    body: "hi",
+  });
+  assert.ok(p);
+  assert.equal(p.fromPhone, "+17145550123");
+  assert.equal(p.toPhone, undefined);
+  assert.equal(p.locationId, undefined);
+});
+
+test("extractInboundVisitorPayload: accepts locationId (camel or snake case)", () => {
+  const p1 = extractInboundVisitorPayload({
+    phone: "+17145550123",
+    body: "hi",
+    locationId: "vdWqRPcn6jIx8AK0DlHF",
+  });
+  assert.equal(p1?.locationId, "vdWqRPcn6jIx8AK0DlHF");
+
+  const p2 = extractInboundVisitorPayload({
+    phone: "+17145550123",
+    body: "hi",
+    location_id: "vdWqRPcn6jIx8AK0DlHF",
+  });
+  assert.equal(p2?.locationId, "vdWqRPcn6jIx8AK0DlHF");
 });
 
 test("extractInboundVisitorPayload: messageText defaults to empty string", () => {
@@ -123,9 +162,9 @@ test("extractInboundVisitorPayload: messageText defaults to empty string", () =>
 // ── findClientIdByInboundToPhone ───────────────────────────────────────────
 
 test("findClientIdByInboundToPhone: queries by sms_config->>fromNumber and active=true", async () => {
-  sbSelectCalls.length = 0;
-  mockClientRows = [
-    { client_id: "santa", sms_config: { fromNumber: "+19499973915" } },
+  resetMocks();
+  mockClientRowQueue = [
+    [{ client_id: "santa", sms_config: { fromNumber: "+19499973915" } }],
   ];
 
   const id = await findClientIdByInboundToPhone("+19499973915");
@@ -141,13 +180,162 @@ test("findClientIdByInboundToPhone: queries by sms_config->>fromNumber and activ
 });
 
 test("findClientIdByInboundToPhone: returns null when no client matches", async () => {
-  sbSelectCalls.length = 0;
-  mockClientRows = [];
+  resetMocks();
+  mockClientRowQueue = [[]];
   const id = await findClientIdByInboundToPhone("+10000000000");
   assert.equal(id, null);
 });
 
-// ── buildOutboundVisitorReplyPayload ───────────────────────────────────────
+// ── findClientIdByLocationId ───────────────────────────────────────────────
+
+test("findClientIdByLocationId: resolves via sms_config.locationId", async () => {
+  resetMocks();
+  mockClientRowQueue = [
+    [{ client_id: "santa", sms_config: { locationId: "loc_abc" } }],
+  ];
+
+  const id = await findClientIdByLocationId("loc_abc");
+  assert.equal(id, "santa");
+
+  const params = sbSelectCalls[0].params as Record<string, string>;
+  assert.equal(params["sms_config->>locationId"], "eq.loc_abc");
+  assert.equal(params.active, "eq.true");
+});
+
+test("findClientIdByLocationId: throws when two active clients share a locationId", async () => {
+  resetMocks();
+  mockClientRowQueue = [
+    [
+      { client_id: "santa", sms_config: { locationId: "loc_shared" } },
+      { client_id: "opsbynoell", sms_config: { locationId: "loc_shared" } },
+    ],
+  ];
+  await assert.rejects(
+    () => findClientIdByLocationId("loc_shared"),
+    /multiple active clients share sms_config.locationId/
+  );
+});
+
+// ── findSoleActiveSmsClient ────────────────────────────────────────────────
+
+test("findSoleActiveSmsClient: returns ok when exactly one active client has fromNumber", async () => {
+  resetMocks();
+  mockClientRowQueue = [
+    [{ client_id: "santa", sms_config: { fromNumber: "+19499973915" } }],
+  ];
+  const r = await findSoleActiveSmsClient();
+  assert.equal(r.kind, "ok");
+  if (r.kind === "ok") {
+    assert.equal(r.clientId, "santa");
+    assert.equal(r.fromNumber, "+19499973915");
+  }
+});
+
+test("findSoleActiveSmsClient: ambiguous when multiple clients configured", async () => {
+  resetMocks();
+  mockClientRowQueue = [
+    [
+      { client_id: "santa", sms_config: { fromNumber: "+19499973915" } },
+      { client_id: "opsbynoell", sms_config: { fromNumber: "+19495550000" } },
+    ],
+  ];
+  const r = await findSoleActiveSmsClient();
+  assert.equal(r.kind, "ambiguous");
+  if (r.kind === "ambiguous") {
+    assert.deepEqual(r.candidates.sort(), ["opsbynoell", "santa"]);
+  }
+});
+
+test("findSoleActiveSmsClient: none when no clients configured", async () => {
+  resetMocks();
+  mockClientRowQueue = [[]];
+  const r = await findSoleActiveSmsClient();
+  assert.equal(r.kind, "none");
+});
+
+// ── resolveClientForInboundVisitorSms ──────────────────────────────────────
+
+test("resolveClientForInboundVisitorSms: prefers toPhone when it resolves", async () => {
+  resetMocks();
+  mockClientRowQueue = [
+    // toPhone lookup → santa
+    [{ client_id: "santa", sms_config: { fromNumber: "+19499973915" } }],
+  ];
+  const r = await resolveClientForInboundVisitorSms({
+    toPhone: "+19499973915",
+    locationId: "loc_abc",
+  });
+  assert.equal(r.kind, "ok");
+  if (r.kind === "ok") {
+    assert.equal(r.clientId, "santa");
+    assert.equal(r.via, "toPhone");
+  }
+  // Only the toPhone query should have fired — locationId never consulted.
+  assert.equal(sbSelectCalls.length, 1);
+});
+
+test("resolveClientForInboundVisitorSms: falls back to locationId when toPhone misses", async () => {
+  resetMocks();
+  mockClientRowQueue = [
+    [], // toPhone miss
+    [{ client_id: "santa", sms_config: { locationId: "loc_abc" } }], // locationId hit
+  ];
+  const r = await resolveClientForInboundVisitorSms({
+    toPhone: "+10000000000",
+    locationId: "loc_abc",
+  });
+  assert.equal(r.kind, "ok");
+  if (r.kind === "ok") {
+    assert.equal(r.clientId, "santa");
+    assert.equal(r.via, "locationId");
+  }
+});
+
+test("resolveClientForInboundVisitorSms: falls back to sole active client when neither toPhone nor locationId supplied", async () => {
+  resetMocks();
+  mockClientRowQueue = [
+    // No toPhone query (not provided). No locationId query. Sole-client query only.
+    [{ client_id: "santa", sms_config: { fromNumber: "+19499973915" } }],
+  ];
+  const r = await resolveClientForInboundVisitorSms({});
+  assert.equal(r.kind, "ok");
+  if (r.kind === "ok") {
+    assert.equal(r.clientId, "santa");
+    assert.equal(r.via, "sole");
+  }
+  assert.equal(sbSelectCalls.length, 1);
+});
+
+test("resolveClientForInboundVisitorSms: returns ambiguous when the sole-fallback would match multiple clients", async () => {
+  resetMocks();
+  mockClientRowQueue = [
+    [
+      { client_id: "santa", sms_config: { fromNumber: "+19499973915" } },
+      { client_id: "opsbynoell", sms_config: { fromNumber: "+19495550000" } },
+    ],
+  ];
+  const r = await resolveClientForInboundVisitorSms({});
+  assert.equal(r.kind, "ambiguous");
+  if (r.kind === "ambiguous") {
+    assert.deepEqual(r.candidates.sort(), ["opsbynoell", "santa"]);
+  }
+});
+
+test("resolveClientForInboundVisitorSms: returns none when no strategy resolves", async () => {
+  resetMocks();
+  mockClientRowQueue = [
+    [], // toPhone miss
+    [], // locationId miss
+    [], // no sole client
+  ];
+  const r = await resolveClientForInboundVisitorSms({
+    toPhone: "+10000000000",
+    locationId: "loc_nope",
+  });
+  assert.equal(r.kind, "none");
+});
+
+// ── isOwnNumberLoop ────────────────────────────────────────────────────────
 
 const stubCfg: ClientConfig = {
   clientId: "santa",
@@ -155,7 +343,23 @@ const stubCfg: ClientConfig = {
   vertical: "massage",
   agents: { support: false, frontDesk: true, care: false },
   active: true,
+  smsConfig: { fromNumber: "+19499973915" },
 };
+
+test("isOwnNumberLoop: true when visitor phone equals our own LC Phone", () => {
+  assert.equal(isOwnNumberLoop(stubCfg, "+19499973915"), true);
+});
+
+test("isOwnNumberLoop: false for a normal visitor phone", () => {
+  assert.equal(isOwnNumberLoop(stubCfg, "+17145550123"), false);
+});
+
+test("isOwnNumberLoop: false when fromNumber is not configured", () => {
+  const cfg: ClientConfig = { ...stubCfg, smsConfig: {} };
+  assert.equal(isOwnNumberLoop(cfg, "+17145550123"), false);
+});
+
+// ── buildOutboundVisitorReplyPayload ───────────────────────────────────────
 
 test("buildOutboundVisitorReplyPayload: returns to/body/agent/sessionId/clientId", () => {
   const out = buildOutboundVisitorReplyPayload({

--- a/src/lib/agents/inbound-visitor-sms-handler.ts
+++ b/src/lib/agents/inbound-visitor-sms-handler.ts
@@ -7,7 +7,13 @@
  *                                existing conversation)
  *
  * On each inbound visitor SMS we:
- *   1. Resolve which client owns the LC Phone (by `sms_config.fromNumber`)
+ *   1. Resolve which client owns the LC Phone. Resolution tries in order:
+ *        a. `toPhone` matches `clients.sms_config->>fromNumber`
+ *        b. `locationId` matches `clients.sms_config->>locationId`
+ *        c. exactly one active client has a `sms_config.fromNumber`
+ *           configured (single-tenant fallback — safe for the current
+ *           one-tenant-per-LC-Phone install; explicitly errors out when
+ *           multiple clients would match)
  *   2. Call runTurn() to persist the visitor message and generate a reply
  *   3. If human_takeover is on OR the reply is empty, skip the outbound
  *   4. Otherwise, send the bot's reply back to the visitor via the
@@ -27,8 +33,15 @@ import type { AgentKind, ClientConfig, MessagingIntegration } from "./types";
 export interface InboundVisitorSmsPayload {
   /** The visitor / lead phone number (E.164). */
   fromPhone: string;
-  /** The LC Phone number that received the SMS (E.164) — used to resolve client. */
-  toPhone: string;
+  /**
+   * The LC Phone number that received the SMS (E.164) — preferred way to
+   * resolve the client. Optional because GHL rejects `{{message.to_number}}`
+   * in some workflow triggers; in that case we fall back to `locationId`
+   * or the single-client shortcut.
+   */
+  toPhone?: string;
+  /** Optional GHL locationId — used as a fallback for client resolution. */
+  locationId?: string;
   /** Message body as sent by the visitor. */
   messageText: string;
   /** Optional GHL contact id, when the webhook supplies it. */
@@ -73,13 +86,15 @@ export type InboundVisitorSmsResult =
  * Normalise a GHL / LeadConnector Conversations webhook body into the
  * shape we need.
  *
- * GHL Conversations webhook (primary):
+ * GHL Conversations webhook (canonical — no toNumber required):
+ *   { phone, body, contactId?, conversationId?, locationId? }
+ *
+ * Legacy / richer shapes (still supported):
  *   { phone, toNumber, body, contactId?, conversationId? }
+ *   { from, to, message }                       // LC workflow aliases
  *
- * LC workflow action (alternate aliases):
- *   { from, to, message }
- *
- * Returns null when either phone is missing — we can't route without both.
+ * Returns null when the visitor phone is missing — we can't do anything
+ * without knowing who texted in.
  */
 export function extractInboundVisitorPayload(
   body: Record<string, unknown>
@@ -91,8 +106,14 @@ export function extractInboundVisitorPayload(
 
   const toPhone =
     (body.toNumber as string | undefined) ??
+    (body.to_number as string | undefined) ??
     (body.to as string | undefined) ??
-    null;
+    undefined;
+
+  const locationId =
+    (body.locationId as string | undefined) ??
+    (body.location_id as string | undefined) ??
+    undefined;
 
   const messageText =
     (body.body as string | undefined) ??
@@ -109,12 +130,19 @@ export function extractInboundVisitorPayload(
     (body.conversation_id as string | undefined) ??
     undefined;
 
-  if (!fromPhone || !toPhone) return null;
-  return { fromPhone, toPhone, messageText, contactId, conversationId };
+  if (!fromPhone) return null;
+  return {
+    fromPhone,
+    toPhone: toPhone || undefined,
+    locationId: locationId || undefined,
+    messageText,
+    contactId,
+    conversationId,
+  };
 }
 
 // ---------------------------------------------------------------------------
-// Client resolution by LC Phone number
+// Client resolution
 // ---------------------------------------------------------------------------
 
 interface ClientSmsIndexRow {
@@ -128,10 +156,6 @@ interface ClientSmsIndexRow {
  *
  * Returns the `client_id` of the first match, or null when no client is
  * configured for that LC Phone.
- *
- * NOTE: We intentionally select by the narrow pair of fields rather than
- * pulling the full config — getClientConfig() will fetch + memoize the full
- * row afterwards.
  */
 export async function findClientIdByInboundToPhone(
   toPhone: string
@@ -142,6 +166,105 @@ export async function findClientIdByInboundToPhone(
     { limit: 1, select: "client_id,sms_config" }
   );
   return rows[0]?.client_id ?? null;
+}
+
+/**
+ * Fallback resolver — match on `sms_config.locationId` (the GHL location
+ * that owns the LC Phone). Used when the webhook payload omits `toNumber`
+ * but supplies `locationId` instead (either explicitly in the body or
+ * via the LC `{{location.id}}` merge field).
+ */
+export async function findClientIdByLocationId(
+  locationId: string
+): Promise<string | null> {
+  const rows = await sbSelect<ClientSmsIndexRow>(
+    "clients",
+    {
+      "sms_config->>locationId": `eq.${locationId}`,
+      active: "eq.true",
+    },
+    { limit: 2, select: "client_id,sms_config" }
+  );
+  if (rows.length === 0) return null;
+  if (rows.length > 1) {
+    // Two clients sharing a locationId is a config bug — refuse rather
+    // than silently routing to the first row.
+    throw new Error(
+      `multiple active clients share sms_config.locationId=${locationId}`
+    );
+  }
+  return rows[0].client_id;
+}
+
+/**
+ * Last-resort resolver for the single-tenant case. Returns a `client_id`
+ * only when there is EXACTLY ONE active client with a configured
+ * `sms_config.fromNumber` — in other words, the resolution is
+ * unambiguous. Returns `{ambiguous:true, candidates:[...]}` if more than
+ * one would match, and `null` when none do.
+ */
+export async function findSoleActiveSmsClient(): Promise<
+  | { kind: "ok"; clientId: string; fromNumber?: string }
+  | { kind: "none" }
+  | { kind: "ambiguous"; candidates: string[] }
+> {
+  const rows = await sbSelect<ClientSmsIndexRow>(
+    "clients",
+    {
+      "sms_config->>fromNumber": "not.is.null",
+      active: "eq.true",
+    },
+    { limit: 5, select: "client_id,sms_config" }
+  );
+  if (rows.length === 0) return { kind: "none" };
+  if (rows.length > 1) {
+    return { kind: "ambiguous", candidates: rows.map((r) => r.client_id) };
+  }
+  const fromNumber =
+    (rows[0].sms_config?.fromNumber as string | undefined) ?? undefined;
+  return { kind: "ok", clientId: rows[0].client_id, fromNumber };
+}
+
+export type ResolveClientResult =
+  | { kind: "ok"; clientId: string; via: "toPhone" | "locationId" | "sole" }
+  | { kind: "none" }
+  | { kind: "ambiguous"; candidates: string[] };
+
+/**
+ * High-level client resolution — tries the strategies in order and
+ * returns a tagged result the route can map onto response codes.
+ *
+ * Priority:
+ *   1. toPhone → sms_config.fromNumber
+ *   2. locationId → sms_config.locationId
+ *   3. exactly one active client with sms_config.fromNumber set
+ *
+ * The `sole` fallback intentionally errors out if two or more clients
+ * would match — that guarantees we never misroute a visitor message to
+ * the wrong tenant.
+ */
+export async function resolveClientForInboundVisitorSms(input: {
+  toPhone?: string;
+  locationId?: string;
+}): Promise<ResolveClientResult> {
+  if (input.toPhone) {
+    const id = await findClientIdByInboundToPhone(input.toPhone);
+    if (id) return { kind: "ok", clientId: id, via: "toPhone" };
+  }
+
+  if (input.locationId) {
+    const id = await findClientIdByLocationId(input.locationId);
+    if (id) return { kind: "ok", clientId: id, via: "locationId" };
+  }
+
+  const sole = await findSoleActiveSmsClient();
+  if (sole.kind === "ok") {
+    return { kind: "ok", clientId: sole.clientId, via: "sole" };
+  }
+  if (sole.kind === "ambiguous") {
+    return { kind: "ambiguous", candidates: sole.candidates };
+  }
+  return { kind: "none" };
 }
 
 // ---------------------------------------------------------------------------
@@ -168,6 +291,26 @@ export function buildOutboundVisitorReplyPayload(params: {
     sessionId: params.sessionId,
     clientId: params.cfg.clientId,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Loop-guard — refuse to reply when fromPhone equals our own LC Phone.
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the inbound `fromPhone` matches the client's own
+ * `sms_config.fromNumber` — which would mean either GHL looped an
+ * outbound send back into the webhook OR someone mis-wired the payload.
+ * Either way, we must not reply.
+ */
+export function isOwnNumberLoop(
+  cfg: ClientConfig,
+  fromPhone: string
+): boolean {
+  const ownNumber =
+    ((cfg.smsConfig ?? {}) as Record<string, unknown>).fromNumber ?? undefined;
+  if (!ownNumber) return false;
+  return String(ownNumber) === fromPhone;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The live `/api/ghl/inbound-visitor-sms` endpoint was returning `{ok:false, reason:"missing_phones"}` because GHL rejects the `{{message.to_number}}` merge field in workflow triggers. The workflow body we can actually ship (`{"phone":"{{contact.phone}}","body":"{{message.body}}"}`) therefore never routed to a client.

This change makes `toNumber` optional and adds two resolution fallbacks — `locationId` then a strict single-active-client shortcut — with an explicit `ambiguous_client` error when the fallback would misroute between tenants.

## Changes

- **`extractInboundVisitorPayload`** — `toNumber` is now optional. Only the visitor phone (`phone` / `from`) is required. Adds support for `locationId` / `location_id` merge fields.
- **`resolveClientForInboundVisitorSms`** — new priority chain:
    1. `toPhone` → `clients.sms_config.fromNumber`
    2. `locationId` → `clients.sms_config.locationId`
    3. exactly one active client with `sms_config.fromNumber` set
  Returns `{kind:"ambiguous"}` if multiple clients could match strategy (3) — the route maps that to `{ok:false, reason:"ambiguous_client", candidates:[...]}` so we never silently misroute.
- **`isOwnNumberLoop`** — server-side loop guard. Refuses to reply when the inbound `fromPhone` equals the client's own `sms_config.fromNumber`. Belt-and-suspenders on top of the required GHL `Direction=Inbound` workflow filter.
- **Route** — richer response (`clientId`, `resolvedVia`) and new `loop_guard` / `ambiguous_client` failure reasons. Still returns HTTP 200 on all soft failures to prevent GHL retry storms.
- **Tests** — 20 new/updated unit tests covering the priority chain, ambiguity, loop guard, toNumber-less payload, and locationId aliases. All 112 tests in the suite pass.
- **Docs** — `docs/inbound-visitor-sms.md` now documents the minimal GHL body, the resolution table, every failure `reason`, and three curl smoke tests.

No public / marketing copy touched.

## Test plan

- [x] `npm test` — all 112 tests pass (28 in `inbound-visitor-sms-handler.test.ts`)
- [x] `tsc --noEmit` — zero errors in app code
- [x] `npm run lint` on changed files — clean
- [ ] Re-run the `curl` smoke test from the task brief with the intended GHL body; expect `{ok:true, clientId:"…", resolvedVia:"sole", …}` (or `"toPhone"` if `toNumber` is supplied). Do NOT send a live SMS test from CI — exercise via the GHL staging workflow.
- [ ] In GHL, update the workflow webhook body to the minimal shape (`{"phone":"{{contact.phone}}","body":"{{message.body}}"}`) and confirm an inbound lead SMS routes + replies end-to-end.

## Verification steps for reviewers

```bash
# Minimal body — resolves via the single-client fallback.
curl -s -X POST "$URL?secret=$SECRET" \
  -H "Content-Type: application/json" \
  -d '{"phone":"+17145550123","body":"smoke test"}' | jq .

# With explicit toNumber — resolves via sms_config.fromNumber.
curl -s -X POST "$URL?secret=$SECRET" \
  -H "Content-Type: application/json" \
  -d '{"phone":"+17145550123","toNumber":"+19499973915","body":"smoke test"}' | jq .

# With locationId — resolves via sms_config.locationId.
curl -s -X POST "$URL?secret=$SECRET" \
  -H "Content-Type: application/json" \
  -d '{"phone":"+17145550123","locationId":"Un5H1b2zXJM3agZ56j7c","body":"smoke test"}' | jq .
```

Check `resolvedVia` in the response to confirm the path taken.