### PR TITLE
fix(api): authenticate + harden public agent/action routes before side effects

### DIFF
--- a/src/app/api/care/message/route.ts
+++ b/src/app/api/care/message/route.ts
@@ -88,43 +88,53 @@ export async function POST(req: NextRequest): Promise<Response> {
   } catch {
     return NextResponse.json({ error: "invalid json" }, { status: 400 });
   }
+  // Defensive payload shape — a probe with `{}` previously crashed in
+  // `lookupContact` reading `payload.from.phone` and surfaced as an
+  // empty 500. Coerce `from` to a usable object before any downstream
+  // DB / model / provider call.
+  if (!payload || typeof payload !== "object") {
+    return NextResponse.json({ error: "invalid payload" }, { status: 400 });
+  }
   if (!payload.clientId || !payload.message) {
     return NextResponse.json(
       { error: "clientId and message are required" },
       { status: 400 }
     );
   }
+  if (!payload.from || typeof payload.from !== "object") {
+    payload.from = {};
+  }
   payload.message = clampPublicMessage(payload.message);
   if (!payload.message) {
     return NextResponse.json({ error: "empty message" }, { status: 400 });
   }
 
-  const contact = await lookupContact(
-    payload.clientId,
-    payload.from.phone,
-    payload.from.email
-  );
-  const kbHits = await queryKnowledgeBase(payload.clientId, payload.message);
-
-  const runtimeContext = [
-    contact
-      ? `Recognized contact: ${contact.name ?? "(no name on file)"}` +
-        (contact.last_visit_at
-          ? ` · last visit ${contact.last_visit_at}`
-          : "") +
-        (contact.visit_count
-          ? ` · ${contact.visit_count} visits total`
-          : "") +
-        (contact.preferred_service
-          ? ` · usual service: ${contact.preferred_service}`
-          : "") +
-        (contact.vip ? " · VIP" : "") +
-        (contact.notes ? ` · notes: ${contact.notes}` : "")
-      : "Contact is not recognized in `client_contacts`. If they claim to be a regular, ask name + phone to pull their file.",
-    formatKnowledgeContext(kbHits),
-  ].join("\n\n");
-
   try {
+    const contact = await lookupContact(
+      payload.clientId,
+      payload.from.phone,
+      payload.from.email
+    );
+    const kbHits = await queryKnowledgeBase(payload.clientId, payload.message);
+
+    const runtimeContext = [
+      contact
+        ? `Recognized contact: ${contact.name ?? "(no name on file)"}` +
+          (contact.last_visit_at
+            ? ` · last visit ${contact.last_visit_at}`
+            : "") +
+          (contact.visit_count
+            ? ` · ${contact.visit_count} visits total`
+            : "") +
+          (contact.preferred_service
+            ? ` · usual service: ${contact.preferred_service}`
+            : "") +
+          (contact.vip ? " · VIP" : "") +
+          (contact.notes ? ` · notes: ${contact.notes}` : "")
+        : "Contact is not recognized in `client_contacts`. If they claim to be a regular, ask name + phone to pull their file.",
+      formatKnowledgeContext(kbHits),
+    ].join("\n\n");
+
     const result = await runTurn({
       agent: "care",
       payload: { ...payload, agent: "care" },
@@ -139,8 +149,10 @@ export async function POST(req: NextRequest): Promise<Response> {
     });
     return NextResponse.json({ ...result, recognizedContactId: contact?.id ?? null });
   } catch (e) {
+    // Never reflect raw error text to unauthenticated callers.
+    console.error("[care/message] handler failed:", e);
     return NextResponse.json(
-      { error: (e as Error).message },
+      { error: "internal_error" },
       { status: 500 }
     );
   }

--- a/src/app/api/front-desk/message/route.ts
+++ b/src/app/api/front-desk/message/route.ts
@@ -48,11 +48,21 @@ export async function POST(req: NextRequest): Promise<Response> {
   } catch {
     return NextResponse.json({ error: "invalid json" }, { status: 400 });
   }
+  // Defensive: a probe with `{}` or a bad shape must not blow up the
+  // route inside runTurn (which leaked `Cannot read properties of
+  // undefined (reading 'name')` to unauthenticated probes). Coerce
+  // `from` to an object before any downstream code reads it.
+  if (!payload || typeof payload !== "object") {
+    return NextResponse.json({ error: "invalid payload" }, { status: 400 });
+  }
   if (!payload.clientId || !payload.message) {
     return NextResponse.json(
       { error: "clientId and message are required" },
       { status: 400 }
     );
+  }
+  if (!payload.from || typeof payload.from !== "object") {
+    payload.from = {};
   }
   payload.message = clampPublicMessage(payload.message);
   if (!payload.message) {
@@ -72,8 +82,12 @@ export async function POST(req: NextRequest): Promise<Response> {
     });
     return NextResponse.json(result);
   } catch (e) {
+    // Never reflect raw error text — internal messages leak
+    // implementation details (stack-shape strings, table names, etc.).
+    // Log server-side; return an opaque 500.
+    console.error("[front-desk/message] runTurn failed:", e);
     return NextResponse.json(
-      { error: (e as Error).message },
+      { error: "internal_error" },
       { status: 500 }
     );
   }

--- a/src/app/api/front-desk/missed-call/route.ts
+++ b/src/app/api/front-desk/missed-call/route.ts
@@ -17,6 +17,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getClientConfig } from "@/lib/agents/config";
 import { getSmsIntegration } from "@/lib/agents/integrations/registry";
 import {
+  type AdminContext,
   clientIdentity,
   hasClientAccess,
   rateLimit,
@@ -34,17 +35,21 @@ export const dynamic = "force-dynamic";
  * Missed-call is triggered by the client's phone system (GHL/Twilio
  * webhook). That traffic authenticates with AGENT_ACTION_SECRET —
  * admins with client access may also call this directly for manual
- * textbacks.
+ * textbacks. Auth runs BEFORE body parse / DB writes / SMS dispatch
+ * so unauth probes get 401, not 400.
  */
-async function authorize(
-  req: Request,
-  clientId: string
-): Promise<{ ok: true } | { ok: false; response: Response }> {
+type AuthResult =
+  | { ok: true; admin: AdminContext | null; mode: "bearer" | "admin" }
+  | { ok: false; response: Response };
+
+async function preauthorize(req: Request): Promise<AuthResult> {
   const expected = process.env.AGENT_ACTION_SECRET;
   const auth = req.headers.get("authorization") ?? "";
-  if (expected && auth === `Bearer ${expected}`) return { ok: true };
+  if (expected && auth === `Bearer ${expected}`) {
+    return { ok: true, admin: null, mode: "bearer" };
+  }
   const admin = await verifyAdminFromCookie(req);
-  if (admin && hasClientAccess(admin, clientId)) return { ok: true };
+  if (admin) return { ok: true, admin, mode: "admin" };
   return {
     ok: false,
     response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
@@ -66,21 +71,26 @@ export async function POST(req: NextRequest): Promise<Response> {
   );
   if (!rl.ok) return rateLimitResponse(rl.retryAfterMs);
 
+  // Auth FIRST — before body parse / field validation / DB or provider calls.
+  const authz = await preauthorize(req);
+  if (!authz.ok) return authz.response;
+
   let body: MissedCallPayload;
   try {
     body = (await req.json()) as MissedCallPayload;
   } catch {
     return NextResponse.json({ error: "invalid json" }, { status: 400 });
   }
-  if (!body.clientId || !body.from) {
+  if (!body || typeof body !== "object" || !body.clientId || !body.from) {
     return NextResponse.json(
       { error: "clientId and from are required" },
       { status: 400 }
     );
   }
 
-  const authz = await authorize(req, body.clientId);
-  if (!authz.ok) return authz.response;
+  if (authz.mode === "admin" && authz.admin && !hasClientAccess(authz.admin, body.clientId)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   const cfg = await getClientConfig(body.clientId);
   if (!cfg.active || !cfg.agents.frontDesk) {

--- a/src/app/api/front-desk/reschedule/route.ts
+++ b/src/app/api/front-desk/reschedule/route.ts
@@ -10,6 +10,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getClientConfig } from "@/lib/agents/config";
 import { getCalendarIntegration, getSmsIntegration } from "@/lib/agents/integrations/registry";
 import {
+  type AdminContext,
   clientIdentity,
   hasClientAccess,
   rateLimit,
@@ -21,15 +22,19 @@ import { sbInsert, sbSelect, sbUpdate } from "@/lib/agents/supabase";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-async function authorize(
-  req: Request,
-  clientId: string
-): Promise<{ ok: true } | { ok: false; response: Response }> {
+/** Auth gate that fires BEFORE body parsing — see schedule/route.ts. */
+type AuthResult =
+  | { ok: true; admin: AdminContext | null; mode: "bearer" | "admin" }
+  | { ok: false; response: Response };
+
+async function preauthorize(req: Request): Promise<AuthResult> {
   const expected = process.env.AGENT_ACTION_SECRET;
   const auth = req.headers.get("authorization") ?? "";
-  if (expected && auth === `Bearer ${expected}`) return { ok: true };
+  if (expected && auth === `Bearer ${expected}`) {
+    return { ok: true, admin: null, mode: "bearer" };
+  }
   const admin = await verifyAdminFromCookie(req);
-  if (admin && hasClientAccess(admin, clientId)) return { ok: true };
+  if (admin) return { ok: true, admin, mode: "admin" };
   return {
     ok: false,
     response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
@@ -57,13 +62,23 @@ export async function POST(req: NextRequest): Promise<Response> {
   );
   if (!rl.ok) return rateLimitResponse(rl.retryAfterMs);
 
+  // Auth FIRST — before body parse / field validation / DB or provider calls.
+  const authz = await preauthorize(req);
+  if (!authz.ok) return authz.response;
+
   let body: RescheduleBody;
   try {
     body = (await req.json()) as RescheduleBody;
   } catch {
     return NextResponse.json({ error: "invalid json" }, { status: 400 });
   }
-  if (!body.clientId || !body.appointmentId || !body.newTime) {
+  if (
+    !body ||
+    typeof body !== "object" ||
+    !body.clientId ||
+    !body.appointmentId ||
+    !body.newTime
+  ) {
     return NextResponse.json({ error: "missing fields" }, { status: 400 });
   }
   const newTime = new Date(body.newTime);
@@ -71,8 +86,9 @@ export async function POST(req: NextRequest): Promise<Response> {
     return NextResponse.json({ error: "invalid newTime" }, { status: 400 });
   }
 
-  const authz = await authorize(req, body.clientId);
-  if (!authz.ok) return authz.response;
+  if (authz.mode === "admin" && authz.admin && !hasClientAccess(authz.admin, body.clientId)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   const cfg = await getClientConfig(body.clientId);
   const calendar = getCalendarIntegration(cfg);

--- a/src/app/api/front-desk/schedule/route.ts
+++ b/src/app/api/front-desk/schedule/route.ts
@@ -27,6 +27,7 @@ import {
   getSmsIntegration,
 } from "@/lib/agents/integrations/registry";
 import {
+  type AdminContext,
   clientIdentity,
   hasClientAccess,
   rateLimit,
@@ -40,20 +41,29 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 /**
- * Auth model: either an authenticated admin with access to the target
- * client OR a server-to-server call with the AGENT_ACTION_SECRET bearer
- * token. The secret is used by the internal agent runner / inbound-SMS
- * bridge so Nikki's chat flows can still book without cookies.
+ * Auth model — runs BEFORE body parsing so unauthenticated probes get
+ * a consistent 401 instead of leaking shape errors / 400s. Two paths:
+ *
+ *   1. Server-to-server: AGENT_ACTION_SECRET bearer token (used by the
+ *      internal agent runner / inbound-SMS bridge so chat flows can
+ *      still book without cookies).
+ *   2. Admin cookie: authenticated admin who passes `hasClientAccess`
+ *      against the target client. Because we don't know `clientId`
+ *      until the body is parsed, we accept the cookie here and re-check
+ *      access against `body.clientId` once it's known.
  */
-async function authorize(
-  req: Request,
-  clientId: string
-): Promise<{ ok: true } | { ok: false; response: Response }> {
+type AuthResult =
+  | { ok: true; admin: AdminContext | null; mode: "bearer" | "admin" }
+  | { ok: false; response: Response };
+
+async function preauthorize(req: Request): Promise<AuthResult> {
   const expected = process.env.AGENT_ACTION_SECRET;
   const auth = req.headers.get("authorization") ?? "";
-  if (expected && auth === `Bearer ${expected}`) return { ok: true };
+  if (expected && auth === `Bearer ${expected}`) {
+    return { ok: true, admin: null, mode: "bearer" };
+  }
   const admin = await verifyAdminFromCookie(req);
-  if (admin && hasClientAccess(admin, clientId)) return { ok: true };
+  if (admin) return { ok: true, admin, mode: "admin" };
   return {
     ok: false,
     response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
@@ -96,6 +106,10 @@ export async function POST(req: NextRequest): Promise<Response> {
   );
   if (!rl.ok) return rateLimitResponse(rl.retryAfterMs);
 
+  // Auth FIRST — before body parse / field validation / DB or provider calls.
+  const authz = await preauthorize(req);
+  if (!authz.ok) return authz.response;
+
   let body: ScheduleBody;
   try {
     body = (await req.json()) as ScheduleBody;
@@ -103,6 +117,8 @@ export async function POST(req: NextRequest): Promise<Response> {
     return NextResponse.json({ error: "invalid json" }, { status: 400 });
   }
   if (
+    !body ||
+    typeof body !== "object" ||
     !body.clientId ||
     !body.clientName ||
     !body.clientPhone ||
@@ -115,8 +131,10 @@ export async function POST(req: NextRequest): Promise<Response> {
     );
   }
 
-  const authz = await authorize(req, body.clientId);
-  if (!authz.ok) return authz.response;
+  // Admin-cookie path: now that we know `clientId`, enforce access.
+  if (authz.mode === "admin" && authz.admin && !hasClientAccess(authz.admin, body.clientId)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   const cfg = await getClientConfig(body.clientId);
   if (!cfg.active || !cfg.agents.frontDesk) {

--- a/src/app/api/support/message/route.ts
+++ b/src/app/api/support/message/route.ts
@@ -89,43 +89,53 @@ export async function POST(req: NextRequest): Promise<Response> {
   } catch {
     return NextResponse.json({ error: "invalid json" }, { status: 400 });
   }
+  // Defensive payload shape — a probe with `{}` previously crashed in
+  // `lookupContact` reading `payload.from.phone` and surfaced as an
+  // empty 500. Coerce `from` to a usable object before any downstream
+  // DB / model / provider call.
+  if (!payload || typeof payload !== "object") {
+    return NextResponse.json({ error: "invalid payload" }, { status: 400 });
+  }
   if (!payload.clientId || !payload.message) {
     return NextResponse.json(
       { error: "clientId and message are required" },
       { status: 400 }
     );
   }
+  if (!payload.from || typeof payload.from !== "object") {
+    payload.from = {};
+  }
   payload.message = clampPublicMessage(payload.message);
   if (!payload.message) {
     return NextResponse.json({ error: "empty message" }, { status: 400 });
   }
 
-  const contact = await lookupContact(
-    payload.clientId,
-    payload.from.phone,
-    payload.from.email
-  );
-  const kbHits = await queryKnowledgeBase(payload.clientId, payload.message);
-
-  const runtimeContext = [
-    contact
-      ? `Recognized contact: ${contact.name ?? "(no name on file)"}` +
-        (contact.last_visit_at
-          ? ` · last visit ${contact.last_visit_at}`
-          : "") +
-        (contact.visit_count
-          ? ` · ${contact.visit_count} visits total`
-          : "") +
-        (contact.preferred_service
-          ? ` · usual service: ${contact.preferred_service}`
-          : "") +
-        (contact.vip ? " · VIP" : "") +
-        (contact.notes ? ` · notes: ${contact.notes}` : "")
-      : "Contact is not recognized in `client_contacts`. Treat as a new prospect.",
-    formatKnowledgeContext(kbHits),
-  ].join("\n\n");
-
   try {
+    const contact = await lookupContact(
+      payload.clientId,
+      payload.from.phone,
+      payload.from.email
+    );
+    const kbHits = await queryKnowledgeBase(payload.clientId, payload.message);
+
+    const runtimeContext = [
+      contact
+        ? `Recognized contact: ${contact.name ?? "(no name on file)"}` +
+          (contact.last_visit_at
+            ? ` · last visit ${contact.last_visit_at}`
+            : "") +
+          (contact.visit_count
+            ? ` · ${contact.visit_count} visits total`
+            : "") +
+          (contact.preferred_service
+            ? ` · usual service: ${contact.preferred_service}`
+            : "") +
+          (contact.vip ? " · VIP" : "") +
+          (contact.notes ? ` · notes: ${contact.notes}` : "")
+        : "Contact is not recognized in `client_contacts`. Treat as a new prospect.",
+      formatKnowledgeContext(kbHits),
+    ].join("\n\n");
+
     const result = await runTurn({
       agent: "support",
       payload: { ...payload, agent: "support" },
@@ -140,8 +150,10 @@ export async function POST(req: NextRequest): Promise<Response> {
     });
     return NextResponse.json({ ...result, recognizedContactId: contact?.id ?? null });
   } catch (e) {
+    // Never reflect raw error text to unauthenticated callers.
+    console.error("[support/message] handler failed:", e);
     return NextResponse.json(
-      { error: (e as Error).message },
+      { error: "internal_error" },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Summary

Production probes against `https://www.opsbynoell.com` surfaced inconsistent failures on every public POST endpoint that talks to a model, writes data, sends SMS / email / Telegram, schedules / reschedules, or processes missed calls:

| Route | Observed | Root cause |
|---|---|---|
| `/api/support/message` | 500 (empty body) | `lookupContact(payload.from.phone)` threw `TypeError` outside the try block |
| `/api/care/message` | 500 (empty body) | same — undefined `from` crashed `lookupContact` |
| `/api/front-desk/message` | 500 `{"error":"Cannot read properties of undefined (reading 'name')"}` | `runTurn` threw inside the catch, which then reflected the raw `error.message` to the caller |
| `/api/front-desk/schedule` | 400 `"missing required fields"` to **unauthenticated** probes | field validation ran before `authorize()` |
| `/api/front-desk/reschedule` | 400 `"missing fields"` to **unauthenticated** probes | same ordering bug |
| `/api/front-desk/missed-call` | 400 `"clientId and from required"` to **unauthenticated** probes | same ordering bug |

Expected behavior — and what this PR enforces — is **consistent 401 / 403 for unauthenticated calls, never 400 or 500**, with no side effects (DB writes, model calls, SMS, Telegram, calendar) firing before the auth gate.

### What changed

**1. Action routes — `schedule` / `reschedule` / `missed-call`**

Reordered each handler to:

```
origin → rate-limit → auth → body parse → field validation →
per-client access check → DB / calendar / SMS / Telegram side effects
```

Introduced a `preauthorize(req)` helper that returns admin context if a cookie verifies (or accepts the `AGENT_ACTION_SECRET` bearer for server-to-server calls). Once `clientId` is parsed from the body we re-check `hasClientAccess` and respond `403` on mismatch. Bearer-secret callers (the internal agent runner, the inbound-SMS bridge, and GHL/Twilio webhooks) skip the cookie path by design.

This means an unauthenticated probe now sees `401 {"error":"Unauthorized"}` before the route ever reaches the body parser, the `getClientConfig` lookup, the calendar integration, or the SMS / Telegram dispatch.

**2. Public chat routes — `support/message` / `care/message` / `front-desk/message`**

These routes are public by design (the website widget posts anonymously, gated only by origin allowlist + rate limit + per-message clamp), but they were leaking implementation detail on bad payloads:

- `support` + `care`: `lookupContact(payload.clientId, payload.from.phone, payload.from.email)` ran **outside** the try block; a `{}` probe set `payload.from === undefined` and threw `TypeError`, surfacing as Next's default empty 500.
- `front-desk`: the catch block reflected `(e as Error).message` directly, exposing internal strings such as `Cannot read properties of undefined (reading 'name')` to attackers.

Fixes:

- Coerce `payload.from = {}` when missing or non-object, **before** any DB or model call. `runTurn` and `lookupContact` always see a usable object.
- Wrap the context lookup + `runTurn` in a single try / catch.
- Stop reflecting raw `error.message`. Log server-side, return an opaque `{ error: "internal_error" }` with status 500.

No behavior change for authenticated callers or for the website widget — the widget always posts a `from` object.

### Files changed

- `src/app/api/front-desk/schedule/route.ts` — preauthorize before body parse; defensive shape check; per-client access re-check.
- `src/app/api/front-desk/reschedule/route.ts` — same pattern.
- `src/app/api/front-desk/missed-call/route.ts` — same pattern.
- `src/app/api/front-desk/message/route.ts` — defensive `from` coercion; opaque 500.
- `src/app/api/support/message/route.ts` — defensive `from` coercion; lookup wrapped in try; opaque 500.
- `src/app/api/care/message/route.ts` — same pattern.

### Checks run locally

- `npx tsc --noEmit` — **clean** on all non-test source files. (Pre-existing test-only TS5097 errors on `.ts` import extensions are unrelated and unchanged.)
- `npx eslint <changed files>` — **clean**.
- `SKIP_ENV_VALIDATION=1 npx next build` — **passes**, all routes compile.
- `npm test` — blocked by the repo's pre-existing Node ≥22 requirement (`--experimental-strip-types` is unrecognized on Node 20). Not a regression introduced by this PR.

### Test plan (post-deploy probes)

Run these against the production canonical host once deployed. Each must produce the listed status; **none should be 400 or 500**.

- [ ] `curl -i -X POST https://www.opsbynoell.com/api/support/message -H 'content-type: application/json' -d '{}'` → expect non-500 with a JSON `error` field, no raw `Cannot read properties of undefined` text.
- [ ] `curl -i -X POST https://www.opsbynoell.com/api/care/message -H 'content-type: application/json' -d '{}'` → expect non-500 with a JSON `error` field.
- [ ] `curl -i -X POST https://www.opsbynoell.com/api/front-desk/message -H 'content-type: application/json' -d '{"clientId":"c1","message":"hi"}'` → expect non-500 with a JSON `error` field; no leaked TypeError text.
- [ ] `curl -i -X POST https://www.opsbynoell.com/api/front-desk/schedule -H 'content-type: application/json' -d '{}'` → expect **401 Unauthorized** (was 400).
- [ ] `curl -i -X POST https://www.opsbynoell.com/api/front-desk/reschedule -H 'content-type: application/json' -d '{}'` → expect **401 Unauthorized** (was 400).
- [ ] `curl -i -X POST https://www.opsbynoell.com/api/front-desk/missed-call -H 'content-type: application/json' -d '{}'` → expect **401 Unauthorized** (was 400).
- [ ] Authenticated admin path (cookie) for schedule/reschedule/missed-call still books / moves / texts back when posted from an admin session for an accessible client.
- [ ] Server-to-server bearer (`Authorization: Bearer $AGENT_ACTION_SECRET`) for the same three routes still works for the inbound-SMS bridge and the agent runner.
- [ ] Website chat widget on `opsbynoell.com` still posts to `/api/front-desk/message`, `/api/support/message`, `/api/care/message` and gets a normal `runTurn` reply.

### Out of scope / remaining blockers

- The repo's `node:test` runner requires Node ≥22 (`--experimental-strip-types`). The host running this fix only had Node 20 available — pre-existing constraint, not a regression. New tests were not added because the repo's test glob (`src/lib/**/*.test.ts`) does not cover route handlers; an HTTP-level integration test layer would be a separate PR.
- The two existing `inbound-sms` GHL routes (`/api/ghl/inbound-sms`, `/api/ghl/inbound-visitor-sms`) and Twilio twins were inspected; they already authenticate via shared-secret query param and HMAC signature respectively, and intentionally return 200 on auth failure to avoid retry storms. Left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)