### PR TITLE
feat(twilio): direct A2P 10DLC sender via Messaging Service

### DIFF
--- a/scripts/twilio-smoke-test.ts
+++ b/scripts/twilio-smoke-test.ts
@@ -2,8 +2,14 @@
 /**
  * Twilio smoke test — sends one SMS to verify the A2P swap is live.
  *
- * Usage:
- *   TWILIO_ACCOUNT_SID=AC... TWILIO_AUTH_TOKEN=... TWILIO_FROM_NUMBER=+1... \
+ * Recommended (Messaging Service / A2P 10DLC):
+ *   TWILIO_ACCOUNT_SID=AC... \
+ *   TWILIO_AUTH_TOKEN=...  (or TWILIO_API_KEY_SID + TWILIO_API_KEY_SECRET) \
+ *   TWILIO_MESSAGING_SERVICE_SID=MG... \
+ *     npm run twilio:smoke -- +19491234567
+ *
+ * Fallback (single FROM number):
+ *   TWILIO_ACCOUNT_SID=... TWILIO_AUTH_TOKEN=... TWILIO_FROM_NUMBER=+1... \
  *     npm run twilio:smoke -- +19491234567
  *
  * Exits 0 on success (prints the message SID), 1 on failure.
@@ -12,12 +18,29 @@
 export {};
 
 const sid = process.env.TWILIO_ACCOUNT_SID;
+const apiKeySid = process.env.TWILIO_API_KEY_SID;
+const apiKeySecret = process.env.TWILIO_API_KEY_SECRET;
 const token = process.env.TWILIO_AUTH_TOKEN;
+const messagingServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID;
 const from = process.env.TWILIO_FROM_NUMBER;
 const to = process.argv[2];
 
-if (!sid || !token || !from) {
-  console.error("Missing TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, or TWILIO_FROM_NUMBER.");
+if (!sid) {
+  console.error("Missing TWILIO_ACCOUNT_SID.");
+  process.exit(1);
+}
+const authUser = apiKeySid ?? sid;
+const authPass = apiKeySid ? apiKeySecret : token;
+if (!authPass) {
+  console.error(
+    "Missing auth — set TWILIO_API_KEY_SID + TWILIO_API_KEY_SECRET (preferred) or TWILIO_AUTH_TOKEN."
+  );
+  process.exit(1);
+}
+if (!messagingServiceSid && !from) {
+  console.error(
+    "Missing sender — set TWILIO_MESSAGING_SERVICE_SID (recommended) or TWILIO_FROM_NUMBER."
+  );
   process.exit(1);
 }
 if (!to) {
@@ -26,17 +49,27 @@ if (!to) {
 }
 
 const body =
-  "Ops by Noell Twilio smoke test — if you received this, the A2P swap is live. STOP to opt out, HELP for help.";
+  "Ops by Noell Twilio smoke test — if you received this, the A2P swap is live. Reply STOP to opt out, HELP for help.";
+
+const params = new URLSearchParams({ To: to, Body: body });
+if (messagingServiceSid) {
+  params.set("MessagingServiceSid", messagingServiceSid);
+  console.log(`Sending via MessagingServiceSid=${messagingServiceSid}`);
+} else if (from) {
+  params.set("From", from);
+  console.log(`Sending via From=${from}`);
+}
 
 const res = await fetch(
   `https://api.twilio.com/2010-04-01/Accounts/${sid}/Messages.json`,
   {
     method: "POST",
     headers: {
-      Authorization: "Basic " + Buffer.from(`${sid}:${token}`).toString("base64"),
+      Authorization:
+        "Basic " + Buffer.from(`${authUser}:${authPass}`).toString("base64"),
       "Content-Type": "application/x-www-form-urlencoded",
     },
-    body: new URLSearchParams({ To: to, From: from, Body: body }),
+    body: params,
   }
 );
 
@@ -45,6 +78,6 @@ if (!res.ok) {
   process.exit(1);
 }
 
-const data = (await res.json()) as { sid: string };
-console.log(`OK — message SID: ${data.sid}`);
+const data = (await res.json()) as { sid: string; status?: string };
+console.log(`OK — message SID: ${data.sid} (status=${data.status ?? "queued"})`);
 process.exit(0);

--- a/src/app/api/twilio/inbound-sms/route.ts
+++ b/src/app/api/twilio/inbound-sms/route.ts
@@ -1,0 +1,134 @@
+/**
+ * POST /api/twilio/inbound-sms
+ *
+ * Twilio inbound SMS webhook — bridges OWNER replies on the A2P-registered
+ * Twilio number back into the originating visitor session.
+ *
+ * Replaces /api/ghl/inbound-sms once the SMS provider is flipped from
+ * GHL LC Phone to Twilio. Same downstream handler, different transport.
+ *
+ * Auth — Twilio request signature
+ * --------------------------------
+ * Twilio signs every webhook with HMAC-SHA1(authToken, fullUrl + sortedFormParams)
+ * and sends the result as `X-Twilio-Signature`. We validate this rather
+ * than using a query-param shared secret. The signing token is the auth
+ * token of the account that owns the Messaging Service. Required env:
+ *
+ *   TWILIO_AUTH_TOKEN           — used for signature validation
+ *   TWILIO_INBOUND_PUBLIC_URL   — the public URL Twilio is calling, exactly
+ *                                 as configured in the Messaging Service.
+ *                                 Set to the production canonical URL so
+ *                                 preview deploys do not silently mismatch
+ *                                 (e.g. https://www.opsbynoell.com/api/twilio/inbound-sms)
+ *
+ * Twilio webhook body (application/x-www-form-urlencoded):
+ *   From:   "+19497849726"   — sender (owner) — from_phone in our table
+ *   To:     "+19499973915"   — receiving Twilio number — to_phone
+ *   Body:   "Heyyyyyy"
+ *   MessageSid, MessagingServiceSid, AccountSid, ...
+ *
+ * Returns an empty TwiML response (200) so Twilio does not auto-reply.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { env } from "@/lib/agents/env";
+import {
+  extractInboundPayload,
+  handleInboundSms,
+} from "@/lib/agents/inbound-sms-handler";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const TWIML_OK =
+  '<?xml version="1.0" encoding="UTF-8"?><Response></Response>';
+
+const twimlResponse = (status = 200): Response =>
+  new Response(TWIML_OK, {
+    status,
+    headers: { "Content-Type": "text/xml; charset=utf-8" },
+  });
+
+/**
+ * Validate Twilio's request signature.
+ *
+ * Algorithm: HMAC-SHA1 of `url + sorted(key+value).join("")`, base64 encoded,
+ * compared in constant time against `X-Twilio-Signature`.
+ */
+function validateTwilioSignature(
+  authToken: string,
+  url: string,
+  params: URLSearchParams,
+  headerSig: string | null
+): boolean {
+  if (!headerSig) return false;
+  const sortedKeys = [...params.keys()].sort();
+  let data = url;
+  for (const k of sortedKeys) {
+    data += k + (params.get(k) ?? "");
+  }
+  const expected = createHmac("sha1", authToken).update(data).digest("base64");
+  const a = Buffer.from(expected);
+  const b = Buffer.from(headerSig);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const authToken = env.twilioAuthToken();
+  const publicUrl = process.env.TWILIO_INBOUND_PUBLIC_URL;
+
+  if (!authToken || !publicUrl) {
+    console.error(
+      "[twilio-inbound] Missing TWILIO_AUTH_TOKEN or TWILIO_INBOUND_PUBLIC_URL"
+    );
+    // Return 200 TwiML so Twilio does not retry against a misconfigured deploy.
+    return twimlResponse(200);
+  }
+
+  // Read the raw form body so we can both validate and parse it.
+  const rawBody = await req.text();
+  const params = new URLSearchParams(rawBody);
+
+  const headerSig = req.headers.get("x-twilio-signature");
+  const valid = validateTwilioSignature(authToken, publicUrl, params, headerSig);
+
+  if (!valid) {
+    console.warn(
+      "[twilio-inbound] Rejected — invalid signature",
+      { headerSig, publicUrl }
+    );
+    return twimlResponse(200);
+  }
+
+  // Translate Twilio's payload into our generic inbound shape.
+  const generic = {
+    from: params.get("From") ?? undefined,
+    to: params.get("To") ?? undefined,
+    body: params.get("Body") ?? undefined,
+    messageId: params.get("MessageSid") ?? undefined,
+  };
+
+  const payload = extractInboundPayload(generic);
+  if (!payload) {
+    console.warn("[twilio-inbound] Missing from phone in payload", generic);
+    return twimlResponse(200);
+  }
+
+  await handleInboundSms(payload);
+
+  // Always 200 with empty TwiML — auto-reply happens via the outbound code path.
+  return twimlResponse(200);
+}
+
+// Twilio sends form-encoded; reject anything else explicitly.
+export async function GET(): Promise<Response> {
+  return NextResponse.json(
+    {
+      ok: true,
+      hint: "POST application/x-www-form-urlencoded from Twilio webhook only",
+    },
+    { status: 200 }
+  );
+}

--- a/src/lib/agents/env.ts
+++ b/src/lib/agents/env.ts
@@ -35,9 +35,19 @@ export const env = {
   telegramDefaultChatId: () => optional("TELEGRAM_DEFAULT_CHAT_ID"),
 
   // Twilio (generic SMS provider)
+  //
+  // A2P 10DLC sender pool is configured via a Messaging Service. When
+  // TWILIO_MESSAGING_SERVICE_SID is set, the Twilio integration uses
+  // MessagingServiceSid (recommended) — Twilio handles sender selection,
+  // sticky sender, and rate-limit smoothing. TWILIO_FROM_NUMBER is kept
+  // for the dev/smoke fallback path only.
   twilioAccountSid: () => optional("TWILIO_ACCOUNT_SID"),
   twilioAuthToken: () => optional("TWILIO_AUTH_TOKEN"),
+  twilioApiKeySid: () => optional("TWILIO_API_KEY_SID"),
+  twilioApiKeySecret: () => optional("TWILIO_API_KEY_SECRET"),
+  twilioMessagingServiceSid: () => optional("TWILIO_MESSAGING_SERVICE_SID"),
   twilioFromNumber: () => optional("TWILIO_FROM_NUMBER"),
+  twilioStatusCallbackUrl: () => optional("TWILIO_STATUS_CALLBACK_URL"),
 
   // GHL (shared across all clients on GHL — individual location configs
   // live in `clients.calendar_config` / `clients.sms_config`).

--- a/src/lib/agents/integrations/generic.ts
+++ b/src/lib/agents/integrations/generic.ts
@@ -165,24 +165,88 @@ export class GenericCalendar implements CalendarIntegration {
 
 // ---------- Twilio SMS ----------
 
+/**
+ * Twilio SMS sender (A2P 10DLC).
+ *
+ * Sender selection (in priority order):
+ *   1. cfg.messagingServiceSid  — per-client override (recommended for multi-tenant)
+ *   2. TWILIO_MESSAGING_SERVICE_SID env  — default Messaging Service for all clients
+ *   3. cfg.fromNumber  — explicit E.164 sender (fallback / dev / smoke test)
+ *   4. TWILIO_FROM_NUMBER env  — last-resort fallback
+ *
+ * Auth (in priority order):
+ *   1. TWILIO_API_KEY_SID + TWILIO_API_KEY_SECRET (recommended — rotatable, scoped)
+ *   2. TWILIO_ACCOUNT_SID + TWILIO_AUTH_TOKEN  (fallback)
+ *
+ * If TWILIO_STATUS_CALLBACK_URL is set, delivery status callbacks (sent /
+ * delivered / failed / undelivered) are POSTed back to that URL by Twilio.
+ */
+export interface TwilioSmsConfig {
+  /** Per-client Messaging Service SID override (e.g. "MGd2131b4ca062be6705d95e671a35a33d"). */
+  messagingServiceSid?: string;
+  /** Per-client explicit FROM number override. Ignored if messagingServiceSid is set. */
+  fromNumber?: string;
+  /** Per-client status callback URL override. */
+  statusCallback?: string;
+}
+
 export class TwilioSms implements SMSIntegration {
+  private readonly cfg: TwilioSmsConfig;
+
+  constructor(cfg: TwilioSmsConfig = {}) {
+    this.cfg = cfg;
+  }
+
   async sendSMS(to: string, body: string): Promise<{ messageId: string }> {
     const sid = env.twilioAccountSid();
-    const token = env.twilioAuthToken();
-    const from = env.twilioFromNumber();
-    if (!sid || !token || !from) {
-      throw new Error("Twilio env vars not configured");
+    if (!sid) {
+      throw new Error("Twilio not configured: missing TWILIO_ACCOUNT_SID");
     }
+
+    // Auth header — prefer scoped API Key over Account auth token.
+    const apiKeySid = env.twilioApiKeySid();
+    const apiKeySecret = env.twilioApiKeySecret();
+    const authUser = apiKeySid ?? sid;
+    const authPass = apiKeySid ? apiKeySecret : env.twilioAuthToken();
+    if (!authPass) {
+      throw new Error(
+        "Twilio not configured: missing TWILIO_API_KEY_SECRET or TWILIO_AUTH_TOKEN"
+      );
+    }
+
+    // Sender selection — Messaging Service wins.
+    const messagingServiceSid =
+      this.cfg.messagingServiceSid ?? env.twilioMessagingServiceSid();
+    const fromNumber = this.cfg.fromNumber ?? env.twilioFromNumber();
+    if (!messagingServiceSid && !fromNumber) {
+      throw new Error(
+        "Twilio not configured: set TWILIO_MESSAGING_SERVICE_SID (recommended) or TWILIO_FROM_NUMBER"
+      );
+    }
+
+    const params = new URLSearchParams({ To: to, Body: body });
+    if (messagingServiceSid) {
+      params.set("MessagingServiceSid", messagingServiceSid);
+    } else if (fromNumber) {
+      params.set("From", fromNumber);
+    }
+
+    const statusCallback =
+      this.cfg.statusCallback ?? env.twilioStatusCallbackUrl();
+    if (statusCallback) {
+      params.set("StatusCallback", statusCallback);
+    }
+
     const res = await fetch(
       `https://api.twilio.com/2010-04-01/Accounts/${sid}/Messages.json`,
       {
         method: "POST",
         headers: {
           Authorization:
-            "Basic " + Buffer.from(`${sid}:${token}`).toString("base64"),
+            "Basic " + Buffer.from(`${authUser}:${authPass}`).toString("base64"),
           "Content-Type": "application/x-www-form-urlencoded",
         },
-        body: new URLSearchParams({ To: to, From: from, Body: body }),
+        body: params,
       }
     );
     if (!res.ok) {

--- a/src/lib/agents/integrations/registry.ts
+++ b/src/lib/agents/integrations/registry.ts
@@ -65,7 +65,11 @@ export function getSmsIntegration(cfg: ClientConfig): MessagingIntegration {
       });
     case "twilio":
     case "generic":
-      return new TwilioSms();
+      return new TwilioSms({
+        messagingServiceSid: conf.messagingServiceSid as string | undefined,
+        fromNumber: conf.fromNumber as string | undefined,
+        statusCallback: conf.statusCallback as string | undefined,
+      });
     default:
       throw new Error(`Unknown SMS provider: ${provider}`);
   }


### PR DESCRIPTION
## Why

The A2P brand + campaign are now verified on the Twilio side (`BNb86392628a2b7a13f49ef64d6bf17e1f` / campaign `CFP1WF7` / Messaging Service `MGd2131b4ca062be6705d95e671a35a33d`). The Noell agents already live outside GHL on Supabase — sending their SMS through GHL LC Phone was a workaround, not the architecture. This makes the agents stand alone:

- No more PIT-token/`contacts.write` hack ([sms-alert fast path](https://github.com/Opsbynoell/opsbynoell-site-production/blob/main/src/lib/agents/integrations/ghl.ts#L246-L280))
- A2P 10DLC sender pool via `MessagingServiceSid` (sticky sender, throughput smoothing)
- Optional delivery-status callbacks
- Per-client config in `clients.sms_config` so future tenants can use different Messaging Services

GHL stays available as a provider option — flipping the runtime is a single column update on the `clients` row plus env vars.

## What changed

- `src/lib/agents/env.ts` — adds `TWILIO_API_KEY_SID`, `TWILIO_API_KEY_SECRET`, `TWILIO_MESSAGING_SERVICE_SID`, `TWILIO_STATUS_CALLBACK_URL`
- `src/lib/agents/integrations/generic.ts` — `TwilioSms` accepts per-client `{ messagingServiceSid, fromNumber, statusCallback }`; chooses `MessagingServiceSid` > `From`; prefers API Key auth over Account auth token
- `src/lib/agents/integrations/registry.ts` — passes per-client overrides through from `clients.sms_config`
- `scripts/twilio-smoke-test.ts` — supports Messaging Service mode
- **NEW** `src/app/api/twilio/inbound-sms/route.ts` — Twilio webhook with `X-Twilio-Signature` HMAC-SHA1 validation, returns empty TwiML

## Cutover plan (after merge)

1. Set Vercel env vars (Production + Preview + Dev):
    - `TWILIO_ACCOUNT_SID`
    - `TWILIO_AUTH_TOKEN` *(or `TWILIO_API_KEY_SID` + `TWILIO_API_KEY_SECRET`)*
    - `TWILIO_MESSAGING_SERVICE_SID=MGd2131b4ca062be6705d95e671a35a33d`
    - `TWILIO_INBOUND_PUBLIC_URL=https://www.opsbynoell.com/api/twilio/inbound-sms`
    - *(optional)* `TWILIO_STATUS_CALLBACK_URL=https://www.opsbynoell.com/api/twilio/status`
2. In Twilio Console → Messaging Service `MGd2131b…` → Integration → set the inbound webhook to `https://www.opsbynoell.com/api/twilio/inbound-sms` (HTTP POST)
3. Smoke: `TWILIO_ACCOUNT_SID=… TWILIO_AUTH_TOKEN=… TWILIO_MESSAGING_SERVICE_SID=MGd2131b… npm run twilio:smoke -- +1xxxxxxxxxx`
4. Flip the client row:
   ```sql
   update clients set sms_provider = 'twilio',
     sms_config = sms_config
       || jsonb_build_object('messagingServiceSid','MGd2131b4ca062be6705d95e671a35a33d')
   where client_id = 'opsbynoell';
   ```
5. Trigger a chat on `opsbynoell.com`, escalate, verify the alert lands from the Twilio number and replies route back through `/api/twilio/inbound-sms`.
6. Once stable: disable the GHL inbound webhook on the LC Phone and remove the `alertContactId` / `fromNumber` keys from `sms_config`.

## Compliance

The verified A2P campaign covers exactly what `opsbynoell.com` is doing today: chat-widget consent + lead follow-up + appointment notifications. `/sms-policy` and `/privacy` already include the required STOP/HELP/Msg-frequency/data-rates language and the "no third-party sharing of opt-in data" clause. No opt-in copy changes required.