### PR TITLE
fix(ghl): unblock inbound-visitor-sms runTurn for opsbynoell

### DIFF
--- a/MANUAL_STEPS.md
+++ b/MANUAL_STEPS.md
@@ -258,6 +258,48 @@ Check GHL Conversations for the contact `+17145551234` — should see a WhatsApp
 
 ---
 
+## Step 9 — Enable frontDesk for `opsbynoell` (inbound visitor-SMS bridge)
+
+The `/api/ghl/inbound-visitor-sms` webhook always runs under `agent=frontDesk`
+because the shared runner writes to `front_desk_sessions` / `front_desk_messages`.
+The original `opsbynoell` seed set `agents.frontDesk = false`, which makes
+`runTurn` abort with `agent_not_enabled` before any session row is written.
+
+The seed file has been updated to `true`, but production rows are only
+overwritten when the `opsbynoell_seed_ghl.sql` is re-run (the `ON CONFLICT
+... DO UPDATE ... agents = EXCLUDED.agents` clause takes care of that).
+If you don't want to re-run the full seed, patch just the one column:
+
+```sql
+UPDATE public.clients
+SET agents = agents || '{"frontDesk": true}'::jsonb
+WHERE id = 'opsbynoell';
+```
+
+Verify:
+
+```sql
+SELECT id, agents FROM public.clients WHERE id = 'opsbynoell';
+```
+
+Expected: `agents` JSON should contain `"frontDesk": true`.
+
+Smoke test (without sending live SMS — dispatch fails soft and is visible
+via `replyError` in the response):
+
+```bash
+curl -X POST "https://www.opsbynoell.com/api/ghl/inbound-visitor-sms?secret=$GHL_WEBHOOK_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"phone":"+19497849726","body":"Controlled bridge test after frontDesk enable."}'
+```
+
+Expected response shape: `{"ok":true, "clientId":"opsbynoell", "sessionId":"...", ...}`.
+A new row should appear in `public.front_desk_sessions` and two rows (visitor
++ bot) in `public.front_desk_messages`. If `ok:false` with
+`reason:"agent_not_enabled"`, the DB update above has not been applied.
+
+---
+
 ## What is already done (no action required)
 
 - **Task 1 — Widget site-wide:** `AgentRouter` component in `src/app/layout.tsx` already renders the correct widget on every page. No changes needed.

--- a/src/app/api/ghl/inbound-visitor-sms/route.ts
+++ b/src/app/api/ghl/inbound-visitor-sms/route.ts
@@ -58,7 +58,7 @@ import {
   resolveClientForInboundVisitorSms,
 } from "@/lib/agents/inbound-visitor-sms-handler";
 import { getSmsIntegration } from "@/lib/agents/integrations/registry";
-import { runTurn } from "@/lib/agents/runner";
+import { RunTurnError, runTurn } from "@/lib/agents/runner";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -175,7 +175,22 @@ export async function POST(req: NextRequest): Promise<Response> {
       defaultTriggerType: "inbound_text",
     });
   } catch (err) {
-    console.error("[inbound-visitor-sms] runTurn failed:", err);
+    // Map runner preconditions onto stable reason codes so the caller
+    // (and production logs) can tell a config-mismatch apart from a
+    // generic runtime blow-up without exposing raw error text.
+    if (err instanceof RunTurnError) {
+      console.error(
+        `[inbound-visitor-sms] runTurn precondition failed — code=${err.code} client=${clientId} agent=frontDesk: ${err.message}`
+      );
+      return NextResponse.json(
+        { ok: false, reason: err.code },
+        { status: 200 }
+      );
+    }
+    console.error(
+      `[inbound-visitor-sms] runTurn failed — client=${clientId} agent=frontDesk:`,
+      err
+    );
     return NextResponse.json(
       { ok: false, reason: "run_turn_failed" },
       { status: 200 }

--- a/src/lib/agents/runner.test.ts
+++ b/src/lib/agents/runner.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for runTurn's precondition checks — the gate that protects
+ * against misconfigured `clients` rows before any DB writes happen.
+ *
+ * These cover the failure mode that silently broke the inbound-visitor-SMS
+ * bridge: a client row resolved correctly via sms_config.fromNumber but
+ * had agents.frontDesk=false, which made the route bubble up as the
+ * opaque `run_turn_failed` reason with no session/message row written.
+ */
+
+import { strict as assert } from "node:assert";
+import { mock, test } from "node:test";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+// `clients` row returned by getClientConfig. Override per test.
+let mockClient: Record<string, unknown> | null = null;
+
+// Track inserts to prove the runner short-circuited before any DB writes
+// on the precondition-failure paths.
+const sbInsertCalls: Array<{ table: string; row: Record<string, unknown> }> = [];
+
+mock.module("./supabase.ts", {
+  namedExports: {
+    sbSelect: async (table: string) => {
+      if (table === "clients" && mockClient) return [mockClient];
+      return [];
+    },
+    sbInsert: async (table: string, row: Record<string, unknown>) => {
+      sbInsertCalls.push({ table, row });
+      return { id: "inserted", ...row };
+    },
+    sbUpdate: async () => [],
+    sbUpsert: async () => ({}),
+  },
+});
+
+// Stub the Claude client so precondition tests never hit the network.
+// Happy-path tests set their own mocks where needed.
+mock.module("./claude.ts", {
+  namedExports: {
+    claudeComplete: async () => ({
+      text: "stub reply",
+      stopReason: "end_turn",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    }),
+    classifyIntent: async () => ({
+      intent: "unknown",
+      escalate: false,
+      reason: "",
+    }),
+  },
+});
+
+// Do not let the config loader memoize across tests — reset it by
+// re-importing after changing mockClient. The simplest approach: clear
+// the module cache entry before each test that needs a different client
+// config. We expose a helper.
+const { runTurn, RunTurnError } = await import("./runner.ts");
+
+function resetCalls() {
+  sbInsertCalls.length = 0;
+}
+
+// ── RunTurnError shape ─────────────────────────────────────────────────────
+
+test("RunTurnError carries a machine-readable code", () => {
+  const err = new RunTurnError("agent_not_enabled", "msg");
+  assert.equal(err.code, "agent_not_enabled");
+  assert.equal(err.name, "RunTurnError");
+  assert.ok(err instanceof Error);
+});
+
+// ── Precondition: client_not_active ────────────────────────────────────────
+
+test("runTurn throws RunTurnError(client_not_active) when active=false", async () => {
+  resetCalls();
+  mockClient = {
+    client_id: "inactive_client",
+    business_name: "Inactive Biz",
+    agents: { support: true, frontDesk: true, care: false },
+    active: false,
+  };
+
+  await assert.rejects(
+    () =>
+      runTurn({
+        agent: "frontDesk",
+        payload: {
+          clientId: "inactive_client",
+          agent: "frontDesk",
+          channel: "sms",
+          from: { phone: "+17145550123" },
+          message: "hi",
+        },
+        tables: {
+          sessions: "front_desk_sessions",
+          messages: "front_desk_messages",
+        },
+        defaultTriggerType: "inbound_text",
+      }),
+    (err: unknown) =>
+      err instanceof RunTurnError && err.code === "client_not_active"
+  );
+
+  // No DB writes on precondition failure.
+  assert.equal(sbInsertCalls.length, 0);
+});
+
+// ── Precondition: agent_not_enabled (the bug we're fixing) ─────────────────
+
+test("runTurn throws RunTurnError(agent_not_enabled) when the resolved client has frontDesk=false", async () => {
+  resetCalls();
+  // Mirror the production `opsbynoell` row shape that broke the bridge:
+  // resolves via sms_config.fromNumber but explicitly opts out of frontDesk.
+  mockClient = {
+    client_id: "opsbynoell_like",
+    business_name: "Ops-by-Noell-like",
+    agents: { support: true, frontDesk: false, care: false },
+    sms_config: { fromNumber: "+19499973915" },
+    active: true,
+  };
+
+  await assert.rejects(
+    () =>
+      runTurn({
+        agent: "frontDesk",
+        payload: {
+          clientId: "opsbynoell_like",
+          agent: "frontDesk",
+          channel: "sms",
+          from: { phone: "+17145550123" },
+          message: "hi",
+        },
+        tables: {
+          sessions: "front_desk_sessions",
+          messages: "front_desk_messages",
+        },
+        defaultTriggerType: "inbound_text",
+      }),
+    (err: unknown) => {
+      if (!(err instanceof RunTurnError)) return false;
+      if (err.code !== "agent_not_enabled") return false;
+      // Message should mention the agent and client for operator diagnostics.
+      return (
+        err.message.includes("frontDesk") &&
+        err.message.includes("opsbynoell_like")
+      );
+    }
+  );
+
+  // Critically, no session/message rows created — matches the
+  // observed production behaviour (no new front_desk_sessions / messages).
+  assert.equal(sbInsertCalls.length, 0);
+});
+
+// ── Happy path: active client with frontDesk=true does NOT throw ───────────
+
+test("runTurn persists a session + two messages when frontDesk is enabled", async () => {
+  resetCalls();
+  mockClient = {
+    client_id: "opsbynoell_fixed",
+    business_name: "Ops-by-Noell-fixed",
+    agents: { support: true, frontDesk: true, care: false },
+    sms_config: { fromNumber: "+19499973915" },
+    active: true,
+  };
+
+  const result = await runTurn({
+    agent: "frontDesk",
+    payload: {
+      clientId: "opsbynoell_fixed",
+      agent: "frontDesk",
+      channel: "sms",
+      from: { phone: "+17145550123" },
+      message: "Controlled bridge test after optional toNumber fix.",
+    },
+    tables: {
+      sessions: "front_desk_sessions",
+      messages: "front_desk_messages",
+    },
+    defaultTriggerType: "inbound_text",
+  });
+
+  assert.equal(result.reply, "stub reply");
+  assert.equal(result.intent, "unknown");
+  assert.equal(result.escalated, false);
+
+  // 1 session insert, 2 message inserts (visitor + bot).
+  const sessionInserts = sbInsertCalls.filter(
+    (c) => c.table === "front_desk_sessions"
+  );
+  const messageInserts = sbInsertCalls.filter(
+    (c) => c.table === "front_desk_messages"
+  );
+  assert.equal(sessionInserts.length, 1);
+  assert.equal(messageInserts.length, 2);
+  assert.equal(messageInserts[0].row.role, "visitor");
+  assert.equal(messageInserts[1].row.role, "bot");
+});

--- a/src/lib/agents/runner.ts
+++ b/src/lib/agents/runner.ts
@@ -39,6 +39,26 @@ interface RunnerTables {
 }
 
 /**
+ * Precondition failure raised by `runTurn` before any database writes.
+ *
+ * Callers map `code` to a stable machine-readable reason in their HTTP
+ * response without leaking the internal message text. Existing callers
+ * that only log `err.message` keep working because we still set it.
+ */
+export type RunTurnErrorCode =
+  | "client_not_active"
+  | "agent_not_enabled";
+
+export class RunTurnError extends Error {
+  readonly code: RunTurnErrorCode;
+  constructor(code: RunTurnErrorCode, message: string) {
+    super(message);
+    this.name = "RunTurnError";
+    this.code = code;
+  }
+}
+
+/**
  * In-process rate-limit map for every-turn SMS alerts.
  *
  * Keyed by session id, value is the epoch-ms of the last shadow-SMS send.
@@ -146,10 +166,14 @@ export async function runTurn({
 }): Promise<AgentMessageResponse> {
   const cfg = await getClientConfig(payload.clientId);
   if (!cfg.active) {
-    throw new Error(`Client ${payload.clientId} is not active`);
+    throw new RunTurnError(
+      "client_not_active",
+      `Client ${payload.clientId} is not active`
+    );
   }
   if (!cfg.agents[agent]) {
-    throw new Error(
+    throw new RunTurnError(
+      "agent_not_enabled",
       `Agent "${agent}" is not enabled for client ${payload.clientId}`
     );
   }

--- a/supabase/seeds/opsbynoell_seed_ghl.sql
+++ b/supabase/seeds/opsbynoell_seed_ghl.sql
@@ -71,7 +71,10 @@ VALUES (
   'internal',
   '+19499973915',
   'hello@opsbynoell.com',
-  '{"support": true, "frontDesk": false, "care": false}'::jsonb,
+  -- frontDesk=true so the inbound-visitor-SMS webhook (which hard-codes
+  -- agent=frontDesk) can reply to leads who text +19499973915. See
+  -- src/app/api/ghl/inbound-visitor-sms/route.ts + MANUAL_STEPS Step 9.
+  '{"support": true, "frontDesk": true, "care": false}'::jsonb,
 
   -- Support system prompt
   'You are the Support agent for Ops by Noell, a small automation agency run by Nikki. Ops by Noell sells three tiers of AI-powered agents to service businesses: Noell Support (website chat + lead capture), Noell Front Desk (24/7 missed-call text-back + booking), and Noell Care (returning-client scheduling and follow-up).


### PR DESCRIPTION
## Summary

Production `/api/ghl/inbound-visitor-sms` returned `{ok:false, reason:"run_turn_failed"}` for a valid payload (`{phone:"+19497849726", body:"Controlled bridge test after optional toNumber fix."}`) with a valid `secret`, and **no** new `front_desk_sessions` or `front_desk_messages` rows were created. This PR fixes it.

### Root cause

`resolveClientForInboundVisitorSms` correctly routes to the `opsbynoell` client (the sole active client with `sms_config.fromNumber = +19499973915`). The route hard-codes `agent: "frontDesk"`, but the original `opsbynoell` seed set `agents.frontDesk = false`. `runTurn` enforces `!cfg.agents[agent]` before any DB write, so it threw and the route caught it into the generic `run_turn_failed` reason — opaque from the response, visible only in Vercel logs.

### Fix

- **`supabase/seeds/opsbynoell_seed_ghl.sql`** — set `agents.frontDesk = true`. Front Desk is the correct agent for visitor-SMS traffic landing on Nikki's LC Phone (the existing visitor-SMS route always writes into `front_desk_sessions/messages`).
- **`src/lib/agents/runner.ts`** — introduce `RunTurnError` with typed `code` (`client_not_active`, `agent_not_enabled`). Existing callers that just log `err.message` keep working; new callers can switch on `code`.
- **`src/app/api/ghl/inbound-visitor-sms/route.ts`** — map `RunTurnError.code` into the response `reason` so future config drift shows up as `reason:"agent_not_enabled"` / `"client_not_active"` rather than the opaque `run_turn_failed`. Server log also includes `client=<id> agent=frontDesk` for triage. Raw error text is **not** leaked to the caller.
- **`MANUAL_STEPS.md`** — Step 9 documents the one-shot `UPDATE` to apply the seed change in production (seed is a source of truth, prod rows are not auto-synced).
- **`src/lib/agents/runner.test.ts`** — new: covers the `client_not_active` / `agent_not_enabled` precondition paths (asserts **no** `sbInsert` calls, matching the observed prod behavior) and a happy-path test that persists a session + visitor-message + bot-message.

### What is intentionally NOT in this PR

- No public site copy changes.
- No GHL dashboard / webhook config changes.
- No live SMS dispatched — the test at the bottom of `MANUAL_STEPS` Step 9 fails dispatch soft and exposes the error in `replyError`.

## How to verify (after merge + DB update)

1. **Apply the DB patch** (not auto-applied by merge):
   ```sql
   UPDATE public.clients
   SET agents = agents || '{"frontDesk": true}'::jsonb
   WHERE id = 'opsbynoell';
   ```
   Verify: `SELECT id, agents FROM public.clients WHERE id = 'opsbynoell';` → `agents.frontDesk = true`.

2. **Re-run the controlled curl** (unchanged from the triage run — no live SMS will be sent because the outbound dispatch path is safe to fail-soft):
   ```bash
   curl -X POST "https://www.opsbynoell.com/api/ghl/inbound-visitor-sms?secret=$GHL_WEBHOOK_SECRET" \
     -H "Content-Type: application/json" \
     -d '{"phone":"+19497849726","body":"Controlled bridge test after frontDesk enable."}'
   ```

3. **Expected response shape:**
   ```json
   {"ok":true,"clientId":"opsbynoell","resolvedVia":"toPhone"|"sole","sessionId":"...","reply":"...","replySent":true|false,"replyMessageId":"...","escalated":false,"intent":"..."}
   ```
   `replySent:false` with a descriptive `replyError` is fine — it means the reply was generated and stored but the outbound SMS was blocked (e.g. loop guard would have caught a self-send).

4. **Supabase verification:**
   ```sql
   SELECT id, client_id, trigger_type, channel, visitor_phone, created_at
   FROM public.front_desk_sessions
   WHERE client_id = 'opsbynoell'
   ORDER BY created_at DESC LIMIT 5;

   SELECT session_id, role, left(content, 80) AS content, created_at
   FROM public.front_desk_messages
   WHERE session_id IN (SELECT id FROM public.front_desk_sessions WHERE client_id = 'opsbynoell' ORDER BY created_at DESC LIMIT 1)
   ORDER BY created_at;
   ```
   Should show exactly 1 new session and 2 messages (visitor + bot).

5. **Regression guard** — if the DB patch is NOT applied, response should now read `{ok:false, reason:"agent_not_enabled"}` (previously `run_turn_failed`), making the misconfiguration self-describing.

## Test plan

- [x] `npx eslint src/lib/agents/runner.ts src/lib/agents/runner.test.ts src/app/api/ghl/inbound-visitor-sms/route.ts` — clean
- [x] `npx tsc --noEmit` — no new type errors in the touched files (pre-existing `@tabler/icons-react` declaration noise and the `.ts` import-extension noise in other test files are unaffected)
- [ ] `npm test` — requires Node 22 (`--experimental-strip-types --experimental-test-module-mocks`) which the sandbox lacks; `runner.test.ts` follows the same module-mock pattern as the existing `inbound-sms-webhook.test.ts` / `inbound-visitor-sms-handler.test.ts` and should run cleanly in CI
- [ ] Controlled curl against production after the `UPDATE` in `MANUAL_STEPS` Step 9 (see "How to verify" above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)