### PR TITLE
feat(twilio): direct inbound-visitor-sms webhook

### DIFF
--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -21,3 +21,20 @@ After setting these, also update in Supabase:
 - `clients.phone` for slug=opsbynoell → set to TWILIO_FROM_NUMBER
 - `clients.locations[0].phone` → same
 - `clients.escalation_rules.qualifiedLead.smsTo` → Nikki's personal cell in E.164
+
+### Twilio inbound webhooks (optional)
+
+Set these only if you wire a client's inbound SMS directly to Twilio
+(instead of going through a GHL workflow). Used to validate the
+`X-Twilio-Signature` header — the URL must match exactly what is
+configured in the Twilio Messaging Service "A message comes in" field.
+
+- `TWILIO_INBOUND_PUBLIC_URL` — owner-reply route public URL, e.g.
+  `https://www.opsbynoell.com/api/twilio/inbound-sms`
+- `TWILIO_INBOUND_VISITOR_PUBLIC_URL` — visitor inbound route public
+  URL, e.g.
+  `https://www.opsbynoell.com/api/twilio/inbound-visitor-sms`.
+  Falls back to `TWILIO_INBOUND_PUBLIC_URL` if unset (single-URL installs).
+
+See [`docs/inbound-visitor-sms.md`](./inbound-visitor-sms.md) for the
+full setup (Messaging Service → Integration webhook).

--- a/docs/inbound-visitor-sms.md
+++ b/docs/inbound-visitor-sms.md
@@ -1,18 +1,29 @@
 # Inbound Visitor-SMS Bridge
 
-When a lead or customer texts a client's LC Phone number, this bridge:
+When a lead or customer texts a client's number, this bridge:
 
-1. Receives the inbound via a GHL webhook
-2. Resolves which client owns the destination LC Phone
+1. Receives the inbound via a webhook (GHL **or** Twilio — see below)
+2. Resolves which client owns the destination number
 3. Stores the message in `front_desk_messages` and generates a reply via
    the shared runner (escalation rules, Telegram alert, owner SMS alert
    still fire normally)
 4. Sends the bot's reply back to the visitor over the client's
-   configured messaging integration (GHL SMS, GHL WhatsApp, or generic)
+   configured messaging integration (GHL SMS, GHL WhatsApp, or Twilio)
 
 This is distinct from [`docs/two-way-sms.md`](./two-way-sms.md), which
 handles the **owner's** reply to an alert SMS, not new inbound from
 leads.
+
+Two transports are supported in parallel:
+
+| Transport | Endpoint | Auth | When to use |
+|---|---|---|---|
+| GHL workflow | `POST /api/ghl/inbound-visitor-sms` | `?secret=GHL_WEBHOOK_SECRET` | Client's number is an LC Phone and inbound routes through a GHL / LeadConnector workflow |
+| Twilio direct | `POST /api/twilio/inbound-visitor-sms` | `X-Twilio-Signature` HMAC | Client's number is an A2P 10DLC number owned by Twilio and wired straight to the Messaging Service webhook |
+
+Both endpoints share the same downstream handler, client-resolution
+chain, loop guard, and outbound reply path — only the wire format and
+auth differ.
 
 ---
 
@@ -228,3 +239,104 @@ live tests — do not pound the production inbox with curl runs.
 | `{ok:true,replySent:false,replyError:"empty_reply"}` | Bot returned no text (human_takeover or model refusal) |
 | Bot replies show up in inbox but visitor never receives them | Outbound SMS integration mis-configured — check `sms_provider` + `sms_config` on the `clients` row |
 | Webhook fires in a loop | Direction filter missing — add `Direction = Inbound` to the workflow trigger |
+
+---
+
+## Twilio direct transport (alternative to GHL workflow)
+
+When the client's inbound SMS is wired directly to Twilio (A2P 10DLC
+sender pool owned by Twilio, not LeadConnector), point the Messaging
+Service's **"A message comes in"** webhook at:
+
+```
+POST https://www.opsbynoell.com/api/twilio/inbound-visitor-sms
+Content-Type: application/x-www-form-urlencoded
+```
+
+Twilio authenticates itself with the `X-Twilio-Signature` header
+(HMAC-SHA1 of `url + sorted(key+value).join("")`, base64 encoded).
+No `?secret=` query param is used; invalid signatures are rejected
+with an empty TwiML 200 so Twilio does not retry-storm.
+
+### Env vars (Vercel)
+
+- `TWILIO_AUTH_TOKEN` — signing token for the Twilio account that owns
+  the Messaging Service (already required for outbound sends)
+- `TWILIO_INBOUND_VISITOR_PUBLIC_URL` — the exact public URL Twilio is
+  configured to call, with no query string. Set this to the canonical
+  production URL so preview deploys do not silently fail signature
+  validation, e.g.
+  `https://www.opsbynoell.com/api/twilio/inbound-visitor-sms`.
+  Falls back to `TWILIO_INBOUND_PUBLIC_URL` if unset (for installs that
+  only use one number and already have that var in place).
+
+### Messaging Service configuration
+
+Twilio Console → **Messaging → Services → <your service>**:
+
+1. **Sender Pool** → add the A2P-registered number(s) the client uses
+   for inbound.
+2. **Integration** → *Send a webhook*
+   - URL: `https://www.opsbynoell.com/api/twilio/inbound-visitor-sms`
+   - Method: `HTTP POST`
+3. **Opt-Out Management** — leave Twilio's defaults in place. Opt-out
+   keywords (STOP / HELP) are handled by Twilio before our webhook
+   fires; we never see those messages.
+
+### Client resolution
+
+Same priority chain as the GHL transport:
+
+| Priority | Twilio field | Lookup |
+|---|---|---|
+| 1 | `To` → `toPhone` | `clients.sms_config->>fromNumber` |
+| 2 | — | *(no locationId on Twilio payloads)* |
+| 3 | *(fallback)* | exactly one active client with `sms_config.fromNumber` |
+
+Each client's `clients.sms_config.fromNumber` **must** match the
+A2P-registered Twilio number in E.164 (e.g. `+19499973915`). If you
+move a client's inbound from LC Phone to a Twilio number, update
+`sms_config.fromNumber` first — otherwise the webhook will either
+`no_client_for_to_phone` or silently route to the wrong tenant.
+
+### Response
+
+Twilio webhooks only care about HTTP status; we always return an empty
+TwiML `<Response/>` body so Twilio does not auto-reply. The bot's
+reply is sent back to the visitor through the Twilio REST API by the
+outbound code path (same as the GHL transport), **not** via TwiML
+`<Message>` — this keeps send-observability, MessagingService sticky
+sender behavior, and sessionId linkage identical across transports.
+
+### Loop safety
+
+1. **Signature validation.** Only Twilio can trigger the webhook.
+2. **Server-side loop guard** (shared with the GHL route). If the
+   inbound `From` equals the client's own `sms_config.fromNumber`, we
+   refuse to reply — protects against a mis-wired Messaging Service
+   that loops outbound sends back into the inbound webhook.
+
+### Manual test plan
+
+1. Confirm `clients.sms_config.fromNumber` matches the A2P Twilio
+   number for the target client.
+2. From a mobile device that is NOT the Twilio number, text the
+   Twilio number.
+3. Expected:
+   - Bot reply arrives on the visitor's phone within a few seconds.
+   - A row lands in `front_desk_sessions` with
+     `trigger_type = 'inbound_text'` and `channel = 'sms'`.
+   - The Twilio Console → Messaging → Logs entry shows the webhook
+     returning HTTP 200 with a `text/xml` body.
+4. Tamper test: flip one char in `TWILIO_AUTH_TOKEN` locally and
+   re-send via the Twilio "Request Inspector" replay — the server
+   should log `Rejected — invalid signature` and still return 200 TwiML.
+
+### Troubleshooting (Twilio-specific)
+
+| Symptom | Likely cause |
+|---|---|
+| Twilio logs show repeated 200s but no reply arrives | Signature failed — `TWILIO_INBOUND_VISITOR_PUBLIC_URL` does not match the URL configured in the Messaging Service, or `TWILIO_AUTH_TOKEN` is wrong |
+| `no_client_for_to_phone` in server logs | `clients.sms_config.fromNumber` is not set to the A2P Twilio number |
+| Bot replies show up in internal inbox but visitor never receives them | `smsProvider` is not `twilio` / `generic`, or `TWILIO_MESSAGING_SERVICE_SID` / `TWILIO_FROM_NUMBER` is unset for outbound |
+| Visitor gets TWO replies (one truncated) | Messaging Service has "Enable Auto-Reply" turned on — disable it; the bot reply is sent via REST API, not TwiML |

--- a/src/app/api/twilio/inbound-sms/route.ts
+++ b/src/app/api/twilio/inbound-sms/route.ts
@@ -31,12 +31,12 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { createHmac, timingSafeEqual } from "node:crypto";
 import { env } from "@/lib/agents/env";
 import {
   extractInboundPayload,
   handleInboundSms,
 } from "@/lib/agents/inbound-sms-handler";
+import { validateTwilioSignature } from "@/lib/agents/twilio-signature";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -49,31 +49,6 @@ const twimlResponse = (status = 200): Response =>
     status,
     headers: { "Content-Type": "text/xml; charset=utf-8" },
   });
-
-/**
- * Validate Twilio's request signature.
- *
- * Algorithm: HMAC-SHA1 of `url + sorted(key+value).join("")`, base64 encoded,
- * compared in constant time against `X-Twilio-Signature`.
- */
-function validateTwilioSignature(
-  authToken: string,
-  url: string,
-  params: URLSearchParams,
-  headerSig: string | null
-): boolean {
-  if (!headerSig) return false;
-  const sortedKeys = [...params.keys()].sort();
-  let data = url;
-  for (const k of sortedKeys) {
-    data += k + (params.get(k) ?? "");
-  }
-  const expected = createHmac("sha1", authToken).update(data).digest("base64");
-  const a = Buffer.from(expected);
-  const b = Buffer.from(headerSig);
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(a, b);
-}
 
 export async function POST(req: NextRequest): Promise<Response> {
   const authToken = env.twilioAuthToken();

--- a/src/app/api/twilio/inbound-visitor-sms/route.ts
+++ b/src/app/api/twilio/inbound-visitor-sms/route.ts
@@ -1,0 +1,234 @@
+/**
+ * POST /api/twilio/inbound-visitor-sms
+ *
+ * Direct Twilio inbound SMS webhook for LEADS / CUSTOMERS texting a
+ * client's A2P-registered Twilio number. The Twilio-transport twin of
+ * /api/ghl/inbound-visitor-sms — same downstream flow (runTurn +
+ * frontDesk + outbound reply via MessagingIntegration), different
+ * wire format.
+ *
+ * Use this route when the client's inbound SMS is wired directly to
+ * Twilio (Messaging Service → "A message comes in" webhook) instead of
+ * going through a GHL / LeadConnector workflow.
+ *
+ * Auth — Twilio request signature
+ * --------------------------------
+ * Twilio signs every webhook with
+ *   HMAC-SHA1(authToken, fullUrl + sortedFormParams)
+ * and sends the result as `X-Twilio-Signature`. We validate this
+ * rather than using a query-param shared secret.
+ *
+ * Required env:
+ *   TWILIO_AUTH_TOKEN                      — signing token (same account that owns the Messaging Service)
+ *   TWILIO_INBOUND_VISITOR_PUBLIC_URL      — the public URL Twilio is calling, exactly as configured in
+ *                                            the Messaging Service (no query string). Falls back to
+ *                                            TWILIO_INBOUND_PUBLIC_URL if unset, so single-number
+ *                                            installs that only use one webhook do not need two vars.
+ *                                            Example:
+ *                                              https://www.opsbynoell.com/api/twilio/inbound-visitor-sms
+ *
+ * Twilio webhook body (application/x-www-form-urlencoded):
+ *   From:        "+17145550123"   — visitor / lead                → fromPhone
+ *   To:          "+19499973915"   — client's Twilio number        → toPhone
+ *   Body:        "hi, any openings today?"
+ *   MessageSid:  "SMxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+ *   MessagingServiceSid / AccountSid / NumMedia / ...             — ignored
+ *
+ * Response
+ * --------
+ * Always returns HTTP 200. If the reply is non-empty and
+ * human_takeover is off, we send it back to the visitor via the
+ * client's configured SMS integration (Twilio API) — NOT via TwiML
+ * <Message> in the response body. Reasons:
+ *   - The outbound sender is selected by the integration registry
+ *     (MessagingServiceSid / fromNumber) so sticky sender + A2P
+ *     compliance continue to work the same way as the runner path.
+ *   - Keeps send-observability, error handling, and sessionId
+ *     linkage identical between the GHL and Twilio transports.
+ *   - Avoids a race where TwiML <Message> fires before we've
+ *     persisted the outbound row.
+ *
+ * The response body is therefore always empty TwiML (<Response/>)
+ * so Twilio treats the webhook as successful and does not auto-reply.
+ *
+ * Loop safety
+ * -----------
+ *   1. Signature validation — only Twilio can trigger this route.
+ *   2. Server-side loop guard — refuses to reply when fromPhone
+ *      equals the client's own sms_config.fromNumber (shared with
+ *      the GHL route).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { env } from "@/lib/agents/env";
+import { getClientConfig } from "@/lib/agents/config";
+import {
+  buildOutboundVisitorReplyPayload,
+  dispatchVisitorReply,
+  extractInboundVisitorPayload,
+  isOwnNumberLoop,
+  resolveClientForInboundVisitorSms,
+} from "@/lib/agents/inbound-visitor-sms-handler";
+import { getSmsIntegration } from "@/lib/agents/integrations/registry";
+import { RunTurnError, runTurn } from "@/lib/agents/runner";
+import { validateTwilioSignature } from "@/lib/agents/twilio-signature";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const TWIML_OK =
+  '<?xml version="1.0" encoding="UTF-8"?><Response></Response>';
+
+const twimlResponse = (status = 200): Response =>
+  new Response(TWIML_OK, {
+    status,
+    headers: { "Content-Type": "text/xml; charset=utf-8" },
+  });
+
+export async function POST(req: NextRequest): Promise<Response> {
+  const authToken = env.twilioAuthToken();
+  // Accept either a visitor-specific public URL or fall back to the
+  // single-number TWILIO_INBOUND_PUBLIC_URL. A misconfigured URL here
+  // is the #1 cause of silent 200 no-ops.
+  const publicUrl =
+    process.env.TWILIO_INBOUND_VISITOR_PUBLIC_URL ??
+    process.env.TWILIO_INBOUND_PUBLIC_URL;
+
+  if (!authToken || !publicUrl) {
+    console.error(
+      "[twilio-inbound-visitor] Missing TWILIO_AUTH_TOKEN or TWILIO_INBOUND_VISITOR_PUBLIC_URL/TWILIO_INBOUND_PUBLIC_URL"
+    );
+    // 200 TwiML so Twilio does not retry against a misconfigured deploy.
+    return twimlResponse(200);
+  }
+
+  // ── Parse form body ───────────────────────────────────────────────────────
+  const rawBody = await req.text();
+  const params = new URLSearchParams(rawBody);
+
+  // ── Validate signature ────────────────────────────────────────────────────
+  const headerSig = req.headers.get("x-twilio-signature");
+  const valid = validateTwilioSignature(authToken, publicUrl, params, headerSig);
+  if (!valid) {
+    console.warn(
+      "[twilio-inbound-visitor] Rejected — invalid signature",
+      { headerSig, publicUrl }
+    );
+    return twimlResponse(200);
+  }
+
+  // ── Translate Twilio fields into our generic visitor-SMS shape ───────────
+  const generic: Record<string, unknown> = {
+    phone: params.get("From") ?? undefined,
+    toNumber: params.get("To") ?? undefined,
+    body: params.get("Body") ?? undefined,
+  };
+  const payload = extractInboundVisitorPayload(generic);
+  if (!payload) {
+    console.warn(
+      "[twilio-inbound-visitor] missing visitor phone in payload",
+      { From: params.get("From"), To: params.get("To") }
+    );
+    return twimlResponse(200);
+  }
+
+  // ── Resolve client ────────────────────────────────────────────────────────
+  let resolution;
+  try {
+    resolution = await resolveClientForInboundVisitorSms({
+      toPhone: payload.toPhone,
+      locationId: payload.locationId,
+    });
+  } catch (err) {
+    console.error("[twilio-inbound-visitor] client lookup failed:", err);
+    return twimlResponse(200);
+  }
+
+  if (resolution.kind === "ambiguous") {
+    console.error(
+      `[twilio-inbound-visitor] ambiguous client resolution — candidates=${resolution.candidates.join(
+        ","
+      )} toPhone=${payload.toPhone ?? "-"}`
+    );
+    return twimlResponse(200);
+  }
+  if (resolution.kind === "none") {
+    console.warn(
+      `[twilio-inbound-visitor] no client configured for toPhone=${
+        payload.toPhone ?? "-"
+      } — ignoring`
+    );
+    return twimlResponse(200);
+  }
+
+  const clientId = resolution.clientId;
+
+  // ── Loop guard — refuse if visitor phone equals our own Twilio number ────
+  const cfg = await getClientConfig(clientId);
+  if (isOwnNumberLoop(cfg, payload.fromPhone)) {
+    console.warn(
+      `[twilio-inbound-visitor] loop guard tripped — fromPhone=${payload.fromPhone} matches own Twilio number for client=${clientId}`
+    );
+    return twimlResponse(200);
+  }
+
+  // ── Generate the reply via the shared runner ──────────────────────────────
+  let runResult;
+  try {
+    runResult = await runTurn({
+      agent: "frontDesk",
+      payload: {
+        clientId,
+        agent: "frontDesk",
+        channel: "sms",
+        from: { phone: payload.fromPhone },
+        message: payload.messageText,
+      },
+      tables: {
+        sessions: "front_desk_sessions",
+        messages: "front_desk_messages",
+      },
+      defaultTriggerType: "inbound_text",
+    });
+  } catch (err) {
+    if (err instanceof RunTurnError) {
+      console.error(
+        `[twilio-inbound-visitor] runTurn precondition failed — code=${err.code} client=${clientId}: ${err.message}`
+      );
+    } else {
+      console.error(
+        `[twilio-inbound-visitor] runTurn failed — client=${clientId}:`,
+        err
+      );
+    }
+    return twimlResponse(200);
+  }
+
+  // ── Dispatch outbound reply (when appropriate) ────────────────────────────
+  const out = buildOutboundVisitorReplyPayload({
+    cfg,
+    agent: "frontDesk",
+    sessionId: runResult.sessionId,
+    visitorPhone: payload.fromPhone,
+    replyText: runResult.reply,
+  });
+
+  if (out.body) {
+    await dispatchVisitorReply(out, cfg, { getSms: getSmsIntegration });
+  }
+
+  // Empty TwiML — outbound send happened via the Twilio API above (or was
+  // intentionally skipped) so there is nothing to auto-reply with here.
+  return twimlResponse(200);
+}
+
+// Twilio sends form-encoded; reject anything else explicitly.
+export async function GET(): Promise<Response> {
+  return NextResponse.json(
+    {
+      ok: true,
+      hint: "POST application/x-www-form-urlencoded from Twilio webhook only",
+    },
+    { status: 200 }
+  );
+}

--- a/src/lib/agents/twilio-signature.test.ts
+++ b/src/lib/agents/twilio-signature.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the Twilio webhook signature validator.
+ *
+ * The algorithm is specified by Twilio:
+ *   base64(HMAC-SHA1(authToken, url + sorted(key+value).join("")))
+ *
+ * We build the expected signature by hand, feed it through the helper,
+ * and assert it validates. We also cover the rejection paths (missing
+ * header, wrong token, tampered body).
+ */
+
+import { strict as assert } from "node:assert";
+import { createHmac } from "node:crypto";
+import { test } from "node:test";
+
+import { validateTwilioSignature } from "./twilio-signature.ts";
+
+const AUTH_TOKEN = "test-auth-token";
+const URL = "https://www.opsbynoell.com/api/twilio/inbound-visitor-sms";
+
+function sign(
+  token: string,
+  url: string,
+  params: URLSearchParams
+): string {
+  const sorted = [...params.keys()].sort();
+  let data = url;
+  for (const k of sorted) {
+    data += k + (params.get(k) ?? "");
+  }
+  return createHmac("sha1", token).update(data).digest("base64");
+}
+
+test("validateTwilioSignature: accepts correctly signed request", () => {
+  const params = new URLSearchParams({
+    From: "+17145550123",
+    To: "+19499973915",
+    Body: "hi, any openings today?",
+    MessageSid: "SM123",
+  });
+  const sig = sign(AUTH_TOKEN, URL, params);
+  assert.equal(validateTwilioSignature(AUTH_TOKEN, URL, params, sig), true);
+});
+
+test("validateTwilioSignature: rejects missing header", () => {
+  const params = new URLSearchParams({ From: "+1", Body: "x" });
+  assert.equal(validateTwilioSignature(AUTH_TOKEN, URL, params, null), false);
+});
+
+test("validateTwilioSignature: rejects wrong auth token", () => {
+  const params = new URLSearchParams({ From: "+1", Body: "x" });
+  const sig = sign("other-token", URL, params);
+  assert.equal(validateTwilioSignature(AUTH_TOKEN, URL, params, sig), false);
+});
+
+test("validateTwilioSignature: rejects tampered body", () => {
+  const params = new URLSearchParams({ From: "+1", Body: "original" });
+  const sig = sign(AUTH_TOKEN, URL, params);
+  const tampered = new URLSearchParams({ From: "+1", Body: "tampered" });
+  assert.equal(
+    validateTwilioSignature(AUTH_TOKEN, URL, tampered, sig),
+    false
+  );
+});
+
+test("validateTwilioSignature: rejects mismatched URL", () => {
+  const params = new URLSearchParams({ From: "+1", Body: "x" });
+  const sig = sign(AUTH_TOKEN, URL, params);
+  const wrongUrl = URL.replace("opsbynoell.com", "evil.example");
+  assert.equal(
+    validateTwilioSignature(AUTH_TOKEN, wrongUrl, params, sig),
+    false
+  );
+});
+
+test("validateTwilioSignature: key order in params does not matter (sorted by validator)", () => {
+  // Build params in different insertion order; Twilio sorts by key name.
+  const a = new URLSearchParams();
+  a.set("To", "+19499973915");
+  a.set("From", "+17145550123");
+  a.set("Body", "hi");
+  const sig = sign(AUTH_TOKEN, URL, a);
+
+  const b = new URLSearchParams();
+  b.set("From", "+17145550123");
+  b.set("Body", "hi");
+  b.set("To", "+19499973915");
+
+  assert.equal(validateTwilioSignature(AUTH_TOKEN, URL, b, sig), true);
+});

--- a/src/lib/agents/twilio-signature.ts
+++ b/src/lib/agents/twilio-signature.ts
@@ -1,0 +1,34 @@
+/**
+ * Twilio webhook signature validation.
+ *
+ * Algorithm: HMAC-SHA1 of `url + sorted(key+value).join("")`, base64
+ * encoded, compared in constant time against `X-Twilio-Signature`.
+ *
+ * The `url` argument must match the public URL Twilio is calling EXACTLY
+ * (scheme + host + path, no query string). Mismatches here are the most
+ * common cause of silent 403-equivalent rejections on inbound webhooks,
+ * so routes always log the `publicUrl` used when a signature fails.
+ *
+ * See: https://www.twilio.com/docs/usage/webhooks/webhooks-security
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export function validateTwilioSignature(
+  authToken: string,
+  url: string,
+  params: URLSearchParams,
+  headerSig: string | null
+): boolean {
+  if (!headerSig) return false;
+  const sortedKeys = [...params.keys()].sort();
+  let data = url;
+  for (const k of sortedKeys) {
+    data += k + (params.get(k) ?? "");
+  }
+  const expected = createHmac("sha1", authToken).update(data).digest("base64");
+  const a = Buffer.from(expected);
+  const b = Buffer.from(headerSig);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}


### PR DESCRIPTION
## Summary

Adds `POST /api/twilio/inbound-visitor-sms` — a Twilio-native twin of `/api/ghl/inbound-visitor-sms` — so clients whose A2P 10DLC number lives directly on Twilio can bypass the GHL workflow layer entirely. Same downstream behavior (client resolution → `runTurn` → outbound reply through the existing `MessagingIntegration`), just a different wire format and auth.

Why: GHL workflow UI and logs have been unreliable. PRs #37 and #39 already landed the inbound-visitor pipeline behind a provider-agnostic handler, so the new route is essentially a transport adapter — no duplication of business logic.

### What it does

- Validates `X-Twilio-Signature` (HMAC-SHA1 of `url + sortedParams`) against `TWILIO_AUTH_TOKEN`. No shared-secret query param.
- Parses Twilio form-urlencoded fields (`From`, `To`, `Body`, `MessageSid`).
- Resolves the client with the same priority chain as the GHL route (`sms_config.fromNumber` → `sms_config.locationId` → sole active client).
- Runs the identical loop guard and `runTurn` frontDesk flow.
- Sends the reply back to the visitor via the Twilio REST API (through the existing integration registry) so sticky sender + MessagingService selection behave the same as every other outbound path. Response body is empty TwiML so Twilio does not auto-reply.

### What it doesn't do

- Does not change any production config or Supabase state.
- Does not send SMS during tests (unit tests stub the integration).
- Does not change public marketing copy.
- Does not touch the Twilio account or Messaging Service — operator has to wire the webhook URL in the Twilio console (documented in `docs/inbound-visitor-sms.md`).

### Refactor

Extracted `validateTwilioSignature` to `src/lib/agents/twilio-signature.ts` so both the owner (`/api/twilio/inbound-sms`) and visitor routes share a single, unit-tested implementation instead of copy-pasting the HMAC logic.

### New env var

- `TWILIO_INBOUND_VISITOR_PUBLIC_URL` — optional; falls back to `TWILIO_INBOUND_PUBLIC_URL` for single-URL installs. Must match the URL Twilio is configured to POST to, exactly.

## Testing

- [x] `npm test` → 118/119 pass. The one failure (`runner.test.ts`) is pre-existing on `main` and unrelated: `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX` from `--experimental-strip-types` choking on a constructor parameter property in `GenericCalendar`.
- [x] New `twilio-signature.test.ts` — 6 cases covering accept / missing header / wrong token / tampered body / mismatched URL / key order.
- [x] Existing `inbound-visitor-sms-handler.test.ts` still green (shared handler is untouched).
- [x] `npx next build` succeeds; `/api/twilio/inbound-visitor-sms` shows up in the route table.
- [x] `npx eslint` on all new / modified files — clean.
- [ ] Live smoke test against Twilio — deferred to operator once the webhook URL is wired in the Twilio Messaging Service (see `docs/inbound-visitor-sms.md` → "Manual test plan").

🤖 Generated with [Claude Code](https://claude.com/claude-code)