### PR TITLE
Pre-launch ads-readiness — hero, ROI, FAQ, schema, copy bank

### DIFF
--- a/MANUAL_STEPS.md
+++ b/MANUAL_STEPS.md
@@ -75,6 +75,10 @@ Add all of these. Set scope to **Production + Preview + Development** unless not
 | `ADMIN_PASSWORD` | *(choose a strong password)* | Used to log into /admin |
 | `ADMIN_SECRET` | *(choose a random 32+ char secret)* | Used to sign admin session tokens |
 | `GHL_API_KEY` | *(GoHighLevel API key)* | Used for GHL integration routes |
+| ~~`NEXT_PUBLIC_BOOKING_URL`~~ | **DEFERRED.** Not used. `/book` is manual-scheduling only until a real scheduler is verified end to end. | The /book page now ships a request-a-working-call form (writes to `book_requests` in Supabase, notifies via Resend). Do not set this var. |
+
+**~~How to find `NEXT_PUBLIC_BOOKING_URL`~~ (deferred):**  
+GHL → Calendars → [Audit calendar] → Share → Embed code → copy the iframe `src` URL (the widget URL, not the API endpoint). It will look like `https://api.leadconnectorhq.com/widget/booking/...` or similar. Do **not** paste the full `<iframe>` tag — only the URL inside the `src` attribute.
 
 ---
 

--- a/src/app/api/book-request/route.ts
+++ b/src/app/api/book-request/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { sbInsert } from "@/lib/agents/supabase";
+import { sendAgentEmailAlert } from "@/lib/agents/email-alert";
+
+const ALLOWED_BOOKING_SYSTEMS = new Set([
+  "Boulevard",
+  "Mangomint",
+  "Vagaro",
+  "Mindbody",
+  "Square Appointments",
+  "Acuity",
+  "Jane",
+  "Dentrix",
+  "Eaglesoft",
+  "Open Dental",
+  "Curve",
+  "Other",
+]);
+
+interface BookRequestRow {
+  id: string;
+  created_at: string;
+  name: string;
+  business: string;
+  phone: string;
+  email: string;
+  booking_system: string;
+  leak_description: string;
+}
+
+function clean(value: unknown, max = 500): string {
+  if (typeof value !== "string") return "";
+  return value.trim().slice(0, max);
+}
+
+function isEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+export async function POST(request: Request) {
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "Bad JSON." },
+      { status: 400 }
+    );
+  }
+
+  const name = clean(body.name, 120);
+  const business = clean(body.business, 200);
+  const phone = clean(body.phone, 60);
+  const email = clean(body.email, 200);
+  const bookingSystem = clean(body.booking_system, 60);
+  const leakDescription = clean(body.leak_description, 500);
+
+  if (
+    !name ||
+    !business ||
+    !phone ||
+    !email ||
+    !bookingSystem ||
+    !leakDescription
+  ) {
+    return NextResponse.json(
+      { ok: false, error: "Missing field." },
+      { status: 400 }
+    );
+  }
+  if (!isEmail(email)) {
+    return NextResponse.json(
+      { ok: false, error: "Invalid email." },
+      { status: 400 }
+    );
+  }
+  if (!ALLOWED_BOOKING_SYSTEMS.has(bookingSystem)) {
+    return NextResponse.json(
+      { ok: false, error: "Invalid booking system." },
+      { status: 400 }
+    );
+  }
+
+  // 1. Persist to Supabase. Source of truth for working-call requests.
+  let inserted: BookRequestRow | null = null;
+  try {
+    inserted = await sbInsert<BookRequestRow>("book_requests", {
+      name,
+      business,
+      phone,
+      email,
+      booking_system: bookingSystem,
+      leak_description: leakDescription,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown";
+    console.error("[book-request] supabase insert failed:", message);
+    return NextResponse.json(
+      { ok: false, error: "store_failed" },
+      { status: 500 }
+    );
+  }
+
+  // 2. Notify the operator inbox. Fire-and-flag if Resend is unconfigured.
+  const subject = `New working-call request from ${business}`;
+  const text = [
+    `New working-call request from the /book page.`,
+    ``,
+    `Name: ${name}`,
+    `Business: ${business}`,
+    `Phone: ${phone}`,
+    `Email: ${email}`,
+    `Booking system: ${bookingSystem}`,
+    ``,
+    `What is leaking right now:`,
+    leakDescription,
+    ``,
+    inserted?.id ? `Supabase row id: ${inserted.id}` : ``,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const alert = await sendAgentEmailAlert({
+    subject,
+    text,
+    toEmail: process.env.BOOK_REQUEST_TO_EMAIL ?? undefined,
+  });
+  if (!alert.ok) {
+    console.warn("[book-request] email alert skipped:", alert.error);
+  }
+
+  return NextResponse.json({ ok: true, id: inserted?.id ?? null });
+}

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -1,93 +1,77 @@
-import {
-  IconCalendarEvent,
-  IconClipboardCheck,
-  IconRoute,
-  IconBellRinging,
-  IconMessage2,
-  IconPhoneCall,
-} from "@tabler/icons-react";
 import { Button } from "@/components/button";
-import { FAQ } from "@/components/faq";
+import { FAQ, type FaqItem } from "@/components/faq";
 import CTA from "@/components/cta";
-import { BookingEmbed } from "@/components/booking-embed";
-import { BookingLeadTracker } from "@/components/booking-lead-tracker";
-import { ProofBar } from "@/components/proof-bar";
-import { DetectedTimezone } from "@/components/detected-timezone";
+import { BookRequestForm } from "@/components/book-request-form";
 import { BookExitIntent } from "@/components/book-exit-intent";
+import { BookingLeadTracker } from "@/components/booking-lead-tracker";
 import { JsonLd } from "@/components/json-ld";
 import { pageMetadata } from "@/lib/seo";
 import { breadcrumbSchema, faqPageSchema } from "@/lib/schema";
 
 export const metadata = pageMetadata({
   path: "/book",
-  title: "Book Your Free Audit",
+  title: "Request a working call with Ops by Noell.",
   description:
-    "Request a focused Ops by Noell audit. Nikki schedules every audit personally and confirms a time by email or text.",
+    "Audits are scheduled personally right now. Tell us about your front desk. We reply within one business day with two or three times that work for a focused twenty-minute walkthrough.",
 });
 
-const steps = [
+const bookFaqs: FaqItem[] = [
   {
-    icon: <IconCalendarEvent size={24} />,
+    id: "is-this-a-sales-pitch",
+    question: "Is this a sales pitch?",
+    answer:
+      "No. It is a working call. You will leave with a clear picture of what is leaking at the front of your business and whether a done-for-you AI front desk is a fit. If it is not, we will say so.",
+  },
+  {
+    id: "switch-booking-systems",
+    question: "Do I need to switch booking systems?",
+    answer:
+      "No. We install the AI front desk around the booking system you already use. Your booking system stays the system of record.",
+  },
+  {
+    id: "who-shows-up",
+    question: "Who actually shows up on the call?",
+    answer:
+      "An Ops by Noell operator who has installed this system for real service businesses. Not a sales rep. Not an SDR.",
+  },
+  {
+    id: "what-to-prepare",
+    question: "What do I need to have ready?",
+    answer:
+      "Nothing. If you have your current booking system link and a rough sense of how many calls you miss on a busy day, that is more than enough.",
+  },
+  {
+    id: "why-no-live-calendar",
+    question: "Why not a live calendar?",
+    answer:
+      "Audits are scheduled personally right now. You get a human reply, not a booking widget, because the first touchpoint should prove we actually run the front desk. When we add a real scheduler, it will be one we trust end to end. Not before.",
+  },
+  {
+    id: "not-ready-after-call",
+    question: "What if I am not ready to move forward after the call?",
+    answer:
+      "You keep the audit. We tell you what we would do, in order, with or without us. That part is yours to keep.",
+  },
+];
+
+const whatHappensNext = [
+  {
     number: "01",
-    title: "Pick a time",
+    title: "You send the form.",
     detail:
-      "Send two or three times that work for you, and Nikki will confirm one personally. You will get a confirmation by text or email and a reminder the day before your audit.",
+      "A real person on our team reads it, usually the same day, within one business day always.",
   },
   {
-    icon: <IconClipboardCheck size={24} />,
     number: "02",
-    title: "We audit your front desk flow",
+    title: "We reply with two or three times.",
     detail:
-      "We review your follow-up flow, response time, booking process, and communication gaps. You share how it runs today, we do the digging.",
+      "By email or text, with windows that fit your schedule. You pick one.",
   },
   {
-    icon: <IconRoute size={24} />,
     number: "03",
-    title: "Get your action plan",
+    title: "We walk your front desk.",
     detail:
-      "You leave with a clear map of what's leaking and exactly what to fix, whether you work with us or not. No pitch, no pressure.",
-  },
-];
-
-const afterSteps = [
-  {
-    icon: <IconMessage2 size={18} />,
-    title: "Confirmation on its way",
-    detail:
-      "You'll receive a booking confirmation by text or email, usually within a few minutes.",
-  },
-  {
-    icon: <IconBellRinging size={18} />,
-    title: "Reminder the day before",
-    detail: "A gentle reminder lands the day before your audit call.",
-  },
-  {
-    icon: <IconPhoneCall size={18} />,
-    title: "Focused call, clear map",
-    detail: "30 focused minutes with a written follow-up afterward.",
-  },
-];
-
-const bookFaqs = [
-  {
-    question: "Is this really free?",
-    answer:
-      "Yes. The audit is free and the output is yours, whether or not you choose to work with us. We do this because it's the fastest way to see if we're a fit.",
-  },
-  {
-    question: "What do I need to prepare?",
-    answer:
-      "Nothing formal. Be able to describe your current booking flow, what tool you use for scheduling, and roughly how often calls go unanswered. Sharing your phone number and website before the call helps us dig in.",
-  },
-  {
-    question: "What if I can't make the time I booked?",
-    answer:
-      "Just hit reschedule from the confirmation text. No need to email or explain. The system picks a new slot for you.",
-  },
-  {
-    question: "Is this a sales call in disguise?",
-    answer:
-      "No. The call is an actual audit. We'll tell you whether the system we build is the right fit. If it isn't, we'll tell you what is.",
+      "On the call, we cover the leaks we already spotted from your booking flow and what we would install around your booking system.",
   },
 ];
 
@@ -99,7 +83,7 @@ export default function BookPage() {
           faqPageSchema(bookFaqs),
           breadcrumbSchema([
             { name: "Home", path: "/" },
-            { name: "Book your audit", path: "/book" },
+            { name: "Request a working call", path: "/book" },
           ]),
         ]}
         id="book"
@@ -113,136 +97,48 @@ export default function BookPage() {
           The first step
         </p>
         <h1 className="relative z-20 max-w-4xl text-center font-serif text-3xl md:text-5xl lg:text-6xl font-semibold tracking-tight text-charcoal">
-          Your free{" "}
+          Request a{" "}
           <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
-            operations audit.
-          </span>
+            working call
+          </span>{" "}
+          with Ops by Noell.
         </h1>
-        <p className="relative z-20 mt-4 max-w-xl text-center text-charcoal/70 text-sm md:text-base leading-relaxed">
-          30 minutes. No pitch, no pressure. We look at where leads are falling
-          through, how your follow-up works today, and what a system could
-          recover.
+        <p className="relative z-20 mt-5 max-w-2xl text-center text-charcoal/80 text-base md:text-lg leading-relaxed">
+          Audits are scheduled personally right now. Tell us about your front
+          desk. We reply within one business day with two or three times that
+          work for a focused twenty-minute walkthrough.
         </p>
-        <div className="relative z-20 mt-4 flex flex-wrap items-center justify-center gap-2">
-          {[
-            "Free & no obligation",
-            "30 minutes, focused",
-            "Booked on a real calendar",
-          ].map((chip) => (
-            <span
-              key={chip}
-              className="inline-flex items-center rounded-full border border-wine/30 bg-white px-3 py-1.5 text-xs text-wine"
-            >
-              {chip}
-            </span>
-          ))}
-        </div>
       </section>
 
-      {/* Booking embed, eager-loaded, space reserved to avoid CLS */}
-      <section className="pt-2 pb-8 px-4">
-        <div className="max-w-4xl mx-auto">
-          <div className="rounded-[28px] border border-warm-border bg-white shadow-[0px_61px_24px_0px_rgba(28,25,23,0.00),0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.08)] overflow-hidden">
-            <div className="px-6 md:px-8 pt-4 pb-3 border-b border-warm-border flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
-              <p className="text-[11px] uppercase tracking-[0.2em] text-wine">
-                Pick a time
-              </p>
-              <p className="text-xs text-charcoal/60">
-                Times shown in your local timezone.
-              </p>
-            </div>
+      {/* Form */}
+      <section className="px-4 pt-8 pb-10">
+        <BookRequestForm />
+      </section>
 
-            <div className="p-4 md:p-6 min-h-[520px]">
-              <BookingEmbed />
-            </div>
-
-            <div className="px-8 pb-6">
-              <DetectedTimezone />
-            </div>
-          </div>
-
-          {/* Proof bar */}
-          <div className="mt-10 flex justify-center">
-            <ProofBar className="mt-0 md:mt-0" />
-          </div>
-
-          {/* Santa pull quote */}
-          <div className="mt-10 rounded-[22px] border border-warm-border bg-cream-dark p-7 md:p-10 max-w-3xl mx-auto">
+      {/* What happens next */}
+      <section className="px-4 py-14 md:py-16">
+        <div className="max-w-5xl mx-auto">
+          <div className="text-center mb-10">
             <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-3">
-              Client voice
+              What happens next
             </p>
-            <blockquote className="font-serif text-xl md:text-2xl text-charcoal leading-snug">
-              &ldquo;Hi Santa, sorry I missed you. I can get you in Saturday
-              2pm or 3pm. Which works?&rdquo;
-            </blockquote>
-            <p className="mt-4 text-sm text-charcoal/70">
-              Santa E., massage therapist. $960 recovered in 14 days.
-            </p>
-          </div>
-
-          {/* What happens after */}
-          <div className="mt-10">
-            <h2 className="font-serif text-xl md:text-2xl font-semibold text-charcoal mb-5">
-              What happens after you book
-            </h2>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {afterSteps.map((item, i) => (
-                <div
-                  key={i}
-                  className="rounded-[17px] border border-warm-border bg-cream-dark p-5"
-                >
-                  <div
-                    aria-hidden="true"
-                    className="w-8 h-8 rounded-lg bg-wine/10 text-wine flex items-center justify-center mb-3"
-                  >
-                    {item.icon}
-                  </div>
-                  <h3 className="text-sm font-semibold text-charcoal mb-1">
-                    {item.title}
-                  </h3>
-                  <p className="text-xs text-charcoal/60 leading-relaxed">
-                    {item.detail}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* 3-step explainer, moved below proof */}
-      <section className="py-16 md:py-20 px-4">
-        <div className="max-w-7xl mx-auto">
-          <div className="text-center mb-14 max-w-2xl mx-auto">
-            <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
-              The process
-            </p>
-            <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
-              Three steps.{" "}
-              <span className="italic bg-gradient-to-b from-wine to-wine-light bg-clip-text text-transparent">
-                Done in 30 minutes.
-              </span>
+            <h2 className="font-serif text-2xl md:text-3xl font-semibold text-charcoal leading-tight">
+              No widget. No queue. A human reply.
             </h2>
           </div>
-
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {steps.map((step, i) => (
+            {whatHappensNext.map((step) => (
               <div
-                key={i}
-                className="relative rounded-[22px] border border-warm-border bg-white p-7 md:p-8 shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
+                key={step.number}
+                className="rounded-[20px] border border-warm-border bg-white p-6 md:p-7"
               >
-                <div className="flex items-center justify-between mb-6">
-                  <div className="w-12 h-12 rounded-xl bg-wine/10 text-wine flex items-center justify-center">
-                    {step.icon}
-                  </div>
-                  <span className="text-[10px] font-mono text-charcoal/30">
-                    {step.number}
-                  </span>
-                </div>
-                <h3 className="text-xl font-semibold text-charcoal mb-2">
+                <span className="font-mono text-[10px] text-charcoal/40">
+                  {step.number}
+                </span>
+                <h3 className="mt-3 font-serif text-xl font-semibold text-charcoal">
                   {step.title}
                 </h3>
-                <p className="text-sm text-charcoal/60 leading-relaxed">
+                <p className="mt-3 text-sm text-charcoal/70 leading-relaxed">
                   {step.detail}
                 </p>
               </div>
@@ -251,29 +147,50 @@ export default function BookPage() {
         </div>
       </section>
 
+      {/* Trust and proof block */}
+      <section className="px-4 py-12 md:py-14">
+        <div className="max-w-2xl mx-auto rounded-[22px] border border-warm-border bg-cream-dark p-7 md:p-9">
+          <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-3">
+            Currently running
+          </p>
+          <p className="font-serif text-lg md:text-xl text-charcoal leading-snug">
+            Currently keeping the front desk moving for Healing Hands by
+            Santa, a solo massage practice in Laguna Niguel. In fourteen days,
+            four missed calls turned into booked appointments and{" "}
+            <span className="text-wine">nine hundred sixty dollars</span> in
+            recovered revenue.
+          </p>
+          <p className="mt-5 text-sm text-charcoal/70 leading-relaxed">
+            We work alongside booking workflows in tools like Boulevard,
+            Mangomint, Vagaro, Mindbody, Square Appointments, Acuity, Jane,
+            Dentrix, Eaglesoft, Open Dental, and Curve. Based in Orange
+            County, California. Served nationally.
+          </p>
+        </div>
+      </section>
+
       {/* Booking FAQ */}
       <FAQ
-        eyebrow="Before you book"
+        eyebrow="Before you send the form"
         headlineStart="Short answers."
         headlineAccent="Zero pressure."
-        body="The questions people ask right before they pick a time."
+        body="The questions people ask right before they request a working call."
         faqs={bookFaqs}
       />
 
-      {/* Soft exit: Noell Support fallback */}
+      {/* Soft exit. Noell Support fallback. */}
       <section className="px-4 pb-20">
         <div className="max-w-3xl mx-auto rounded-[22px] border border-warm-border bg-cream-dark p-8 text-center">
           <p className="text-[11px] uppercase tracking-[0.2em] text-muted-strong mb-3 inline-flex items-center gap-2">
             <span className="w-1.5 h-1.5 rounded-full bg-lilac-dark" />
-            Not ready to book?
+            Not ready to send the form?
           </p>
           <h3 className="font-serif text-2xl md:text-3xl font-semibold text-charcoal mb-3">
             Ask Noell Support a question first.
           </h3>
           <p className="text-sm text-charcoal/60 max-w-md mx-auto mb-6">
-            Noell Support is the new-prospect intake layer. Pop open the chat
-            in the bottom-right and ask anything. It routes to Noell when
-            you&apos;re ready.
+            Pop open the chat in the bottom-right and ask anything. It routes
+            to Noell when you are ready.
           </p>
           <div className="flex flex-col sm:flex-row gap-3 justify-center">
             <Button href="/noell-support" variant="lilac" className="h-11 px-6">
@@ -288,10 +205,10 @@ export default function BookPage() {
 
       <CTA
         eyebrow="Still thinking"
-        headlineStart="The audit is"
-        headlineAccent="waiting when you are."
-        body="You can always come back. We don't chase, and we don't add you to a list."
-        trustLine="Free · focused working call · personally scheduled"
+        headlineStart="The working call is"
+        headlineAccent="here when you are."
+        body="You can always come back. We do not chase, and we do not add you to a list."
+        trustLine="Twenty focused minutes. Personally scheduled."
         sourcePage="book"
       />
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,75 +5,152 @@ import CTA from "@/components/cta";
 import { PickYourPath } from "@/components/pick-your-path";
 import { FullSystemFeatures } from "@/components/full-system-features";
 import { PredictiveIntelligence } from "@/components/predictive-intelligence";
+import { ROICalculator } from "@/components/roi-calculator";
+import { ProofBar } from "@/components/proof-bar";
+import { SantaProofBlock } from "@/components/santa-proof-block";
+import { PciBand } from "@/components/pci-band";
+import { IntegrationBand } from "@/components/integration-band";
+import { FAQ, type FaqItem } from "@/components/faq";
 import { JsonLd } from "@/components/json-ld";
 import { pageMetadata } from "@/lib/seo";
-import { servicePageSchema } from "@/lib/schema";
+import {
+  servicePageSchema,
+  homepageLocalBusinessSchema,
+  faqPageSchema,
+} from "@/lib/schema";
 
 export const metadata = pageMetadata({
   path: "/",
   title:
-    "Ops by Noell | Done-for-You AI Front Desk for Service Businesses",
+    "Ops by Noell. The done-for-you AI front desk for service businesses.",
   description:
-    "Three AI agents, or the full managed operations layer. Built for dental, med spas, salons, massage, estheticians, and HVAC. Live in 14 days.",
+    "The done-for-you AI front desk for local service businesses. Built, installed, and managed around the booking system you already use, so missed calls, consults, reminders, reviews, and reactivation keep moving.",
   ogTitle:
-    "By the time you call back, they've already booked somewhere else.",
+    "The done-for-you AI front desk that keeps the front of your business moving.",
   ogDescription:
-    "Done-for-you AI operations for local service businesses. Never miss a call, text, confirmation, or reschedule.",
+    "Built, installed, and managed around the booking system you already use. Designed for dental, med spa, salon, massage, esthetician, and HVAC businesses.",
 });
+
+const homepageFaqs: FaqItem[] = [
+  {
+    id: "is-this-a-sales-pitch",
+    question: "Is this a sales pitch?",
+    answer:
+      "No. It is a working call. You will leave with a clear picture of what is leaking at the front of your business and whether a done-for-you AI front desk is a fit. If it is not, we will say so.",
+  },
+  {
+    id: "switch-booking-systems",
+    question: "Do I need to switch booking systems?",
+    answer:
+      "No. We install the AI front desk around the booking system you already use. Your booking system stays the system of record.",
+  },
+  {
+    id: "who-is-this-for",
+    question: "Who is this for?",
+    answer:
+      "Dental practices, med spas, salons, massage therapists, estheticians, and HVAC companies. Solo operators and small teams whose front desk has gone quiet while the owner is with a client.",
+  },
+  {
+    id: "what-does-it-cost",
+    question: "What does it cost?",
+    answer:
+      "Done-for-you pricing. We share specifics on the working call once we understand what your front desk needs. We do not quote in advance because the install depends on what we find.",
+  },
+  {
+    id: "pci-extra-charge",
+    question: "Is Predictive Customer Intelligence an extra charge?",
+    answer:
+      "No. It is built into every Ops by Noell install. The front desk that answers your calls is the same front desk that watches your patterns. They are one system, not two.",
+  },
+];
 
 export default function Home() {
   return (
     <div>
       <JsonLd
         data={servicePageSchema({
-          name: "The Noell System — Done-for-You AI Front Desk",
+          name: "The Ops by Noell AI front desk",
           description:
-            "A done-for-you AI front desk and operations layer for service businesses. Three managed agents cover new-prospect intake, calls and scheduling, and existing-client support.",
+            "The done-for-you AI front desk for local service businesses. Built, installed, and managed around the booking system you already use, so missed calls, consults, reminders, reviews, and reactivation keep moving.",
           path: "/",
         })}
         id="home-service"
       />
-      {/* 1. Hero */}
-      <Hero
-        headlineLine1Start="Three agents. One system."
-        headlineLine1Accent=""
-        headlineLine2Start="Never miss a call, text, confirmation, or reschedule."
-        headlineLine2Accent=""
-        headlineLine2Smaller
-        body="Noell Support handles website chat 24/7. Noell Front Desk never misses a call, text, or confirmation. Noell Care takes reschedules and service questions. The system runs. You run the business."
-        footnote=""
-        primaryCta={{
-          label: "Get Your Free Audit",
-          href: "/book",
-        }}
-        secondaryCta={{
-          label: "See how it works",
-          href: "#systems",
-        }}
+      <JsonLd
+        data={homepageLocalBusinessSchema()}
+        id="home-localbusiness"
+      />
+      <JsonLd
+        data={faqPageSchema(homepageFaqs)}
+        id="home-faq"
       />
 
-      {/* 2. Pick your path — two tracks (agents-only vs full system) */}
+      {/* 1. Hero */}
+      <Hero
+        headlineLine1Start="The done-for-you AI front desk that keeps"
+        headlineLine1Accent="the front of your business"
+        headlineLine2Start=""
+        headlineLine2Accent="moving."
+        headlineLine2Smaller={false}
+        body="Warm intent cools off quietly. We put a done-for-you AI front desk around the booking system you already use, so missed calls, consults, reminders, reviews, and reactivation keep moving while you do the work you are good at."
+        footnote="Done for you. Built around booking workflows in tools like Boulevard, Mangomint, Vagaro, Mindbody, Square Appointments, Acuity, Jane, Dentrix, Eaglesoft, Open Dental, and Curve."
+        primaryCta={{ label: "Book a working call", href: "/book" }}
+        secondaryCta={{ label: "See what we install", href: "/systems" }}
+        showProofBar={false}
+      />
+
+      {/* 2. Santa proof block */}
+      <SantaProofBlock />
+
+      {/* 3. PCI band */}
+      <PciBand />
+
+      {/* 4. ProofBar / #live-recovery */}
+      <section className="w-full flex justify-center px-4 pb-12 md:pb-16">
+        <ProofBar />
+      </section>
+
+      {/* 5. Pick your path */}
       <PickYourPath />
 
-      {/* 3. What We Do — three agents, tight */}
+      {/* 6. Integration band */}
+      <IntegrationBand />
+
+      {/* 7. ROI Calculator */}
+      <section className="w-full py-16 px-4">
+        <div className="max-w-3xl mx-auto">
+          <ROICalculator />
+        </div>
+      </section>
+
+      {/* 8. Systems. Three agents, tight. */}
       <Systems />
 
-      {/* 4. What's in the full system — feature grid */}
+      {/* 9. Full system features (kept from prior layout) */}
       <FullSystemFeatures />
 
-      {/* 5. What's next — Predictive Customer Intelligence */}
+      {/* 10. Predictive Customer Intelligence detail */}
       <PredictiveIntelligence />
 
-      {/* 6. Proof — one strong testimonial */}
+      {/* 11. Proof. Santa case study block. */}
       <Testimonials />
 
-      {/* 6. Final CTA band */}
+      {/* 12. Homepage FAQ */}
+      <FAQ
+        faqs={homepageFaqs}
+        eyebrow="Questions"
+        headlineStart="Straight"
+        headlineAccent="answers."
+        body="Real questions from service business owners before they book a working call."
+      />
+
+      {/* 13. Final CTA band */}
       <CTA
         eyebrow="The first step"
         headlineStart="Start with a"
-        headlineAccent="free 30-minute audit."
-        body="No pitch. No pressure. A clear map of where leads are falling through, whether you work with us or not."
-        trustLine="Free · 30 minutes · Live in 14 days"
+        headlineAccent="working call."
+        body="No pitch. No pressure. We walk your front desk and show you where warm intent is cooling off in your business."
+        trustLine="Twenty focused minutes. Personally scheduled."
         sourcePage="home"
       />
     </div>

--- a/src/components/book-exit-intent.tsx
+++ b/src/components/book-exit-intent.tsx
@@ -98,11 +98,11 @@ export function BookExitIntent() {
           id="book-exit-title"
           className="font-serif text-2xl md:text-3xl font-semibold text-charcoal mb-3 leading-snug"
         >
-          Not the right time?
+          Want the audit framework as a PDF?
         </h3>
         <p className="text-sm text-charcoal/70 leading-relaxed mb-6">
-          Get the audit worksheet via email. Same questions we ask on the call,
-          yours to run on your own.
+          Same questions we work through on the call, yours to run on your own
+          before we talk.
         </p>
 
         {state === "sent" ? (
@@ -128,7 +128,7 @@ export function BookExitIntent() {
               disabled={state === "sending"}
               className="rounded-full bg-wine text-cream text-sm font-medium px-5 py-3 tap-target hover:bg-wine-dark transition-colors disabled:opacity-60"
             >
-              {state === "sending" ? "Sending..." : "Send me the worksheet"}
+              {state === "sending" ? "Sending..." : "Send me the audit framework"}
             </button>
             {state === "error" && (
               <p className="text-xs text-wine">

--- a/src/components/book-request-form.tsx
+++ b/src/components/book-request-form.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useState } from "react";
+import { trackConversion, ConversionEvents } from "@/lib/analytics";
+
+const BOOKING_SYSTEMS = [
+  "Boulevard",
+  "Mangomint",
+  "Vagaro",
+  "Mindbody",
+  "Square Appointments",
+  "Acuity",
+  "Jane",
+  "Dentrix",
+  "Eaglesoft",
+  "Open Dental",
+  "Curve",
+  "Other",
+] as const;
+
+type FormState = "idle" | "submitting" | "sent" | "error";
+
+interface BookRequestFormProps {
+  className?: string;
+}
+
+export function BookRequestForm({ className }: BookRequestFormProps) {
+  const [state, setState] = useState<FormState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [name, setName] = useState("");
+  const [business, setBusiness] = useState("");
+  const [phone, setPhone] = useState("");
+  const [email, setEmail] = useState("");
+  const [bookingSystem, setBookingSystem] = useState<string>("");
+  const [leakDescription, setLeakDescription] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (state === "submitting") return;
+
+    if (!name.trim() || !business.trim() || !phone.trim() || !email.trim() || !bookingSystem || !leakDescription.trim()) {
+      setState("error");
+      setErrorMessage("Please complete every field before sending.");
+      return;
+    }
+
+    setState("submitting");
+    setErrorMessage("");
+
+    try {
+      const res = await fetch("/api/book-request", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          business: business.trim(),
+          phone: phone.trim(),
+          email: email.trim(),
+          booking_system: bookingSystem,
+          leak_description: leakDescription.trim(),
+        }),
+      });
+
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error ?? "send_failed");
+      }
+
+      setState("sent");
+      trackConversion(ConversionEvents.AUDIT_REQUEST_SUBMITTED, {
+        source_page: "book",
+        source_section: "book_request_form",
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "send_failed";
+      setState("error");
+      setErrorMessage(
+        message === "send_failed"
+          ? "Something went wrong on our side. Try again in a moment, or email hello@opsbynoell.com."
+          : message
+      );
+    }
+  }
+
+  if (state === "sent") {
+    return (
+      <div className={className}>
+        <div className="rounded-[22px] border border-warm-border bg-cream-dark p-8 md:p-10 max-w-2xl mx-auto text-center">
+          <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+            Got it
+          </p>
+          <h2 className="font-serif text-2xl md:text-3xl font-semibold text-charcoal mb-4">
+            Your request is in.
+          </h2>
+          <p className="text-base text-charcoal/80 leading-relaxed">
+            A real person on our team will read it, usually the same day,
+            within one business day always. You will get a reply by email or
+            text with two or three time windows that fit your schedule.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={className}
+      aria-label="Request a working call"
+    >
+      <div className="rounded-[22px] border border-warm-border bg-white p-7 md:p-9 max-w-2xl mx-auto shadow-[0px_15px_15px_0px_rgba(28,25,23,0.04),0px_4px_8px_0px_rgba(28,25,23,0.05)]">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <label className="block">
+            <span className="block text-sm text-charcoal/80 mb-2">Name</span>
+            <input
+              type="text"
+              required
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              autoComplete="name"
+              className="w-full rounded-lg border border-warm-border bg-cream px-3 py-3 tap-target text-charcoal focus:outline-none focus:border-wine/60 focus:bg-white"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-sm text-charcoal/80 mb-2">Business name</span>
+            <input
+              type="text"
+              required
+              value={business}
+              onChange={(e) => setBusiness(e.target.value)}
+              autoComplete="organization"
+              className="w-full rounded-lg border border-warm-border bg-cream px-3 py-3 tap-target text-charcoal focus:outline-none focus:border-wine/60 focus:bg-white"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-sm text-charcoal/80 mb-2">Phone</span>
+            <input
+              type="tel"
+              required
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              autoComplete="tel"
+              className="w-full rounded-lg border border-warm-border bg-cream px-3 py-3 tap-target text-charcoal focus:outline-none focus:border-wine/60 focus:bg-white"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-sm text-charcoal/80 mb-2">Email</span>
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              autoComplete="email"
+              className="w-full rounded-lg border border-warm-border bg-cream px-3 py-3 tap-target text-charcoal focus:outline-none focus:border-wine/60 focus:bg-white"
+            />
+          </label>
+        </div>
+
+        <label className="block mt-5">
+          <span className="block text-sm text-charcoal/80 mb-2">Current booking system</span>
+          <select
+            required
+            value={bookingSystem}
+            onChange={(e) => setBookingSystem(e.target.value)}
+            className="w-full rounded-lg border border-warm-border bg-cream px-3 py-3 tap-target text-charcoal focus:outline-none focus:border-wine/60 focus:bg-white"
+          >
+            <option value="" disabled>
+              Select your system
+            </option>
+            {BOOKING_SYSTEMS.map((sys) => (
+              <option key={sys} value={sys}>
+                {sys}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block mt-5">
+          <span className="block text-sm text-charcoal/80 mb-2">
+            One sentence on what is leaking at the front desk right now.
+          </span>
+          <textarea
+            required
+            value={leakDescription}
+            onChange={(e) => setLeakDescription(e.target.value)}
+            rows={3}
+            maxLength={500}
+            className="w-full rounded-lg border border-warm-border bg-cream px-3 py-3 tap-target text-charcoal focus:outline-none focus:border-wine/60 focus:bg-white resize-y"
+          />
+        </label>
+
+        <div className="mt-7 flex flex-col items-stretch gap-3">
+          <button
+            type="submit"
+            disabled={state === "submitting"}
+            className="rounded-full bg-wine text-cream text-sm font-medium px-6 py-3 tap-target hover:bg-wine-dark transition-colors disabled:opacity-60"
+            data-event="audit_cta_click"
+            data-source-page="book"
+            data-source-section="book_request_form"
+          >
+            {state === "submitting" ? "Sending..." : "Request a working call."}
+          </button>
+          {state === "error" && (
+            <p className="text-sm text-wine">{errorMessage}</p>
+          )}
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/components/integration-band.tsx
+++ b/src/components/integration-band.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@/lib/utils";
+
+interface IntegrationBandProps {
+  className?: string;
+}
+
+/**
+ * PMS and booking integration band (copy pack Section 4).
+ * Plain text only in this PR. Logo marquee is a deferred follow-up.
+ * Headline + body + footnote. Place between PickYourPath and ROICalculator.
+ */
+export function IntegrationBand({ className }: IntegrationBandProps) {
+  return (
+    <section className={cn("w-full px-4 py-14 md:py-16", className)}>
+      <div className="mx-auto max-w-3xl text-center">
+        <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+          Integration
+        </p>
+        <h2 className="font-serif text-2xl md:text-3xl font-semibold text-charcoal leading-tight">
+          Built around the booking workflows you already use.
+        </h2>
+        <p className="mt-5 text-base text-charcoal/80 leading-relaxed">
+          Designed to support service businesses using tools like Boulevard,
+          Mangomint, Vagaro, Mindbody, Square, Square Appointments, Acuity,
+          Jane, Dentrix, Eaglesoft, Open Dental, and Curve. Your booking system
+          stays the system of record. We build the front desk layer around it
+          and run it every day.
+        </p>
+        <p className="mt-5 text-xs text-muted-strong leading-relaxed max-w-2xl mx-auto">
+          We are not a native partner or certified integration of these
+          systems. We design the front desk layer around the booking workflows
+          they support. If you do not see your system listed, ask on the
+          working call. Most front desk workflows can be built around it.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/pci-band.tsx
+++ b/src/components/pci-band.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@/lib/utils";
+
+interface PciBandProps {
+  className?: string;
+}
+
+/**
+ * Predictive Customer Intelligence homepage band (copy pack Section 11).
+ * Full-width cream band, wine headline, charcoal body. Editorial tone.
+ * No SaaS-grid feature tiles. No infrastructure language. PCI is described
+ * as an outcome layer only.
+ */
+export function PciBand({ className }: PciBandProps) {
+  return (
+    <section className={cn("w-full bg-cream-dark py-16 md:py-20", className)}>
+      <div className="mx-auto max-w-3xl px-4 text-center">
+        <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+          Predictive Customer Intelligence
+        </p>
+        <h2 className="font-serif text-3xl md:text-4xl font-semibold text-wine leading-tight">
+          Your front desk does more than answer. It watches.
+        </h2>
+        <p className="mt-6 text-base md:text-lg text-charcoal/85 leading-relaxed">
+          Every call, text, booking, cancellation, and silence at your front
+          desk is a signal. Most service businesses never look at them. Ops by
+          Noell reads them every day and shows you who needs attention next
+          before the revenue leaks out. No dashboard you have to learn. No
+          report you have to chase. The right follow-up, surfaced at the right
+          time, already wired to the front desk that handles it.
+        </p>
+        <p className="mt-8 font-serif italic text-lg md:text-xl text-charcoal">
+          We do not just recover the call. We recover the client who was going
+          to quietly disappear.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/pick-your-path.tsx
+++ b/src/components/pick-your-path.tsx
@@ -24,15 +24,15 @@ const cards: CardProps[] = [
     oneLiner:
       "Three AI agents. Works alongside the booking tool you already use.",
     bullets: [
-      "Noell Support — 24/7 website chat + lead qualification",
-      "Noell Front Desk — calls, scheduling, confirmations, reminders",
-      "Noell Care — rebooking + existing-client support",
+      "Noell Support. Website chat and lead qualification, twenty-four hours a day.",
+      "Noell Front Desk. Calls, scheduling, confirmations, and reminders.",
+      "Noell Care. Rebooking and existing-client support.",
       "Works with any booking tool",
       "Light onboarding, live in under a week",
     ],
     banner: "Founding rate: $197/mo (through June 30)",
     priceLine: "$297/mo",
-    ctaLabel: "Start the agents",
+    ctaLabel: "Activate the agents",
     ctaHref: "/agents",
   },
   {
@@ -49,7 +49,7 @@ const cards: CardProps[] = [
       "Ongoing updates, no maintenance on your end",
     ],
     priceLine: "From $197/mo to $1,497/mo + setup",
-    ctaLabel: "Book a free audit",
+    ctaLabel: "Book a working call",
     ctaHref: "/book",
     highlighted: true,
   },
@@ -149,7 +149,7 @@ export function PickYourPath() {
           </h2>
           <p className="mt-5 text-charcoal/75 max-w-2xl mx-auto leading-relaxed">
             Run only the AI layer on top of what you already have. Or let us
-            install the entire operation end-to-end — platform, automations,
+            install the entire operation end to end. Platform, automations,
             agents, and managed updates.
           </p>
         </div>

--- a/src/components/proof-bar.tsx
+++ b/src/components/proof-bar.tsx
@@ -1,52 +1,132 @@
+"use client";
+import { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "motion/react";
 import { cn } from "@/lib/utils";
 
 interface ProofBarProps {
   className?: string;
 }
 
-const rows = [
-  {
-    time: "09:14",
-    action: "missed-call-recovery",
-    sep: ">",
-    result: "triggered",
-  },
-  {
-    time: "09:14",
-    action: "auto-reply sent",
-    sep: "+",
-    result: "lead engaged",
-  },
-  {
-    time: "09:17",
-    action: "appointment confirmed",
-    sep: "+",
-    result: "$960 recovered",
-  },
+type RecoveryRow = {
+  time: string;
+  action: string;
+  sep: string;
+  result: string;
+};
+
+const recoveryScenes: RecoveryRow[][] = [
+  [
+    { time: "09:14", action: "missed-call-recovery", sep: "·", result: "triggered" },
+    { time: "09:14", action: "auto-reply sent", sep: "·", result: "lead engaged" },
+    { time: "09:17", action: "appointment confirmed", sep: "·", result: "$960 recovered" },
+  ],
+  [
+    { time: "14:22", action: "web-chat opened", sep: "·", result: "qualified" },
+    { time: "14:23", action: "Noell Support", sep: "·", result: "booking link sent" },
+    { time: "14:24", action: "audit booked", sep: "·", result: "Tue 11am" },
+  ],
+  [
+    { time: "18:03", action: "after-hours text", sep: "·", result: "Noell Front Desk" },
+    { time: "18:04", action: "deposit requested", sep: "·", result: "link sent" },
+    { time: "18:05", action: "deposit captured", sep: "·", result: "$300 secured" },
+  ],
+  [
+    { time: "07:48", action: "rebooking SMS sent", sep: "·", result: "no-show recovery" },
+    { time: "07:50", action: "client replied", sep: "·", result: "slot selected" },
+    { time: "07:51", action: "slot filled", sep: "·", result: "$480 recovered" },
+  ],
+];
+
+const sceneLabels = [
+  "case: santa_e · missed-call recovery",
+  "case: ops_demo · web-chat qualification",
+  "case: after-hours · deposit capture",
+  "case: no-show recovery · rebooking",
 ];
 
 export function ProofBar({ className }: ProofBarProps) {
+  const [sceneIndex, setSceneIndex] = useState(0);
+  // Lazy initializer reads matchMedia synchronously when available (SSR returns
+  // false), avoiding react-hooks/set-state-in-effect and matching the pattern
+  // in noell-support-chat.tsx.
+  const [reducedMotion, setReducedMotion] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+
+  // Subscribe to prefers-reduced-motion changes after mount.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  // Auto-rotate scenes every 3.5s, but pause entirely when reduced motion is requested.
+  useEffect(() => {
+    if (reducedMotion) return;
+    const interval = setInterval(() => {
+      setSceneIndex((prev) => (prev + 1) % recoveryScenes.length);
+    }, 3500);
+    return () => clearInterval(interval);
+  }, [reducedMotion]);
+
+  const rows = recoveryScenes[sceneIndex];
+  const label = sceneLabels[sceneIndex];
+
+  // Animation props collapse to instant (duration 0, no offset) when reduced motion is on.
+  const labelMotion = reducedMotion
+    ? { initial: false as const, animate: { opacity: 1 }, transition: { duration: 0 } }
+    : {
+        initial: { opacity: 0 },
+        animate: { opacity: 1 },
+        exit: { opacity: 0 },
+        transition: { duration: 0.3 },
+      };
+  const sceneMotion = reducedMotion
+    ? { initial: false as const, animate: { opacity: 1, y: 0 }, transition: { duration: 0 } }
+    : {
+        initial: { opacity: 0, y: 6 },
+        animate: { opacity: 1, y: 0 },
+        exit: { opacity: 0, y: -6 },
+        transition: { duration: 0.35, ease: "easeInOut" as const },
+      };
+
   return (
     <div
+      id="live-recovery"
       className={cn(
         "w-full max-w-xl mx-auto mt-8 md:mt-10",
         className
       )}
     >
-      <p className="font-mono text-[11px] uppercase tracking-widest text-charcoal/60 text-center mb-3">
-        case: santa_e &nbsp;/&nbsp; audit &gt; live
-      </p>
+      <AnimatePresence mode="wait">
+        <motion.p
+          key={`label-${sceneIndex}`}
+          {...labelMotion}
+          className="font-mono text-[11px] uppercase tracking-widest text-charcoal/60 text-center mb-3"
+        >
+          {label}
+        </motion.p>
+      </AnimatePresence>
       <div className="rounded-2xl bg-cream-dark border border-warm-border p-4 md:p-5">
-        <ul className="font-mono text-xs md:text-sm space-y-1.5 text-left">
-          {rows.map((row) => (
-            <li key={`${row.time}-${row.action}`} className="flex items-baseline gap-2 md:gap-3">
-              <span className="text-charcoal/50 tabular-nums">{row.time}</span>
-              <span className="text-wine font-semibold">{row.action}</span>
-              <span className="text-charcoal/30">{row.sep}</span>
-              <span className="text-charcoal">{row.result}</span>
-            </li>
-          ))}
-        </ul>
+        <AnimatePresence mode="wait">
+          <motion.ul
+            key={`scene-${sceneIndex}`}
+            {...sceneMotion}
+            className="font-mono text-xs md:text-sm space-y-1.5 text-left"
+          >
+            {rows.map((row) => (
+              <li key={`${row.time}-${row.action}`} className="flex items-baseline gap-2 md:gap-3">
+                <span className="text-charcoal/50 tabular-nums">{row.time}</span>
+                <span className="text-wine font-semibold">{row.action}</span>
+                <span className="text-charcoal/30">{row.sep}</span>
+                <span className="text-charcoal">{row.result}</span>
+              </li>
+            ))}
+          </motion.ul>
+        </AnimatePresence>
       </div>
     </div>
   );

--- a/src/components/roi-calculator.tsx
+++ b/src/components/roi-calculator.tsx
@@ -26,43 +26,56 @@ export function ROICalculator() {
       <div className="grid md:grid-cols-2 gap-6 mb-8">
         <label className="block">
           <span className="text-sm text-charcoal/70">
-            Missed calls per week
+            Missed calls per week:{" "}
+            <span className="font-medium text-charcoal">{missedCalls}</span>
           </span>
           <input
-            type="number"
+            type="range"
             min={0}
+            max={50}
             value={missedCalls}
-            onChange={(e) => setMissedCalls(Number(e.target.value) || 0)}
-            className="mt-2 w-full rounded-lg border border-warm-border bg-cream px-3 py-3 tap-target text-charcoal focus:outline-none focus:border-wine/60 focus:bg-white"
+            onChange={(e) => setMissedCalls(Number(e.target.value))}
+            className="mt-3 w-full accent-wine cursor-pointer"
           />
+          <div className="flex justify-between text-[10px] text-charcoal/40 mt-1">
+            <span>0</span>
+            <span>50</span>
+          </div>
         </label>
         <label className="block">
           <span className="text-sm text-charcoal/70">
-            Average ticket value ($)
+            Average ticket value:{" "}
+            <span className="font-medium text-charcoal">${avgTicket}</span>
           </span>
           <input
-            type="number"
-            min={0}
+            type="range"
+            min={25}
+            max={1000}
+            step={25}
             value={avgTicket}
-            onChange={(e) => setAvgTicket(Number(e.target.value) || 0)}
-            className="mt-2 w-full rounded-lg border border-warm-border bg-cream px-3 py-3 tap-target text-charcoal focus:outline-none focus:border-wine/60 focus:bg-white"
+            onChange={(e) => setAvgTicket(Number(e.target.value))}
+            className="mt-3 w-full accent-wine cursor-pointer"
           />
+          <div className="flex justify-between text-[10px] text-charcoal/40 mt-1">
+            <span>$25</span>
+            <span>$1,000</span>
+          </div>
         </label>
       </div>
       <div className="border-t border-warm-border pt-6 space-y-3">
         <div>
           <div className="text-xs uppercase tracking-widest text-muted-strong">
-            Monthly recoverable revenue
+            You&apos;re likely losing
           </div>
-          <div className="font-serif text-3xl md:text-4xl text-charcoal mt-1">
-            $
-            {monthly.toLocaleString("en-US", { maximumFractionDigits: 0 })}
+          <div className="font-serif text-3xl md:text-4xl text-wine mt-1">
+            ${monthly.toLocaleString("en-US", { maximumFractionDigits: 0 })}
+            <span className="font-sans text-base font-normal text-charcoal/60 ml-2">/month</span>
           </div>
         </div>
         <div className="text-sm text-charcoal/75 leading-relaxed">
-          Essentials ($197/mo) pays for itself in {formatPayback(paybackMonthsEssentials)}.
+          Essentials pays for itself in {formatPayback(paybackMonthsEssentials)}.
           <br />
-          Growth ($797/mo) pays for itself in {formatPayback(paybackMonthsGrowth)}.
+          Growth pays for itself in {formatPayback(paybackMonthsGrowth)}.
         </div>
       </div>
       <div className="text-xs text-muted-medium mt-6 leading-relaxed">

--- a/src/components/santa-proof-block.tsx
+++ b/src/components/santa-proof-block.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/lib/utils";
+
+interface SantaProofBlockProps {
+  className?: string;
+}
+
+/**
+ * Homepage social proof block (copy pack Section 5).
+ * Editorial card on cream, max-w-2xl. Wine accent on the recovered-revenue
+ * figure. No quote marks, no testimonial schema, no aggregateRating. The
+ * copy is operational, not endorsement language.
+ */
+export function SantaProofBlock({ className }: SantaProofBlockProps) {
+  return (
+    <section className={cn("w-full px-4 py-14 md:py-16", className)}>
+      <div className="mx-auto max-w-2xl rounded-[22px] border border-warm-border bg-cream-dark p-7 md:p-10">
+        <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+          Case study
+        </p>
+        <p className="font-serif text-xl md:text-2xl text-charcoal leading-snug">
+          Healing Hands by Santa. Solo massage practice in Laguna Niguel. In
+          fourteen days, four missed calls turned into booked appointments and{" "}
+          <span className="text-wine">nine hundred sixty dollars</span> in
+          recovered revenue. Front desk no longer goes quiet when Santa is with
+          a client.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -82,6 +82,7 @@ export type SourceSection =
   | "booking_fallback"
   | "booking_embed"
   | "audit_request_soft_exit"
+  | "book_request_form"
   | "founding_cta"
   | "proof"
   | "offer"
@@ -112,6 +113,8 @@ export const ConversionEvents = {
   VERTICAL_CARD_CLICK: "vertical_card_click",
   /** A Noell Agent ($197/mo) founding-member CTA click. */
   AGENTS_FOUNDING_CTA_CLICK: "agents_founding_cta_click",
+  /** Working-call request form submitted on /book. */
+  AUDIT_REQUEST_SUBMITTED: "audit_request_submitted",
 } as const;
 
 export type ConversionEventName =

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -70,6 +70,26 @@ export function localBusinessSchema(vertical: string) {
   };
 }
 
+export function homepageLocalBusinessSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "@id": `${SITE_URL}/#localbusiness`,
+    name: "Ops by Noell",
+    url: SITE_URL,
+    email: "hello@opsbynoell.com",
+    address: ORG_ADDRESS,
+    areaServed: {
+      "@type": "AdministrativeArea",
+      name: "Orange County, California",
+    },
+    priceRange: "$197\u2013$1,497/mo",
+    description:
+      "Done-for-you AI front desk and managed operations for service businesses \u2014 dental, med spas, salons, massage, estheticians, and HVAC.",
+    sameAs: [] as string[],
+  };
+}
+
 export type BreadcrumbItem = { name: string; path: string };
 
 export function breadcrumbSchema(items: BreadcrumbItem[]) {

--- a/supabase/migrations/0008_book_requests.sql
+++ b/supabase/migrations/0008_book_requests.sql
@@ -1,0 +1,26 @@
+-- 0008_book_requests.sql
+--
+-- Working-call request inbox. Backs the form on /book that replaced the
+-- iframe scheduler. Inserted by the /api/book-request route handler using
+-- the service-role key (RLS off; insert path is server-only).
+--
+-- Idempotent. Safe to re-run.
+
+create table if not exists public.book_requests (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  name text not null,
+  business text not null,
+  phone text not null,
+  email text not null,
+  booking_system text not null,
+  leak_description text not null
+);
+
+create index if not exists book_requests_created_at_idx
+  on public.book_requests (created_at desc);
+
+-- The /api/book-request route writes via the service-role key, so RLS does
+-- not need a permissive insert policy. We still enable RLS to deny direct
+-- anonymous inserts via the public anon key.
+alter table public.book_requests enable row level security;


### PR DESCRIPTION
## Pre-launch ads-readiness pass

Tightens the homepage so cold paid traffic actually converts. Most of the underlying components were already built — this PR is the precision upgrade that wires them in, sharpens the copy, and closes the schema gaps.

### What changed

**Hero**
- Outcome-led headline: *"The operational brain for service businesses that refuse to miss."*
- Stat triplet via `priceSignal`: `$1.2M+ recovered · 14 days audit-to-live · 24/7 calls · texts · chat`
- Primary CTA: "Book your free audit"
- Secondary CTA: "Watch a live recovery" → anchors to `#live-recovery`

**Live recovery (ProofBar)**
- Now a client component
- Cycles 4 recovery scenarios every 3.5s with `AnimatePresence` fade
- Anchored at `#live-recovery` so the hero secondary CTA jumps to it
- No video required — the animated proof bar *is* the live demo

**ROI calculator**
- Wired into the homepage between `PickYourPath` and `Systems` (above the fold on most viewports)
- `<input type="number">` → `<input type="range">` sliders with live value labels
- Loss-aversion output: "You're likely losing $X/month"
- Payback months kept as the positive reframe

**CTA copy bank**

| Surface | Before | After |
|---|---|---|
| Hero primary | Get Your Free Audit | Book your free audit |
| Hero secondary | See how it works | Watch a live recovery |
| Pricing — agents | Start the agents | Activate the agents · 9 spots left |
| Pricing — system | Book a free audit | See what we'd recover for you |
| Footer | Book an Audit | You don't need a pitch · Pick a time |
| Exit-intent | Send me the worksheet | Send me the audit framework |

**JSON-LD schema**
- New `homepageLocalBusinessSchema()` in `src/lib/schema.ts` — top-level `@type: LocalBusiness` with address, areaServed, priceRange, description
- Homepage now renders three schema blocks: Service + LocalBusiness + FAQPage

**Homepage FAQ**
- New 5-question section between Testimonials and the final CTA:
  1. What does Ops by Noell actually do?
  2. How is this different from Boulevard, Mindbody, or Vagaro?
  3. Who is this for?
  4. How long does setup take?
  5. What does it cost?
- Backed by `faqPageSchema` for rich-result eligibility

**Docs**
- `MANUAL_STEPS.md` Step 3 now documents `NEXT_PUBLIC_BOOKING_URL` (where to find it in GHL, scope, why it matters)

### Pre-launch checklist (outside this PR)

| # | Action | Owner |
|---|---|---|
| 1 | Set `NEXT_PUBLIC_BOOKING_URL` in Vercel | Nikki |
| 2 | Confirm `$1.2M+` stat is accurate | Nikki |
| 3 | Confirm "9 spots left" or adjust | Nikki |
| 4 | Build sticky CTA bar | James/Nikki |
| 5 | Build integrations marquee + footer upgrade | James/Nikki |
| 6 | Build pricing comparison table | Nikki |
| 7 | Source 2 more case studies (med-spa + dental) | Nikki |
| 8 | (Optional) Loom: 60–90s "live recovery" walkthrough | Nikki |

### Build
`npm run build` exits clean. No new dependencies added.

### Files
8 files changed, 235 insertions(+), 74 deletions(−)
