### PR TITLE
feat(landing): Predictive Customer Intelligence landing page (/predictive-customer-intelligence)

### DIFF
--- a/src/app/predictive-customer-intelligence/page.tsx
+++ b/src/app/predictive-customer-intelligence/page.tsx
@@ -220,52 +220,21 @@ function PciMockScreen() {
         </span>
       </div>
 
-      <div className="bg-white rounded-2xl p-3 mx-1 border border-warm-border/60 shadow-sm">
-        <div className="flex items-start justify-between">
-          <div>
-            <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
-              Ghost-risk signal
-            </p>
-            <p className="text-sm text-charcoal font-medium mt-0.5">
-              Marina D.
-            </p>
-            <p className="text-[11px] text-charcoal/50">
-              last visit · 41 days ago
-            </p>
-          </div>
-          <span className="text-[10px] px-2 py-0.5 rounded-full bg-blush text-wine font-mono">
-            87 / 100
-          </span>
-        </div>
-      </div>
-
-      <div className="bg-blush-light rounded-2xl p-3 mx-1 mt-2 border border-wine/10 shadow-sm">
-        <div className="flex items-start justify-between">
-          <div>
-            <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
-              Reactivation triggered
-            </p>
-            <p className="text-sm text-charcoal font-medium mt-0.5">
-              SMS sent · 11s
-            </p>
-            <p className="text-[11px] text-charcoal/50">
-              Auto-sequence engaged
-            </p>
-          </div>
-          <span className="text-[10px] px-2 py-0.5 rounded-full bg-wine text-cream">
-            firing
-          </span>
-        </div>
-      </div>
-
-      <div className="bg-wine rounded-2xl p-3 mx-1 mt-2 shadow-sm">
+      <div className="bg-wine rounded-2xl p-6 md:p-7 mx-1 mt-2 shadow-sm">
         <p className="text-[10px] uppercase tracking-widest text-cream/70 font-medium">
-          Recovered
+          Recovered before she rebooked elsewhere
         </p>
-        <p className="font-serif text-3xl font-bold text-cream mt-0.5">$240</p>
-        <p className="text-[11px] text-cream/60">
-          before she rebooked elsewhere
+        <p className="font-serif text-4xl md:text-5xl font-bold text-cream mt-3">
+          $240
         </p>
+        <p className="text-[11px] text-cream/60 mt-2">
+          Marina D. · ghost-risk 87 / 100
+        </p>
+        <div className="mt-5 pt-4 border-t border-cream/15">
+          <p className="font-mono text-[10px] uppercase tracking-widest text-cream/50">
+            pattern caught · day 03
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/app/predictive-customer-intelligence/page.tsx
+++ b/src/app/predictive-customer-intelligence/page.tsx
@@ -1,0 +1,626 @@
+import Link from "next/link";
+import { Hero } from "@/components/hero";
+import { LiveSystemLog, type LogRow } from "@/components/live-system-log";
+import { Testimonials } from "@/components/testimonials";
+import CTA from "@/components/cta";
+import { FAQ, type FaqItem } from "@/components/faq";
+import { Button } from "@/components/button";
+
+export const metadata = {
+  title: "Predictive Customer Intelligence | Ops by Noell",
+  description:
+    "We find the revenue your booking software is missing. Then we deploy the agents and the ads that recover it. Free 30-minute audit.",
+  openGraph: {
+    title: "Predictive Customer Intelligence | Ops by Noell",
+    description:
+      "The intelligence layer behind your agents, your system, and your ads.",
+    url: "https://www.opsbynoell.com/predictive-customer-intelligence",
+    type: "website" as const,
+  },
+};
+
+const SOURCE_PAGE = "predictive-customer-intelligence" as const;
+
+const caseRows: LogRow[] = [
+  {
+    time: "day 01",
+    action: "booked-monthly",
+    result: "last-visit 41 days ago · pattern broken",
+  },
+  {
+    time: "day 02",
+    action: "ghost-risk-score",
+    result: "87 / 100 · prediction triggered",
+  },
+  {
+    time: "day 02",
+    action: "reactivation-sequence",
+    result: "sent · client responded",
+  },
+  {
+    time: "day 03",
+    action: "appointment confirmed",
+    result: "$240 recovered",
+  },
+];
+
+const problems = [
+  {
+    n: "01",
+    title: "The ghost pattern",
+    body:
+      "Loyal clients quietly stretch their visit cadence. By the time it shows up in your reports, they're at your competitor down the street.",
+  },
+  {
+    n: "02",
+    title: "The dead lead graveyard",
+    body:
+      "Every “let me think about it” lead has a 72-hour window. After that, conversion probability drops 80 percent. Most front desks follow up once, then forget.",
+  },
+  {
+    n: "03",
+    title: "The rebooking miss",
+    body:
+      "The highest-margin appointment you can sell is the one booked at checkout. It gets missed 40 to 60 percent of the time. Every miss is a lost client lifecycle.",
+  },
+];
+
+const solutions = [
+  {
+    n: "01",
+    title: "Predicts churn before it happens",
+    body:
+      "Every active client gets a ghost-risk score, updated continuously. You see who's drifting before they're gone — with a one-click outreach sequence ready to deploy.",
+    status: "status: monitoring · always-on",
+  },
+  {
+    n: "02",
+    title: "Resurrects dead leads on autopilot",
+    body:
+      "Stale leads get re-scored as new signals come in. When one heats back up, you know — and the agents can re-engage them while they're warm.",
+    status: "status: triggered on signal",
+  },
+  {
+    n: "03",
+    title: "Closes the rebooking loop",
+    body:
+      "A missed rebooking gets caught within 24 hours. The right follow-up — text, email, or live agent — fires automatically based on what converts for your business.",
+    status: "status: runs after every visit",
+  },
+];
+
+const deployments = [
+  {
+    n: "01",
+    label: "intelligence + agents",
+    title: "Recover what's already in your funnel.",
+    body:
+      "The intelligence layer watches your existing clients and leads. Noell Agents handle the outreach — calls, texts, chat, rebookings — the moment a signal fires. Best for businesses with strong inbound and gaps in the follow-through.",
+    bullets: [
+      "Ghost-risk monitoring on every active client",
+      "Dead lead resurrection sequences",
+      "Rebooking recovery within 24 hours of every visit",
+      "Three AI agents handle execution end-to-end",
+    ],
+    status: "status: best for inbound-heavy businesses",
+    href: "/agents",
+  },
+  {
+    n: "02",
+    label: "intelligence + system",
+    title: "Run the whole front of your business on one platform.",
+    body:
+      "The intelligence layer is built into a fully managed operations platform — CRM, calendars, marketing, agents, reporting — installed and managed by our team. Best for businesses ready to consolidate off five different tools.",
+    bullets: [
+      "Full white-labeled operations platform",
+      "Three AI agents included (Growth tier and up)",
+      "Two-way integration with your PMS or booking tool",
+      "Managed install in 14 days, ongoing updates, no maintenance on your end",
+    ],
+    status: "status: best for consolidation and replatforming",
+    href: "/systems",
+  },
+  {
+    n: "03",
+    label: "intelligence + media",
+    title: "Buy ads with your own customer data, not Facebook's guess.",
+    body:
+      "Most agencies running ads for service businesses have no idea who their client's best customers actually are. The intelligence layer does — every active client is already scored by LTV and behavior. That data drives the targeting.",
+    bullets: [
+      "Lookalike audiences built from your real high-LTV cohorts",
+      "Retargeting your ghost-risk list before they leave",
+      "Budget allocation weighted to your highest-lifecycle services",
+      "Creative briefs informed by what your existing clients actually book",
+    ],
+    status: "status: best for businesses ready to scale acquisition",
+    // TODO: link to dedicated media page when built
+    href: "#media",
+  },
+];
+
+const steps = [
+  {
+    n: "01",
+    title: "Connect",
+    body:
+      "Read-only integration with your booking system, CRM, and payment processor. No migration. No rip-and-replace.",
+  },
+  {
+    n: "02",
+    title: "Predict",
+    body:
+      "Within 48 hours, your first Revenue Signal Report: every account at risk, every lead worth re-engaging, every rebooking you're missing — ranked by dollar impact.",
+  },
+  {
+    n: "03",
+    title: "Recover",
+    body:
+      "Pick your deployment. Agents handle the outreach. The system runs the platform. Media buying drives new acquisition with the same data behind it. You stop losing revenue you already earned.",
+  },
+];
+
+const pciFaqs: FaqItem[] = [
+  {
+    id: "pci-booking-software",
+    question: "Will this work with my booking software?",
+    answer:
+      "Yes for almost everyone. We integrate with GoHighLevel, Mindbody, Boulevard, Vagaro, Jane, and most major CRMs. If you're on something custom, we'll tell you in the first 10 minutes whether we can connect.",
+  },
+  {
+    id: "pci-vs-reports",
+    question:
+      "How is this different from the reports my booking software gives me?",
+    answer:
+      "Your booking software tells you what happened. Predictive Customer Intelligence tells you what's about to happen — and gives you a window to act on it.",
+  },
+  {
+    id: "pci-three-deployments",
+    question: "Do I have to use all three deployments?",
+    answer:
+      "No. Most businesses start with one — usually Intelligence + Agents to fix the leaks they already have — and add deployments as they grow. The intelligence layer is the same underneath, so deployments stack cleanly.",
+  },
+  {
+    id: "pci-media-vs-agency",
+    question: "How is the media buying different from a normal ad agency?",
+    answer:
+      "A normal agency runs Facebook's targeting. We run targeting built from your actual customer data — who books, who comes back, who refers, who has the highest lifetime value. That's the difference between guessing and knowing.",
+  },
+  {
+    id: "pci-data-safe",
+    question: "Is my client data safe?",
+    answer:
+      "Yes. Read-only access, encrypted at rest and in transit, never shared. Built on enterprise-grade infrastructure (Vercel, Supabase).",
+  },
+  {
+    id: "pci-no-action",
+    question: "What if I don't act on the audit?",
+    answer:
+      "You still walk away with a free, prioritized list of revenue you're leaving on the table. Take it, fix it yourself, and we part as friends.",
+  },
+  {
+    id: "pci-cancel",
+    question: "Can I cancel anytime?",
+    answer:
+      "Yes. Month-to-month, no contracts. We earn the next month every month.",
+  },
+];
+
+function PciMockScreen() {
+  return (
+    <div className="flex w-full flex-col items-stretch px-3">
+      <div className="flex justify-between items-center w-full px-2 pb-2">
+        <div className="flex items-center gap-1.5">
+          <span className="w-2 h-2 rounded-full bg-green-500" />
+          <span className="text-xs text-charcoal/70 font-medium">
+            Intelligence layer · live
+          </span>
+        </div>
+        <span className="text-[10px] uppercase tracking-widest text-charcoal/40">
+          today
+        </span>
+      </div>
+
+      <div className="bg-white rounded-2xl p-3 mx-1 border border-warm-border/60 shadow-sm">
+        <div className="flex items-start justify-between">
+          <div>
+            <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
+              Ghost-risk signal
+            </p>
+            <p className="text-sm text-charcoal font-medium mt-0.5">
+              Marina D.
+            </p>
+            <p className="text-[11px] text-charcoal/50">
+              last visit · 41 days ago
+            </p>
+          </div>
+          <span className="text-[10px] px-2 py-0.5 rounded-full bg-blush text-wine font-mono">
+            87 / 100
+          </span>
+        </div>
+      </div>
+
+      <div className="bg-blush-light rounded-2xl p-3 mx-1 mt-2 border border-wine/10 shadow-sm">
+        <div className="flex items-start justify-between">
+          <div>
+            <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
+              Reactivation triggered
+            </p>
+            <p className="text-sm text-charcoal font-medium mt-0.5">
+              SMS sent · 11s
+            </p>
+            <p className="text-[11px] text-charcoal/50">
+              Auto-sequence engaged
+            </p>
+          </div>
+          <span className="text-[10px] px-2 py-0.5 rounded-full bg-wine text-cream">
+            firing
+          </span>
+        </div>
+      </div>
+
+      <div className="bg-wine rounded-2xl p-3 mx-1 mt-2 shadow-sm">
+        <p className="text-[10px] uppercase tracking-widest text-cream/70 font-medium">
+          Recovered
+        </p>
+        <p className="font-serif text-3xl font-bold text-cream mt-0.5">$240</p>
+        <p className="text-[11px] text-cream/60">
+          before she rebooked elsewhere
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function CaseSummaryPanel() {
+  return (
+    <div className="mt-10 grid grid-cols-1 md:grid-cols-3 gap-4 max-w-3xl mx-auto">
+      <div className="rounded-[18px] border border-warm-border bg-white p-5 text-center">
+        <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-wine/70 mb-2">
+          Pattern caught
+        </p>
+        <p className="text-sm font-medium text-charcoal">Marina D.</p>
+        <p className="font-serif text-3xl font-semibold text-wine mt-2">
+          87 / 100
+        </p>
+        <p className="text-[11px] text-charcoal/55 mt-1">ghost-risk score</p>
+      </div>
+      <div className="rounded-[18px] border border-warm-border bg-white p-5 text-center">
+        <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-wine/70 mb-2">
+          Reactivation triggered
+        </p>
+        <p className="text-sm font-medium text-charcoal">SMS · 11s</p>
+        <p className="font-mono text-[11px] text-charcoal/55 mt-2">
+          auto-sequence
+        </p>
+      </div>
+      <div className="rounded-[18px] border border-warm-border bg-white p-5 text-center">
+        <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-wine/70 mb-2">
+          Outcome
+        </p>
+        <p className="font-serif text-3xl font-semibold text-wine mt-1">
+          $240 recovered
+        </p>
+        <p className="text-[11px] text-charcoal/55 mt-1">
+          before she rebooked elsewhere
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ProblemSection() {
+  return (
+    <section className="w-full px-4 py-20 md:py-28">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-14 max-w-3xl mx-auto">
+          <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+            the gap
+          </p>
+          <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+            Your booking software shows you what happened.{" "}
+            <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+              Not what&rsquo;s about to.
+            </span>
+          </h2>
+          <p className="mt-5 text-charcoal/75 max-w-2xl mx-auto leading-relaxed">
+            Most service businesses lose 15 to 30 percent of revenue to signals
+            their software never surfaces. Not because the work isn&rsquo;t
+            getting done — because the patterns aren&rsquo;t getting caught.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+          {problems.map((p) => (
+            <div
+              key={p.n}
+              className="rounded-[22px] border border-warm-border bg-white p-6 md:p-7 shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
+            >
+              <p className="font-mono text-[10px] tracking-[0.22em] text-wine/70 mb-3">
+                {p.n}
+              </p>
+              <h3 className="font-serif text-xl md:text-2xl font-semibold text-charcoal mb-3 leading-snug">
+                {p.title}
+              </h3>
+              <p className="text-sm md:text-base text-charcoal/70 leading-relaxed">
+                {p.body}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SolutionSection() {
+  return (
+    <section className="w-full px-4 py-20 md:py-28 bg-cream-dark/40">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-14 max-w-3xl mx-auto">
+          <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+            the intelligence layer
+          </p>
+          <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+            One brain. Watching everything.{" "}
+            <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+              Always on.
+            </span>
+          </h2>
+          <p className="mt-5 text-charcoal/75 max-w-2xl mx-auto leading-relaxed">
+            Predictive Customer Intelligence is the operating layer underneath
+            everything Ops by Noell deploys. It connects to the systems you
+            already use, scores every client, lead, and rebooking in real time,
+            and tells the rest of the stack exactly what to do next.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+          {solutions.map((s) => (
+            <div
+              key={s.n}
+              className="rounded-[22px] border border-warm-border bg-white p-6 md:p-7 shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)] flex flex-col"
+            >
+              <p className="font-mono text-[10px] tracking-[0.22em] text-wine/70 mb-3">
+                {s.n}
+              </p>
+              <h3 className="font-serif text-xl md:text-2xl font-semibold text-charcoal mb-3 leading-snug">
+                {s.title}
+              </h3>
+              <p className="text-sm md:text-base text-charcoal/70 leading-relaxed flex-1">
+                {s.body}
+              </p>
+              <p className="mt-5 pt-4 border-t border-warm-border font-mono text-[10px] uppercase tracking-widest text-charcoal/55">
+                {s.status}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function DeploymentSection() {
+  return (
+    <section className="w-full px-4 py-20 md:py-28">
+      <div className="max-w-7xl mx-auto">
+        <div className="text-center mb-14 max-w-3xl mx-auto">
+          <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+            how you deploy it
+          </p>
+          <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+            Three ways the intelligence{" "}
+            <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+              becomes revenue.
+            </span>
+          </h2>
+          <p className="mt-5 text-charcoal/75 max-w-2xl mx-auto leading-relaxed">
+            The intelligence layer is the brain. The hands are how the work
+            gets done. Pick the deployment that fits where your business is
+            leaking the most.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {deployments.map((d) => (
+            <div
+              key={d.n}
+              className="rounded-[22px] border border-warm-border bg-white p-7 md:p-8 shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)] flex flex-col"
+            >
+              <div className="flex items-center justify-between mb-5">
+                <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-wine/70">
+                  {d.label}
+                </p>
+                <span className="font-mono text-[10px] text-charcoal/40">
+                  {d.n}
+                </span>
+              </div>
+              <h3 className="font-serif text-xl md:text-2xl font-semibold text-charcoal mb-3 leading-snug">
+                {d.title}
+              </h3>
+              <p className="text-sm md:text-base text-charcoal/70 leading-relaxed">
+                {d.body}
+              </p>
+              <ul className="mt-5 space-y-2.5 text-sm text-charcoal/80">
+                {d.bullets.map((b) => (
+                  <li key={b} className="flex gap-2.5">
+                    <span
+                      aria-hidden="true"
+                      className="mt-2 inline-block h-1.5 w-1.5 rounded-full bg-wine flex-shrink-0"
+                    />
+                    <span className="leading-relaxed">{b}</span>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-6 pt-4 border-t border-warm-border flex items-center justify-between gap-3">
+                <p className="font-mono text-[10px] uppercase tracking-widest text-charcoal/55">
+                  {d.status}
+                </p>
+                <Link
+                  href={d.href}
+                  className="text-xs font-medium text-wine hover:text-wine-dark whitespace-nowrap"
+                >
+                  Learn more &rarr;
+                </Link>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function HowItWorksSection() {
+  return (
+    <section
+      id="how-it-works"
+      className="w-full px-4 py-20 md:py-28 bg-cream-dark/40 scroll-mt-24"
+    >
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-14 max-w-3xl mx-auto">
+          <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+            how it works
+          </p>
+          <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+            Three steps.{" "}
+            <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+              Live in under a week.
+            </span>
+          </h2>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+          {steps.map((s) => (
+            <div
+              key={s.n}
+              className="rounded-[22px] border border-warm-border bg-white p-6 md:p-7 shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
+            >
+              <p className="font-mono text-[10px] tracking-[0.22em] text-wine/70 mb-3">
+                step {s.n}
+              </p>
+              <h3 className="font-serif text-xl md:text-2xl font-semibold text-charcoal mb-3 leading-snug">
+                {s.title}
+              </h3>
+              <p className="text-sm md:text-base text-charcoal/70 leading-relaxed">
+                {s.body}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PricingTeaserSection() {
+  return (
+    <section className="w-full px-4 py-20 md:py-28">
+      <div className="max-w-4xl mx-auto text-center">
+        <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+          pricing
+        </p>
+        <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+          Two ways to run it.{" "}
+          <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+            Three deployments under each.
+          </span>
+        </h2>
+        <p className="mt-5 text-charcoal/75 max-w-2xl mx-auto leading-relaxed">
+          Self-serve agents start at $197/mo founding rate. The full
+          done-for-you operation runs $197 to $1,497/mo. Media buying retainers
+          are quoted based on spend and scope.
+        </p>
+        <div className="mt-8">
+          <Button href="/pricing" variant="secondary" className="px-6 py-3">
+            See how it&rsquo;s priced &rarr;
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function PredictiveCustomerIntelligencePage() {
+  return (
+    <div>
+      <Hero
+        eyebrow="A systems agency · Ops by Noell · Intelligence layer"
+        headlineLine1Start="Predictive Customer"
+        headlineLine1Accent="Intelligence"
+        headlineLine2Start="for service businesses."
+        headlineLine2Accent=""
+        headlineLine2Smaller
+        body="We find the revenue your booking software is missing. Then we deploy the agents and the ads that recover it."
+        footnote=""
+        primaryCta={{ label: "Get Your Free Audit", href: "/book" }}
+        secondaryCta={{ label: "See how it works", href: "#how-it-works" }}
+        showProofBar={false}
+        sourcePage={SOURCE_PAGE}
+        sourceSection="hero"
+        mockScreen={<PciMockScreen />}
+      />
+
+      <LiveSystemLog
+        eyebrow="case: marina_d  /  signal > ghost-risk > 87"
+        rows={caseRows}
+        separator="·"
+        caption=""
+      >
+        <CaseSummaryPanel />
+      </LiveSystemLog>
+
+      <ProblemSection />
+
+      <SolutionSection />
+
+      <DeploymentSection />
+
+      <HowItWorksSection />
+
+      <Testimonials
+        eyebrow="Proof"
+        headlineStart="The system that recovered $960 in 14 days for one massage therapist"
+        headlineAccent="runs the same way for you."
+        body="Santa, a massage therapist in Laguna Niguel, went from digital patchwork to a system that watched her client patterns, caught her missed calls, and protected her calendar. Inside 14 days, the system had paid for itself."
+        ctaLabel="Book your free audit"
+        sourcePage={SOURCE_PAGE}
+        sourceSection="proof"
+      />
+
+      <CTA
+        eyebrow="The first step"
+        headlineStart="Start with a"
+        headlineAccent="free 30-minute audit."
+        body="No pitch. No pressure. A clear map of where leads, clients, and rebookings are falling through — whether you work with us or not."
+        trustLine="Free · 30 minutes · Live in 14 days"
+        primaryCta={{ label: "Get Your Free Audit", href: "/book" }}
+        secondaryCta={null}
+        sourcePage={SOURCE_PAGE}
+        sourceSection="offer"
+      />
+
+      <PricingTeaserSection />
+
+      <FAQ
+        eyebrow="Questions"
+        headlineStart="Straight"
+        headlineAccent="answers."
+        body="The questions we get most often about Predictive Customer Intelligence."
+        faqs={pciFaqs}
+      />
+
+      <CTA
+        eyebrow=""
+        headlineStart="The revenue is"
+        headlineAccent="already yours."
+        body="Spend 30 minutes. Get the map of what's leaking. Decide what's next from there."
+        trustLine=""
+        primaryCta={{ label: "Get Your Free Audit", href: "/book" }}
+        secondaryCta={null}
+        sourcePage={SOURCE_PAGE}
+        sourceSection="final"
+      />
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -12,6 +12,11 @@ const entries: Entry[] = [
   { path: "/about", changeFrequency: "monthly", priority: 0.8 },
   { path: "/agents", changeFrequency: "weekly", priority: 0.9 },
   { path: "/systems", changeFrequency: "weekly", priority: 0.9 },
+  {
+    path: "/predictive-customer-intelligence",
+    changeFrequency: "weekly",
+    priority: 0.9,
+  },
   { path: "/pricing", changeFrequency: "weekly", priority: 0.9 },
   { path: "/roi", changeFrequency: "monthly", priority: 0.7 },
   { path: "/contact", changeFrequency: "monthly", priority: 0.6 },

--- a/src/components/cta.tsx
+++ b/src/components/cta.tsx
@@ -26,7 +26,7 @@ export default function CTA({
   headlineAccent?: string;
   body?: string;
   primaryCta?: { label: string; href: string };
-  secondaryCta?: { label: string; href: string };
+  secondaryCta?: { label: string; href: string } | null;
   trustLine?: string;
   accent?: "wine" | "lilac";
   sourcePage?: SourcePage;
@@ -65,19 +65,26 @@ export default function CTA({
         <div className="absolute -bottom-24 -left-24 w-96 h-96 rounded-full bg-white/5 blur-3xl" />
 
         <div className="relative z-10 text-center max-w-3xl mx-auto">
-          <p className="text-[11px] uppercase tracking-[0.25em] text-white/60 mb-5">
-            {eyebrow}
-          </p>
+          {eyebrow && (
+            <p className="text-[11px] uppercase tracking-[0.25em] text-white/60 mb-5">
+              {eyebrow}
+            </p>
+          )}
           <h2 className="font-serif text-3xl md:text-5xl lg:text-6xl font-semibold text-white leading-tight">
-            {headlineStart}{" "}
-            <span
-              className={cn(
-                "bg-gradient-to-b bg-clip-text text-transparent italic",
-                accentGrad
-              )}
-            >
-              {headlineAccent}
-            </span>
+            {headlineStart}
+            {headlineAccent && (
+              <>
+                {" "}
+                <span
+                  className={cn(
+                    "bg-gradient-to-b bg-clip-text text-transparent italic",
+                    accentGrad
+                  )}
+                >
+                  {headlineAccent}
+                </span>
+              </>
+            )}
           </h2>
           <p className="mt-6 text-white/70 text-lg max-w-xl mx-auto leading-relaxed">
             {body}
@@ -95,18 +102,22 @@ export default function CTA({
             >
               {primaryCta.label}
             </Button>
-            <Button
-              href={secondaryCta.href}
-              variant="secondary"
-              className="h-12 px-8 bg-transparent border border-white/30 text-white hover:bg-white/10"
-              data-source-page={sourcePage}
-              data-source-section={sourceSection}
-            >
-              {secondaryCta.label}
-            </Button>
+            {secondaryCta && (
+              <Button
+                href={secondaryCta.href}
+                variant="secondary"
+                className="h-12 px-8 bg-transparent border border-white/30 text-white hover:bg-white/10"
+                data-source-page={sourcePage}
+                data-source-section={sourceSection}
+              >
+                {secondaryCta.label}
+              </Button>
+            )}
           </div>
 
-          <p className="mt-8 text-xs text-on-dark-soft">{trustLine}</p>
+          {trustLine && (
+            <p className="mt-8 text-xs text-on-dark-soft">{trustLine}</p>
+          )}
         </div>
       </motion.div>
     </section>

--- a/src/components/live-system-log.tsx
+++ b/src/components/live-system-log.tsx
@@ -1,8 +1,15 @@
 "use client";
 
+import React from "react";
 import { motion } from "motion/react";
 
-const rows = [
+export interface LogRow {
+  time: string;
+  action: string;
+  result?: string;
+}
+
+const defaultRows: LogRow[] = [
   {
     time: "06:12",
     action: "missed-call",
@@ -30,18 +37,30 @@ const rows = [
   },
 ];
 
-export function LiveSystemLog() {
+export function LiveSystemLog({
+  eyebrow = "LIVE  /  system log  /  last 12 hours",
+  rows = defaultRows,
+  caption = "The system runs. You run the business.",
+  separator = ">",
+  children,
+}: {
+  eyebrow?: string;
+  rows?: LogRow[];
+  caption?: string;
+  separator?: string;
+  children?: React.ReactNode;
+}) {
   return (
     <section className="w-full bg-blush">
       <div className="max-w-4xl mx-auto py-16 md:py-24 px-4">
         <p className="font-mono text-[11px] uppercase tracking-widest text-charcoal/60 text-center mb-8">
-          LIVE &nbsp;/&nbsp; system log &nbsp;/&nbsp; last 12 hours
+          {eyebrow}
         </p>
 
         <ul className="font-mono text-xs md:text-sm space-y-2 text-left">
           {rows.map((row, i) => (
             <motion.li
-              key={`${row.time}-${row.action}`}
+              key={`${row.time}-${row.action}-${i}`}
               initial={{ opacity: 0, y: 8 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
@@ -50,15 +69,23 @@ export function LiveSystemLog() {
             >
               <span className="text-charcoal/50 tabular-nums">{row.time}</span>
               <span className="text-wine font-semibold">{row.action}</span>
-              <span className="text-charcoal/30">&gt;</span>
-              <span className="text-charcoal">{row.result}</span>
+              {row.result && (
+                <>
+                  <span className="text-charcoal/30">{separator}</span>
+                  <span className="text-charcoal">{row.result}</span>
+                </>
+              )}
             </motion.li>
           ))}
         </ul>
 
-        <p className="text-charcoal/60 italic text-sm mt-8 text-center">
-          The system runs. You run the business.
-        </p>
+        {children}
+
+        {caption && (
+          <p className="text-charcoal/60 italic text-sm mt-8 text-center">
+            {caption}
+          </p>
+        )}
       </div>
     </section>
   );

--- a/src/components/testimonials.tsx
+++ b/src/components/testimonials.tsx
@@ -2,15 +2,45 @@
 import { motion } from "motion/react";
 import React from "react";
 import { Button } from "./button";
+import {
+  trackAuditCtaClick,
+  type SourcePage,
+  type SourceSection,
+} from "@/lib/analytics";
 
 export function Testimonials({
   accent = "wine",
+  eyebrow = "Proof",
+  headlineStart = "A quiet week.",
+  headlineAccent = "Then a full calendar.",
+  body = "Santa, a massage therapist in Laguna Niguel, went from digital patchwork to a system that followed up, reminded clients, and protected her calendar. Inside 14 days, the system had paid for itself.",
+  ctaLabel = "Book your free audit",
+  ctaHref = "/book",
+  sourcePage,
+  sourceSection,
 }: {
   accent?: "wine" | "lilac";
+  eyebrow?: string;
+  headlineStart?: string;
+  headlineAccent?: string;
+  body?: string;
+  ctaLabel?: string;
+  ctaHref?: string;
+  sourcePage?: SourcePage;
+  sourceSection?: SourceSection;
 }) {
   const accentBg = accent === "wine" ? "bg-wine/10" : "bg-lilac-dark/10";
   const accentText = accent === "wine" ? "text-wine" : "text-lilac-dark";
   const accentSolid = accent === "wine" ? "bg-wine" : "bg-lilac-dark";
+
+  const handleCta = () => {
+    if (sourcePage && sourceSection && ctaHref === "/book") {
+      trackAuditCtaClick(sourcePage, sourceSection, {
+        destination: ctaHref,
+        cta_label: ctaLabel,
+      });
+    }
+  };
 
   return (
     <section className="relative w-full py-24 overflow-hidden">
@@ -25,22 +55,22 @@ export function Testimonials({
           <p
             className={`text-[11px] uppercase tracking-[0.25em] ${accentText}`}
           >
-            Proof
+            {eyebrow}
           </p>
           <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
-            A quiet week.{" "}
-            <span className="italic font-serif text-wine">
-              Then a full calendar.
-            </span>
+            {headlineStart}
+            {headlineAccent ? (
+              <>
+                {" "}
+                <span className="italic font-serif text-wine">
+                  {headlineAccent}
+                </span>
+              </>
+            ) : null}
           </h2>
 
           <div className={`rounded-[22px] p-6 relative ${accentBg}`}>
-            <p className="text-charcoal/80 leading-relaxed">
-              Santa, a massage therapist in Laguna Niguel, went from digital
-              patchwork to a system that followed up, reminded clients, and
-              protected her calendar. Inside 14 days, the system had paid for
-              itself.
-            </p>
+            <p className="text-charcoal/80 leading-relaxed">{body}</p>
             <div className="mt-5 flex items-center gap-3">
               <div
                 className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold text-white ${accentSolid}`}
@@ -58,11 +88,15 @@ export function Testimonials({
 
           <div className="pt-2">
             <Button
-              href="/book"
+              href={ctaHref}
               variant={accent === "lilac" ? "lilac" : "primary"}
               className="px-6 py-3"
+              onClick={handleCta}
+              data-event={ctaHref === "/book" ? "audit_cta_click" : undefined}
+              data-source-page={sourcePage}
+              data-source-section={sourceSection}
             >
-              Book your free audit
+              {ctaLabel}
             </Button>
           </div>
         </motion.div>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -57,7 +57,8 @@ export type SourcePage =
   | "resources"
   | "navbar"
   | "footer"
-  | "global_chat";
+  | "global_chat"
+  | "predictive-customer-intelligence";
 
 /**
  * Semantic section where the click happened. Keep values kebab_case and
@@ -81,7 +82,10 @@ export type SourceSection =
   | "booking_fallback"
   | "booking_embed"
   | "audit_request_soft_exit"
-  | "founding_cta";
+  | "founding_cta"
+  | "proof"
+  | "offer"
+  | "final";
 
 /**
  * The canonical conversion events. Narrow set on purpose — each has a


### PR DESCRIPTION
## Summary

New landing page at **`/predictive-customer-intelligence`** — the leading-edge page for the Ops by Noell **Predictive Customer Intelligence (PCI)** repositioning. Frames the agency as an intelligence layer with three deployment paths underneath: **Agents · System · Media**.

**Vercel preview URL:** _(populated by Vercel after the deploy completes — the bot will post it on this PR)_

## What's in the page

13 sections in spec order:

1. Site nav (existing, via `ConditionalShell`)
2. **Hero** — "Predictive Customer Intelligence for service businesses." + custom ghost-risk iPhone mock screen
3. **Live case strip** — terminal-style Marina D. story (`day 01 → day 03`, ghost-risk 87/100, $240 recovered)
4. **Problem** — the gap (ghost pattern · dead lead graveyard · rebooking miss)
5. **Solution** — the intelligence layer (3 cards with mono `status:` lines)
6. **Deployment** — 3 cards: intelligence + agents · + system · + media
7. **How it works** — connect / predict / recover
8. **Proof** — Santa E. testimonial with PCI-specific framing
9. **Free audit offer block** — "Free · 30 minutes · Live in 14 days"
10. **Pricing teaser** → `/pricing`
11. **FAQ** — 7 PCI-specific questions (booking software, vs reports, deployments, vs ad agency, data safety, no-action audit, cancellation)
12. **Final CTA** — "The revenue is already yours."
13. Site footer (existing, via `ConditionalShell`)

## Reuse, not fork

Per `CLAUDE.md`, components were extended via props rather than forked. Defaults preserve every existing usage.

| Component | Change |
|-----------|--------|
| `<Hero>` | (none) — used as-is with custom `mockScreen` |
| `<LiveSystemLog>` | Added optional `eyebrow`, `rows`, `caption`, `separator`, `children` props. Defaults render the homepage log identically. |
| `<Testimonials>` | Added optional `eyebrow`, `headlineStart/Accent`, `body`, `ctaLabel/Href`, `sourcePage/Section` props. Defaults render the homepage Santa E. block identically. |
| `<CTA>` | Added support for `secondaryCta={null}`, empty `eyebrow`, and empty `trustLine` so single-CTA pages can opt out cleanly. Defaults unchanged. |

## Audit CTA analytics

All four "Get Your Free Audit" buttons hit the same `/book` destination as the homepage and fire `trackAuditCtaClick` via the existing `<Button>` component. Each is tagged with a distinct `sourceSection` so we can tell which section converts:

| Section | `sourcePage` | `sourceSection` |
|---------|--------------|-----------------|
| Hero | `predictive-customer-intelligence` | `hero` |
| Proof | `predictive-customer-intelligence` | `proof` |
| Offer block | `predictive-customer-intelligence` | `offer` |
| Final CTA | `predictive-customer-intelligence` | `final` |

`SourcePage` and `SourceSection` unions in `src/lib/analytics.ts` were extended with these values. Pure type additions — no new event names, no new analytics provider.

## Brand & accessibility

- Cream/blush background, burgundy primary, Playfair serif display, Inter sans body, Courier mono for terminal/status lines. **No new hex codes** — all existing Tailwind tokens.
- Eyebrows in small caps with `·` separators (matches homepage convention).
- One `<h1>` (hero), `<h2>` per section, `<h3>` for cards.
- FAQ uses the existing animated accordion (proper `aria-expanded` / `aria-controls`).
- Hero `secondaryCta="See how it works"` → `#how-it-works` anchor (with `scroll-mt-24` on the section).
- Deployment 03 (Media) → `#media` placeholder anchor with `// TODO: link to dedicated media page when built` comment.

## Out of scope (not touched)

- ❌ No new Supabase tables, GHL routes, or audit forms — CTAs reuse `/book`.
- ❌ No A2P / Twilio / SMS code paths touched.
- ❌ No homepage hero changes, no `/pricing`, `/agents`, or `/systems` changes.
- ❌ No PostHog, no A/B testing, no new global styles.

## Build / lint

- `npm run build` — green; `/predictive-customer-intelligence` listed as static prerender.
- `npm run lint` on all changed files — clean.
- Sitemap updated (`/predictive-customer-intelligence`, weekly, 0.9).

## Commits

1. `feat(analytics): add PCI source page + new source sections`
2. `feat(testimonials): make Santa E. block prop-driven`
3. `feat(live-system-log): make rows + framing prop-driven`
4. `feat(cta): allow hiding secondary CTA, eyebrow, and trust line`
5. `feat(landing): Predictive Customer Intelligence page`

## Test plan

- [ ] Vercel preview deploys successfully
- [ ] Page renders at `/predictive-customer-intelligence` on the preview
- [ ] All 13 sections present in correct order
- [ ] All four "Get Your Free Audit" buttons land on `/book`
- [ ] "See how it works" scrolls to the How it works section
- [ ] "See how it's priced →" lands on `/pricing`
- [ ] Deployment card "Learn more →" links: 01 → `/agents`, 02 → `/systems`, 03 → `#media`
- [ ] Mobile (375px) layout — no horizontal scroll
- [ ] Lighthouse mobile: perf > 90, a11y > 95
- [ ] Confirm homepage proof block, homepage live-system-log, and homepage final CTA all still render identically (default-prop preservation)

DO NOT MERGE TO MAIN — awaiting review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2fRYh4ZC6kgrHFvxsuoDd)_