### PR TITLE
fix(api): public message routes 400 on malformed payloads, not 500

### DIFF
--- a/src/app/api/care/message/route.ts
+++ b/src/app/api/care/message/route.ts
@@ -18,15 +18,15 @@ import {
   queryKnowledgeBase,
 } from "@/lib/agents/knowledge-base";
 import {
-  clampPublicMessage,
   clientIdentity,
+  invalidRequestResponse,
   isOriginAllowed,
   rateLimit,
   rateLimitResponse,
+  validatePublicMessagePayload,
 } from "@/lib/agents/request-security";
 import { runTurn } from "@/lib/agents/runner";
 import { sbSelect } from "@/lib/agents/supabase";
-import type { AgentMessagePayload } from "@/lib/agents/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -82,32 +82,20 @@ export async function POST(req: NextRequest): Promise<Response> {
   );
   if (!rl.ok) return rateLimitResponse(rl.retryAfterMs);
 
-  let payload: AgentMessagePayload;
+  let raw: unknown;
   try {
-    payload = (await req.json()) as AgentMessagePayload;
+    raw = await req.json();
   } catch {
-    return NextResponse.json({ error: "invalid json" }, { status: 400 });
+    return invalidRequestResponse();
   }
-  // Defensive payload shape — a probe with `{}` previously crashed in
-  // `lookupContact` reading `payload.from.phone` and surfaced as an
-  // empty 500. Coerce `from` to a usable object before any downstream
-  // DB / model / provider call.
-  if (!payload || typeof payload !== "object") {
-    return NextResponse.json({ error: "invalid payload" }, { status: 400 });
-  }
-  if (!payload.clientId || !payload.message) {
-    return NextResponse.json(
-      { error: "clientId and message are required" },
-      { status: 400 }
-    );
-  }
-  if (!payload.from || typeof payload.from !== "object") {
-    payload.from = {};
-  }
-  payload.message = clampPublicMessage(payload.message);
-  if (!payload.message) {
-    return NextResponse.json({ error: "empty message" }, { status: 400 });
-  }
+  // Single fail-closed gate. Anything malformed (missing clientId,
+  // missing/empty message, bogus channel, bad `from` shape) returns an
+  // opaque 400 BEFORE contact lookup, knowledge-base query, runTurn, DB
+  // writes, model calls, or fanout. Legitimate widget POSTs are
+  // unaffected.
+  const validated = validatePublicMessagePayload(raw);
+  if (!validated.ok) return invalidRequestResponse();
+  const payload = validated.payload;
 
   try {
     const contact = await lookupContact(

--- a/src/app/api/front-desk/message/route.ts
+++ b/src/app/api/front-desk/message/route.ts
@@ -14,13 +14,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { runTurn } from "@/lib/agents/runner";
 import {
-  clampPublicMessage,
   clientIdentity,
+  invalidRequestResponse,
   isOriginAllowed,
   rateLimit,
   rateLimitResponse,
+  validatePublicMessagePayload,
 } from "@/lib/agents/request-security";
-import type { AgentMessagePayload } from "@/lib/agents/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -42,32 +42,19 @@ export async function POST(req: NextRequest): Promise<Response> {
   );
   if (!rl.ok) return rateLimitResponse(rl.retryAfterMs);
 
-  let payload: AgentMessagePayload;
+  let raw: unknown;
   try {
-    payload = (await req.json()) as AgentMessagePayload;
+    raw = await req.json();
   } catch {
-    return NextResponse.json({ error: "invalid json" }, { status: 400 });
+    return invalidRequestResponse();
   }
-  // Defensive: a probe with `{}` or a bad shape must not blow up the
-  // route inside runTurn (which leaked `Cannot read properties of
-  // undefined (reading 'name')` to unauthenticated probes). Coerce
-  // `from` to an object before any downstream code reads it.
-  if (!payload || typeof payload !== "object") {
-    return NextResponse.json({ error: "invalid payload" }, { status: 400 });
-  }
-  if (!payload.clientId || !payload.message) {
-    return NextResponse.json(
-      { error: "clientId and message are required" },
-      { status: 400 }
-    );
-  }
-  if (!payload.from || typeof payload.from !== "object") {
-    payload.from = {};
-  }
-  payload.message = clampPublicMessage(payload.message);
-  if (!payload.message) {
-    return NextResponse.json({ error: "empty message" }, { status: 400 });
-  }
+  // Single fail-closed gate. Anything malformed (missing clientId,
+  // missing/empty message, bogus channel, bad `from` shape) returns an
+  // opaque 400 BEFORE we touch the DB, the model, or fanout — so probes
+  // cannot fingerprint fields and cannot drive a 500.
+  const validated = validatePublicMessagePayload(raw);
+  if (!validated.ok) return invalidRequestResponse();
+  const payload = validated.payload;
 
   try {
     const result = await runTurn({

--- a/src/app/api/support/message/route.ts
+++ b/src/app/api/support/message/route.ts
@@ -19,15 +19,15 @@ import {
   queryKnowledgeBase,
 } from "@/lib/agents/knowledge-base";
 import {
-  clampPublicMessage,
   clientIdentity,
+  invalidRequestResponse,
   isOriginAllowed,
   rateLimit,
   rateLimitResponse,
+  validatePublicMessagePayload,
 } from "@/lib/agents/request-security";
 import { runTurn } from "@/lib/agents/runner";
 import { sbSelect } from "@/lib/agents/supabase";
-import type { AgentMessagePayload } from "@/lib/agents/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -83,32 +83,20 @@ export async function POST(req: NextRequest): Promise<Response> {
   );
   if (!rl.ok) return rateLimitResponse(rl.retryAfterMs);
 
-  let payload: AgentMessagePayload;
+  let raw: unknown;
   try {
-    payload = (await req.json()) as AgentMessagePayload;
+    raw = await req.json();
   } catch {
-    return NextResponse.json({ error: "invalid json" }, { status: 400 });
+    return invalidRequestResponse();
   }
-  // Defensive payload shape — a probe with `{}` previously crashed in
-  // `lookupContact` reading `payload.from.phone` and surfaced as an
-  // empty 500. Coerce `from` to a usable object before any downstream
-  // DB / model / provider call.
-  if (!payload || typeof payload !== "object") {
-    return NextResponse.json({ error: "invalid payload" }, { status: 400 });
-  }
-  if (!payload.clientId || !payload.message) {
-    return NextResponse.json(
-      { error: "clientId and message are required" },
-      { status: 400 }
-    );
-  }
-  if (!payload.from || typeof payload.from !== "object") {
-    payload.from = {};
-  }
-  payload.message = clampPublicMessage(payload.message);
-  if (!payload.message) {
-    return NextResponse.json({ error: "empty message" }, { status: 400 });
-  }
+  // Single fail-closed gate. Anything malformed (missing clientId,
+  // missing/empty message, bogus channel, bad `from` shape) returns an
+  // opaque 400 BEFORE contact lookup, knowledge-base query, runTurn, DB
+  // writes, model calls, or fanout. Legitimate widget POSTs are
+  // unaffected.
+  const validated = validatePublicMessagePayload(raw);
+  if (!validated.ok) return invalidRequestResponse();
+  const payload = validated.payload;
 
   try {
     const contact = await lookupContact(

--- a/src/lib/agents/request-security.test.ts
+++ b/src/lib/agents/request-security.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for `validatePublicMessagePayload` — the fail-closed gate that
+ * guards the three public agent message routes
+ * (/api/{support,care,front-desk}/message) against malformed POSTs.
+ *
+ * Production probes hitting these routes with `{clientId, message}`
+ * (no channel, no from) used to drive a 500 inside runTurn / contact
+ * lookup. The validator must reject anything malformed BEFORE any
+ * downstream side-effect, while leaving a legitimate widget payload
+ * untouched.
+ */
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import {
+  validatePublicMessagePayload,
+  PUBLIC_MESSAGE_MAX_CHARS,
+} from "./request-security.ts";
+
+// ── happy path: widget shape ────────────────────────────────────────────────
+
+test("accepts the canonical widget payload (chat channel, empty from)", () => {
+  const r = validatePublicMessagePayload({
+    clientId: "opsbynoell",
+    sessionId: "sess_123",
+    agent: "frontDesk",
+    channel: "chat",
+    from: {},
+    message: "Hello",
+  });
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.payload.clientId, "opsbynoell");
+  assert.equal(r.payload.channel, "chat");
+  assert.equal(r.payload.message, "Hello");
+  assert.deepEqual(r.payload.from, {});
+  assert.equal(r.payload.sessionId, "sess_123");
+});
+
+test("trims and clamps message to PUBLIC_MESSAGE_MAX_CHARS", () => {
+  const long = "a".repeat(PUBLIC_MESSAGE_MAX_CHARS + 500);
+  const r = validatePublicMessagePayload({
+    clientId: "opsbynoell",
+    channel: "chat",
+    from: {},
+    message: `   ${long}   `,
+  });
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.payload.message.length, PUBLIC_MESSAGE_MAX_CHARS);
+});
+
+test("preserves valid sms / voice channels", () => {
+  for (const channel of ["sms", "voice"] as const) {
+    const r = validatePublicMessagePayload({
+      clientId: "opsbynoell",
+      channel,
+      from: {},
+      message: "hi",
+    });
+    assert.equal(r.ok, true, `channel=${channel}`);
+    if (!r.ok) return;
+    assert.equal(r.payload.channel, channel);
+  }
+});
+
+test("preserves known string fields on `from`", () => {
+  const r = validatePublicMessagePayload({
+    clientId: "opsbynoell",
+    channel: "chat",
+    message: "hi",
+    from: { name: "Sam", phone: "+19495550142", email: "s@x.co", ip: "1.2.3.4" },
+  });
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.payload.from.name, "Sam");
+  assert.equal(r.payload.from.phone, "+19495550142");
+  assert.equal(r.payload.from.email, "s@x.co");
+  assert.equal(r.payload.from.ip, "1.2.3.4");
+});
+
+// ── reject: bad payload shapes ──────────────────────────────────────────────
+
+test("rejects null / non-object payloads", () => {
+  for (const v of [null, undefined, "foo", 42, true]) {
+    const r = validatePublicMessagePayload(v);
+    assert.equal(r.ok, false, `value=${JSON.stringify(v)}`);
+  }
+});
+
+test("rejects missing clientId", () => {
+  const r = validatePublicMessagePayload({
+    channel: "chat",
+    from: {},
+    message: "hi",
+  });
+  assert.equal(r.ok, false);
+});
+
+test("rejects clientId with disallowed characters (path/url injection guard)", () => {
+  for (const clientId of ["../etc/passwd", "ops by noell", "ops/byn", "ops?q=1", ""]) {
+    const r = validatePublicMessagePayload({
+      clientId,
+      channel: "chat",
+      from: {},
+      message: "hi",
+    });
+    assert.equal(r.ok, false, `clientId=${clientId}`);
+  }
+});
+
+test("rejects clientId longer than 64 chars", () => {
+  const r = validatePublicMessagePayload({
+    clientId: "a".repeat(65),
+    channel: "chat",
+    from: {},
+    message: "hi",
+  });
+  assert.equal(r.ok, false);
+});
+
+test("rejects missing / non-string / empty / whitespace-only message", () => {
+  for (const message of [undefined, null, 42, "", "   ", "\t\n  "]) {
+    const r = validatePublicMessagePayload({
+      clientId: "opsbynoell",
+      channel: "chat",
+      from: {},
+      message,
+    });
+    assert.equal(r.ok, false, `message=${JSON.stringify(message)}`);
+  }
+});
+
+test("rejects unknown / missing / non-string channel values", () => {
+  for (const channel of [undefined, null, "telegram", "", 1, true, []]) {
+    const r = validatePublicMessagePayload({
+      clientId: "opsbynoell",
+      channel,
+      from: {},
+      message: "hi",
+    });
+    assert.equal(r.ok, false, `channel=${JSON.stringify(channel)}`);
+  }
+});
+
+test("rejects missing `from`", () => {
+  const r = validatePublicMessagePayload({
+    clientId: "opsbynoell",
+    channel: "chat",
+    message: "hi",
+  });
+  assert.equal(r.ok, false);
+});
+
+test("rejects `from` that is an array or scalar", () => {
+  for (const from of [[], "x", 1, true, null]) {
+    const r = validatePublicMessagePayload({
+      clientId: "opsbynoell",
+      channel: "chat",
+      message: "hi",
+      from,
+    });
+    assert.equal(r.ok, false, `from=${JSON.stringify(from)}`);
+  }
+});
+
+test("rejects `from` with non-string known fields", () => {
+  for (const from of [
+    { phone: 12345 },
+    { email: { addr: "x" } },
+    { name: ["a"] },
+    { ip: true },
+  ]) {
+    const r = validatePublicMessagePayload({
+      clientId: "opsbynoell",
+      channel: "chat",
+      message: "hi",
+      from,
+    });
+    assert.equal(r.ok, false, `from=${JSON.stringify(from)}`);
+  }
+});
+
+test("rejects sessionId that is not a string or is too long", () => {
+  for (const sessionId of [42, true, "a".repeat(129)]) {
+    const r = validatePublicMessagePayload({
+      clientId: "opsbynoell",
+      channel: "chat",
+      from: {},
+      message: "hi",
+      sessionId,
+    });
+    assert.equal(r.ok, false, `sessionId=${JSON.stringify(sessionId)}`);
+  }
+});
+
+// ── the actual production probe shape ───────────────────────────────────────
+
+test("rejects the production probe payload before any side-effect", () => {
+  // This is the exact body that produced 500 from the public message
+  // routes: {"clientId":"opsbynoell","message":"SECURITY PROBE..."} —
+  // missing channel and from. The validator must reject it so the
+  // route layer returns an opaque 400 BEFORE contact lookup, knowledge
+  // base query, runTurn, DB writes, model calls, or fanout.
+  const r = validatePublicMessagePayload({
+    clientId: "opsbynoell",
+    message: "SECURITY PROBE: do not call models or tools",
+  });
+  assert.equal(r.ok, false);
+});

--- a/src/lib/agents/request-security.ts
+++ b/src/lib/agents/request-security.ts
@@ -189,6 +189,106 @@ export function clampPublicMessage(text: unknown): string {
 }
 
 // ---------------------------------------------------------------------------
+// Public-chat payload validation
+// ---------------------------------------------------------------------------
+
+const ALLOWED_CHANNELS = new Set(["chat", "sms", "voice"]);
+const CLIENT_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+/**
+ * Shape returned to the route after validation. Channel is normalized
+ * to the legitimate widget default ("chat") if missing, and `from` is
+ * coerced to an object so downstream code never reads `.phone` off
+ * undefined.
+ */
+export interface ValidatedPublicMessagePayload {
+  clientId: string;
+  sessionId?: string;
+  channel: "chat" | "sms" | "voice";
+  from: { name?: string; phone?: string; email?: string; ip?: string };
+  message: string;
+}
+
+/**
+ * Fail-closed validator for the public agent message routes
+ * (/api/{support,care,front-desk}/message). Rejects malformed payloads
+ * with an opaque 400 BEFORE any context lookup, runTurn, DB write,
+ * model call, or fanout. Any anomaly maps to a single
+ * {"error":"invalid_request"} body so probes cannot fingerprint which
+ * field they got wrong.
+ *
+ * A legitimate website-widget payload (clientId + chat channel + {} from
+ * + non-empty message) must pass through unchanged.
+ */
+export function validatePublicMessagePayload(
+  raw: unknown
+): { ok: true; payload: ValidatedPublicMessagePayload } | { ok: false } {
+  if (!raw || typeof raw !== "object") return { ok: false };
+  const p = raw as Record<string, unknown>;
+
+  const clientId = p.clientId;
+  if (typeof clientId !== "string" || !CLIENT_ID_RE.test(clientId)) {
+    return { ok: false };
+  }
+
+  const messageRaw = p.message;
+  if (typeof messageRaw !== "string") return { ok: false };
+  const message = clampPublicMessage(messageRaw);
+  if (!message) return { ok: false };
+
+  // Channel is required and must be one of the known values. The
+  // legitimate website widget always sends "chat"; SMS/voice come in
+  // through internal bridges that also set this explicitly. Refusing
+  // missing/unknown channel here means an anonymous probe with just
+  // {clientId, message} fails closed before any downstream call.
+  if (typeof p.channel !== "string" || !ALLOWED_CHANNELS.has(p.channel)) {
+    return { ok: false };
+  }
+  const channel = p.channel as ValidatedPublicMessagePayload["channel"];
+
+  // `from` is required (the widget always sends at least `{}`). It must
+  // be a plain object — no arrays, no scalars — and each known field,
+  // if present, must be a string.
+  if (
+    p.from === undefined ||
+    p.from === null ||
+    typeof p.from !== "object" ||
+    Array.isArray(p.from)
+  ) {
+    return { ok: false };
+  }
+  const from: ValidatedPublicMessagePayload["from"] = {};
+  const f = p.from as Record<string, unknown>;
+  for (const k of ["name", "phone", "email", "ip"] as const) {
+    const v = f[k];
+    if (v === undefined) continue;
+    if (typeof v !== "string") return { ok: false };
+    from[k] = v;
+  }
+
+  let sessionId: string | undefined;
+  if (p.sessionId !== undefined && p.sessionId !== null) {
+    if (typeof p.sessionId !== "string" || p.sessionId.length > 128) {
+      return { ok: false };
+    }
+    sessionId = p.sessionId;
+  }
+
+  return {
+    ok: true,
+    payload: { clientId, sessionId, channel, from, message },
+  };
+}
+
+/** Standard opaque 400 used by the public message routes. */
+export function invalidRequestResponse(): Response {
+  return new Response(JSON.stringify({ error: "invalid_request" }), {
+    status: 400,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Response helpers
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Follow-up to #56. After PR #56 merged, prod probes confirmed all
authenticated/action routes correctly return 401 — but anonymous POSTs
to the three public widget routes still produced HTTP 500
`{"error":"internal_error"}`:

- `/api/support/message`
- `/api/care/message`
- `/api/front-desk/message`

with body `{"clientId":"opsbynoell","message":"SECURITY PROBE..."}`
(no `channel`, no `from`). Supabase showed no DB writes, but the 500
made the failure-lab noisy and was a fingerprintable signal.

Root cause: each route had a partial defensive block (coerced `from` to
`{}`, checked `clientId`/`message` truthiness) and then handed the
partial payload to `runTurn`, where missing `channel` / unknown
`clientId` (`getClientConfig`) bubbled up as an opaque 500.

## What changed

- Added `validatePublicMessagePayload(raw)` and `invalidRequestResponse()`
  helpers in `src/lib/agents/request-security.ts`.
- Validator is a single fail-closed gate run BEFORE any context
  lookup, `runTurn`, DB write, model call, or fanout.
- Required fields:
  - `clientId` — string, `[A-Za-z0-9_-]{1,64}`
  - `channel` — `"chat" | "sms" | "voice"` (the widget always sends `"chat"`)
  - `from` — plain object; known fields (`name|phone|email|ip`) must be strings if present
  - `message` — non-empty after `clampPublicMessage` (4000-char ceiling, trimmed)
  - `sessionId` — optional string ≤ 128 chars
- Any anomaly → opaque `400 {"error":"invalid_request"}` (no field-by-field error reflection, so probes can't fingerprint).
- All three message routes refactored to use the shared validator. Origin allowlist + rate limit still run first; legitimate widget shape is unaffected.

## Files

- `src/lib/agents/request-security.ts` — new validator + response helper
- `src/lib/agents/request-security.test.ts` — 15 cases covering the
  widget happy path, the production probe shape, and every rejection
  branch
- `src/app/api/support/message/route.ts`
- `src/app/api/care/message/route.ts`
- `src/app/api/front-desk/message/route.ts`

## Test plan

- [x] `npx tsx --test src/lib/agents/request-security.test.ts` — 15/15 pass locally
- [x] `npx tsc --noEmit` — clean (only pre-existing `.ts`-import-extension noise from existing test files)
- [x] `npm run lint` — no new errors/warnings in changed files
- [x] `npm run build` — Next.js production build succeeds
- [ ] Post-deploy: re-run the three malformed probes against prod; expect `400 {"error":"invalid_request"}`
- [ ] Post-deploy: confirm widget on `https://www.opsbynoell.com` still receives normal replies (legitimate `{clientId, sessionId, agent, channel: "chat", from: {}, message}` shape)
- [ ] Post-deploy: confirm Supabase still shows no rows written from the malformed probes

## Not deployed

Per request: PR opened as draft. **Do not merge / do not deploy** until reviewer signs off.

---
🤖 *Generated by Computer*