### PR TITLE
Professional language pass + Santa naming + /what-you-get

### DIFF
--- a/MANUAL_STEPS.md
+++ b/MANUAL_STEPS.md
@@ -222,7 +222,7 @@ Variables: `{{1}}` = first name, `{{2}}` = Google review URL
 **Template name:** `healing_hands_reactivation`  
 **Body text:**
 ```
-Hi {{1}}, it's been a while and I'd love to see you back on my table. I have openings this week: {{2}} — Santa
+Hi {{1}}, it's been a while and I'd love to see you back in for an appointment. I have openings this week: {{2}} — Santa
 ```
 Variables: `{{1}}` = first name, `{{2}}` = booking URL
 

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -155,8 +155,9 @@ export default function BookPage() {
           </p>
           <p className="font-serif text-lg md:text-xl text-charcoal leading-snug">
             Currently keeping the front desk moving for Healing Hands by
-            Santa, a solo massage practice in Laguna Niguel. In fourteen days,
-            four missed calls turned into booked appointments and{" "}
+            Santa — a solo licensed therapeutic massage practice in Laguna
+            Niguel run by Santa, the owner. In fourteen days, four missed
+            calls turned into booked appointments and{" "}
             <span className="text-wine">nine hundred sixty dollars</span> in
             recovered revenue.
           </p>

--- a/src/app/case-studies/santa-e/page.tsx
+++ b/src/app/case-studies/santa-e/page.tsx
@@ -55,12 +55,13 @@ export default function CaseStudy() {
         meta="Orange County, CA · Solo massage practice · 14-day result"
       >
         <p>
-          Santa has run a solo massage practice in Orange County for almost a
-          decade. Most of her calendar is regulars, but her growth engine has
-          always been new-client intent from Google and word of mouth. Until
-          install, that intent lived and died on voicemail. Hands on a client,
-          phone ringing in the next room — by the time she could call back,
-          the caller had already booked somewhere else.
+          Santa, owner of Healing Hands by Santa, has run a solo licensed
+          massage practice in Orange County for almost a decade. Most of her
+          calendar is regulars, but her growth engine has always been
+          new-client intent from Google and word of mouth. Until install, that
+          intent lived and died on voicemail. In session with a client, phone
+          ringing in the next room — by the time she could call back, the
+          caller had already booked somewhere else.
         </p>
 
         <h2>The problem, in her words</h2>

--- a/src/app/predictive-customer-intelligence/page.tsx
+++ b/src/app/predictive-customer-intelligence/page.tsx
@@ -616,7 +616,7 @@ export default function PredictiveCustomerIntelligencePage() {
         eyebrow="Proof"
         headlineStart="The system that recovered $960 in 14 days for one massage therapist"
         headlineAccent="runs the same way for you."
-        body="Santa, a massage therapist in Laguna Niguel, went from digital patchwork to a system that watched her client patterns, caught her missed calls, and protected her calendar. Inside 14 days, the system had paid for itself."
+        body="Santa, owner of Healing Hands by Santa, a licensed massage therapist in Laguna Niguel, went from digital patchwork to a system that watched her client patterns, caught her missed calls, and protected her calendar. Inside 14 days, the system had paid for itself."
         ctaLabel="Book your free audit"
         sourcePage={SOURCE_PAGE}
         sourceSection="proof"

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -18,6 +18,7 @@ const entries: Entry[] = [
     priority: 0.9,
   },
   { path: "/pricing", changeFrequency: "weekly", priority: 0.9 },
+  { path: "/what-you-get", changeFrequency: "weekly", priority: 0.9 },
   { path: "/roi", changeFrequency: "monthly", priority: 0.7 },
   {
     path: "/resources/revenue-calculator",

--- a/src/app/verticals/massage/page.tsx
+++ b/src/app/verticals/massage/page.tsx
@@ -28,7 +28,7 @@ export const metadata = pageMetadata({
   path: "/verticals/massage",
   title: "AI Front Desk for Massage Therapy",
   description:
-    "Hands on a client while the phone rings. Ops by Noell catches missed calls, confirms appointments, and keeps your calendar full without making you feel like a salesperson on top of being a therapist.",
+    "In session with a client while the phone rings. Ops by Noell catches missed calls, confirms appointments, and keeps your calendar full without making you feel like a salesperson on top of being a therapist.",
 });
 
 const massageStats = [
@@ -60,10 +60,10 @@ type Concern = {
 const massageConcerns: Concern[] = [
   {
     icon: <IconPhoneOff size={22} />,
-    tag: "On the table",
-    title: "Hands on a client while the phone rings.",
+    tag: "In session with a client",
+    title: "In session with a client while the phone rings.",
     worry:
-      "You are in a session. The phone buzzes in the other room. You hear it. You cannot answer it. By the time your client is off the table and the sheets are changed, the caller has already Googled another therapist in your zip code.",
+      "You are in a session. The phone buzzes in the other room. You hear it. You cannot answer it. By the time the appointment ends and the room is reset, the caller has already Googled another therapist in your zip code.",
     answer:
       "The missed call triggers an on-brand text in under ten seconds. Your next two openings, a warm note in your voice, and a direct booking link. Most prospects book themselves before you are even back at the front.",
   },
@@ -167,7 +167,7 @@ const massageScreen = (
       <div className="flex items-start justify-between">
         <div>
           <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
-            Missed call, on the table
+            Missed call, with a client
           </p>
           <p className="text-sm text-charcoal font-medium mt-0.5">Santa E.</p>
           <p className="text-[11px] text-charcoal/70">Auto-text sent, 8s</p>
@@ -218,8 +218,8 @@ export default function MassageVerticalPage() {
       />
       <Hero
         eyebrow="Ops by Noell for Massage Therapy"
-        headlineLine1Start="Hands on"
-        headlineLine1Accent="a client."
+        headlineLine1Start="In session"
+        headlineLine1Accent="with a client."
         headlineLine2Start="Phone"
         headlineLine2Accent="ringing off the hook."
         body="A done-for-you AI front desk for solo and small-team massage practices. Missed calls caught in seconds, reminders that keep no-shows low, and quiet reactivation that fills slow weeks before they show up on the calendar."

--- a/src/app/what-you-get/page.tsx
+++ b/src/app/what-you-get/page.tsx
@@ -1,0 +1,439 @@
+import Link from "next/link";
+import {
+  IconPhoneCall,
+  IconRobot,
+  IconLayoutDashboard,
+  IconHandStop,
+  IconChecklist,
+  IconShieldLock,
+} from "@tabler/icons-react";
+import CTA from "@/components/cta";
+import { FAQ, type FaqItem } from "@/components/faq";
+import { Button } from "@/components/button";
+import { JsonLd } from "@/components/json-ld";
+import { pageMetadata } from "@/lib/seo";
+import {
+  breadcrumbSchema,
+  faqPageSchema,
+  servicePageSchema,
+} from "@/lib/schema";
+
+const PATH = "/what-you-get";
+
+export const metadata = pageMetadata({
+  path: PATH,
+  title: "What You Get — Ops by Noell",
+  description:
+    "What you actually get when you sign up for Ops by Noell: a business line that never misses a call, three AI agents working in the background, the dashboard that runs your front office, the tap-in feature, done-for-you setup, and compliance built in.",
+  ogTitle: "Stay focused on the client in front of you. We'll handle the phone.",
+  ogDescription:
+    "An AI front desk that answers your calls, books your appointments, and texts your customers — so you can be present with the client you're serving without losing the next booking.",
+});
+
+type GetItem = {
+  icon: React.ReactNode;
+  number: string;
+  title: string;
+  body: React.ReactNode;
+  callout?: React.ReactNode;
+};
+
+const items: GetItem[] = [
+  {
+    icon: <IconPhoneCall size={26} />,
+    number: "01",
+    title: "A business line that never misses a call",
+    body: (
+      <>
+        A dedicated phone number (or we port the one you have), answered the
+        moment it rings — by an AI trained on your business, your hours, your
+        services, your prices, and your booking rules. Calls get answered,
+        qualified, and either booked, transferred, or texted back. No
+        voicemail backlog.
+      </>
+    ),
+  },
+  {
+    icon: <IconRobot size={26} />,
+    number: "02",
+    title: "Three AI agents working in the background",
+    body: (
+      <ul className="mt-2 space-y-2 list-none pl-0">
+        <li className="flex gap-2">
+          <span className="text-wine font-semibold shrink-0">Front Desk</span>
+          <span className="text-charcoal/80">
+            picks up calls and books appointments
+          </span>
+        </li>
+        <li className="flex gap-2">
+          <span className="text-wine font-semibold shrink-0">Care</span>
+          <span className="text-charcoal/80">
+            sends reminders, follows up after visits, and recovers no-shows
+          </span>
+        </li>
+        <li className="flex gap-2">
+          <span className="text-wine font-semibold shrink-0">Support</span>
+          <span className="text-charcoal/80">
+            runs the live chat on your website and your text inbox
+          </span>
+        </li>
+      </ul>
+    ),
+  },
+  {
+    icon: <IconLayoutDashboard size={26} />,
+    number: "03",
+    title: "The dashboard that runs your front office",
+    body: (
+      <>
+        One login. Every call, every text, every chat — organized by customer,
+        searchable, with full transcripts. Watch it work in real time, or
+        check it once a day. Your call.
+      </>
+    ),
+  },
+  {
+    icon: <IconHandStop size={26} />,
+    number: "04",
+    title: "The “tap-in” feature",
+    body: (
+      <>
+        When a customer asks something only you can answer, your AI pauses and
+        texts you. You text back from your personal phone — your reply lands
+        inside that customer&apos;s conversation as if you typed it from a
+        desk. The AI stays out of the way until you&apos;re done.
+      </>
+    ),
+    callout: (
+      <div className="mt-5 rounded-[18px] border border-wine/15 bg-blush-light/70 p-5 md:p-6">
+        <p className="text-[10px] uppercase tracking-[0.22em] text-wine font-medium mb-2">
+          Example
+        </p>
+        <p className="text-sm md:text-base text-charcoal/85 leading-relaxed">
+          You&apos;re with a client. A new customer texts asking about
+          availability for a 90-minute appointment next Tuesday at 4 PM.
+          Between appointments, you reply &ldquo;Yes, that time is open —
+          here&apos;s the booking link.&rdquo; They book. Your current
+          client&apos;s appointment was never interrupted.
+        </p>
+      </div>
+    ),
+  },
+  {
+    icon: <IconChecklist size={26} />,
+    number: "05",
+    title: "Done-for-you setup",
+    body: (
+      <>
+        We do the work. Number, AI training, automations, dashboard,
+        deliverability. You get a login and a 10-minute walkthrough video.
+        You&apos;re live in a week.
+      </>
+    ),
+  },
+  {
+    icon: <IconShieldLock size={26} />,
+    number: "06",
+    title: "Compliance built in, not bolted on",
+    body: (
+      <>
+        Carrier-approved messaging (A2P 10DLC). Encrypted at rest and in
+        transit. Auditable trail of every interaction. Architected to stay
+        out of PCI scope so you don&apos;t inherit compliance burden from us.
+      </>
+    ),
+  },
+];
+
+type Differentiator = { title: string; body: string };
+
+const differentiators: Differentiator[] = [
+  {
+    title: "Not another inbox.",
+    body: "Other tools give you a place to see missed messages. We give you a system that answers them — and only pulls you in when it actually needs you.",
+  },
+  {
+    title: "Not a chatbot.",
+    body: "A real voice on the phone, real intelligence in the texts, trained on your specific business.",
+  },
+  {
+    title: "Not a DIY toolkit.",
+    body: "You don't configure anything. We build it, run it, and tune it.",
+  },
+];
+
+type PricingCard = {
+  name: string;
+  body: string;
+  bestFor: string;
+  highlighted?: boolean;
+};
+
+const pricingCards: PricingCard[] = [
+  {
+    name: "Starter",
+    body: "Dedicated line, NOELL Front Desk, dashboard, 500 conversations/mo.",
+    bestFor: "Best for solo operators.",
+  },
+  {
+    name: "Growth",
+    body: "Everything in Starter + NOELL Care, website chat widget, no-show recovery.",
+    bestFor: "Best for 1–3 person teams.",
+    highlighted: true,
+  },
+  {
+    name: "Pro",
+    body: "Everything in Growth + advanced analytics, custom agent training, priority support.",
+    bestFor: "Best for 4+ teams or multi-location.",
+  },
+];
+
+const faqs: FaqItem[] = [
+  {
+    id: "wyg-tech-savvy",
+    question: "Do I need to be tech-savvy?",
+    answer:
+      "No. We set everything up. You get a login and a video.",
+  },
+  {
+    id: "wyg-customers-know",
+    question: "Will my customers know it's AI?",
+    answer:
+      "Only if you want them to. We tune the voice and tone to match your brand.",
+  },
+  {
+    id: "wyg-take-over",
+    question: "What happens when I take over a conversation?",
+    answer:
+      "The AI immediately stops responding in that thread. When you wrap up, it picks back up only if you tell it to.",
+  },
+  {
+    id: "wyg-keep-number",
+    question: "Can I keep my existing number?",
+    answer: "Yes. We port it.",
+  },
+  {
+    id: "wyg-after-hours",
+    question: "What about texts after hours?",
+    answer:
+      "AI handles them. You wake up to a clean inbox of qualified bookings, not a backlog.",
+  },
+];
+
+export default function WhatYouGetPage() {
+  return (
+    <div id="main-content">
+      <JsonLd
+        data={[
+          servicePageSchema({
+            name: "Ops by Noell — AI front desk for service businesses",
+            description:
+              "Done-for-you AI front desk. Dedicated phone line, three AI agents (Front Desk, Care, Support), unified dashboard, tap-in human-handoff, A2P 10DLC compliance.",
+            path: PATH,
+          }),
+          faqPageSchema(faqs),
+          breadcrumbSchema([
+            { name: "Home", path: "/" },
+            { name: "What You Get", path: PATH },
+          ]),
+        ]}
+        id="what-you-get"
+      />
+
+      {/* HERO */}
+      <section className="relative flex max-w-7xl rounded-b-3xl my-2 md:my-8 mx-auto flex-col items-center justify-center pt-24 md:pt-28 pb-12 md:pb-16 overflow-hidden px-4 md:px-8 bg-gradient-to-t from-[rgba(107,45,62,0.35)] via-[rgba(240,224,214,0.65)] to-[rgba(250,246,241,1)]">
+        <p className="relative z-20 text-[11px] uppercase tracking-[0.25em] text-muted-strong mb-5">
+          What you get
+        </p>
+        <h1 className="relative z-20 max-w-4xl text-center font-serif text-3xl md:text-5xl lg:text-6xl font-semibold tracking-tight text-charcoal leading-tight">
+          Stay focused on the client in front of you.{" "}
+          <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+            We&apos;ll handle the phone.
+          </span>
+        </h1>
+        <p className="relative z-20 mt-6 max-w-2xl text-center text-charcoal/80 text-base md:text-lg leading-relaxed">
+          Ops by Noell builds an AI front desk that answers your calls, books
+          your appointments, and texts your customers — so you can be present
+          with the client you&apos;re serving without losing the next booking.
+        </p>
+        <div className="relative z-20 mt-8">
+          <Button
+            href="/book"
+            variant="primary"
+            data-event="audit_cta_click"
+            data-source-page="what_you_get"
+            data-source-section="hero"
+          >
+            Book a 15-min walkthrough &rarr;
+          </Button>
+        </div>
+      </section>
+
+      {/* WHAT YOU ACTUALLY GET */}
+      <section className="w-full px-4 py-16 md:py-20">
+        <div className="max-w-5xl mx-auto">
+          <div className="text-center mb-12 max-w-3xl mx-auto">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+              The build
+            </p>
+            <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+              What you actually get{" "}
+              <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+                when you sign up.
+              </span>
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+            {items.map((item) => (
+              <article
+                key={item.number}
+                className="rounded-[22px] border border-warm-border bg-white p-7 md:p-8 shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
+              >
+                <div className="flex items-center gap-3 mb-4">
+                  <div className="w-11 h-11 rounded-lg bg-wine/10 text-wine flex items-center justify-center">
+                    {item.icon}
+                  </div>
+                  <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-charcoal/70">
+                    {item.number}
+                  </span>
+                </div>
+                <h3 className="font-serif text-xl md:text-2xl font-semibold text-charcoal mb-3 leading-snug">
+                  {item.title}
+                </h3>
+                <div className="text-sm md:text-base text-charcoal/80 leading-relaxed">
+                  {item.body}
+                </div>
+                {item.callout}
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* HOW WE'RE DIFFERENT */}
+      <section className="w-full px-4 py-16 md:py-20 bg-cream-dark/60">
+        <div className="max-w-5xl mx-auto">
+          <div className="text-center mb-12 max-w-3xl mx-auto">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+              The difference
+            </p>
+            <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+              How we&apos;re{" "}
+              <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+                different.
+              </span>
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+            {differentiators.map((d) => (
+              <div
+                key={d.title}
+                className="rounded-[22px] border border-warm-border bg-white p-7 md:p-8"
+              >
+                <h3 className="font-serif text-lg md:text-xl font-semibold text-charcoal mb-3 leading-snug">
+                  {d.title}
+                </h3>
+                <p className="text-sm md:text-base text-charcoal/75 leading-relaxed">
+                  {d.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* PRICING */}
+      <section className="w-full px-4 py-16 md:py-20">
+        <div className="max-w-5xl mx-auto">
+          <div className="text-center mb-12 max-w-3xl mx-auto">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+              Pricing
+            </p>
+            <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+              Three tiers.{" "}
+              <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+                Pick where you start.
+              </span>
+            </h2>
+            <p className="mt-4 text-charcoal/70 text-sm md:text-base">
+              See full pricing on the{" "}
+              <Link
+                href="/pricing"
+                className="underline underline-offset-4 decoration-wine/40 text-wine hover:text-wine-dark"
+              >
+                pricing page
+              </Link>
+              .
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+            {pricingCards.map((card) => (
+              <div
+                key={card.name}
+                className={
+                  card.highlighted
+                    ? "rounded-[22px] border-2 border-wine bg-white p-7 md:p-8 shadow-[0px_34px_21px_0px_rgba(106,44,62,0.10),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
+                    : "rounded-[22px] border border-warm-border bg-white p-7 md:p-8"
+                }
+              >
+                {card.highlighted && (
+                  <p className="text-[10px] uppercase tracking-[0.22em] text-wine font-medium mb-3">
+                    Most teams start here
+                  </p>
+                )}
+                <h3 className="font-serif text-2xl font-semibold text-charcoal mb-3">
+                  {card.name}
+                </h3>
+                <p className="text-sm text-charcoal/80 leading-relaxed mb-4">
+                  {card.body}
+                </p>
+                <p className="text-xs uppercase tracking-[0.18em] text-charcoal/60">
+                  {card.bestFor}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-10 flex flex-wrap justify-center gap-3">
+            <Button
+              href="/book"
+              variant="primary"
+              data-event="audit_cta_click"
+              data-source-page="what_you_get"
+              data-source-section="pricing"
+            >
+              Start with Starter &rarr;
+            </Button>
+            <Button href="/book" variant="secondary">
+              Talk to us first &rarr;
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <FAQ
+        eyebrow="Questions"
+        headlineStart="Common"
+        headlineAccent="questions."
+        body="Real questions from owners before they sign up."
+        faqs={faqs}
+      />
+
+      {/* CLOSING CTA */}
+      <CTA
+        eyebrow="The first step"
+        headlineStart="Stop missing the next booking"
+        headlineAccent="while you're with the current one."
+        body="A 15-minute walkthrough. We show you exactly what gets installed, what it costs, and how fast you'd be live."
+        primaryCta={{ label: "Book a 15-min walkthrough", href: "/book" }}
+        secondaryCta={{ label: "See full pricing", href: "/pricing" }}
+        trustLine="Done-for-you setup · Live in a week · No contracts"
+        sourcePage="what_you_get"
+      />
+    </div>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -38,6 +38,7 @@ export const Navbar = () => {
     { name: "About", link: "/about" },
     { name: "Verticals", link: "/verticals" },
     { name: "Agents", link: "/agents" },
+    { name: "What You Get", link: "/what-you-get" },
     { name: "Pricing", link: "/pricing" },
     { name: "Noell Support", link: "/noell-support", isAccent: true },
     { name: "Book", link: "/book" },

--- a/src/components/revenue-calculator.tsx
+++ b/src/components/revenue-calculator.tsx
@@ -333,8 +333,8 @@ export function RevenueCalculator() {
 
           {/* Assumption note */}
           <p className="text-[11px] text-charcoal/50 leading-relaxed mb-6">
-            Model assumes +21.5% booking conversion lift and 67.5% no-show reduction (midpoints of verified ranges). 
-            Santa Essenberge saw 75% no-show reduction and $960 recovered in 14 days. 
+            Model assumes +21.5% booking conversion lift and 67.5% no-show reduction (midpoints of verified ranges).
+            Healing Hands by Santa saw 75% no-show reduction and $960 recovered in 14 days.
             Your results depend on lead volume, timing, and existing workflow.
           </p>
 

--- a/src/components/santa-proof-block.tsx
+++ b/src/components/santa-proof-block.tsx
@@ -18,9 +18,10 @@ export function SantaProofBlock({ className }: SantaProofBlockProps) {
           Case study · Healing Hands by Santa · Laguna Niguel, CA
         </p>
         <p className="font-serif text-xl md:text-2xl text-charcoal leading-snug mb-5">
-          Santa Essenberge has been a licensed massage therapist for 25 years.
-          Before Ops by Noell, her phone went quiet every time she was with a client.
-          No one followed up. Clients booked elsewhere.
+          Santa, owner of Healing Hands by Santa, has been a licensed massage
+          therapist for 25 years. Before Ops by Noell, her phone went quiet
+          every time she was with a client. No one followed up. Clients
+          booked elsewhere.
         </p>
         <div className="grid grid-cols-3 gap-4 mb-6">
           <div className="text-center">

--- a/src/components/testimonials.tsx
+++ b/src/components/testimonials.tsx
@@ -13,7 +13,7 @@ export function Testimonials({
   eyebrow = "Proof",
   headlineStart = "A quiet week.",
   headlineAccent = "Then a full calendar.",
-  body = "Santa, a massage therapist in Laguna Niguel, went from digital patchwork to a system that followed up, reminded clients, and protected her calendar. Inside 14 days, the system had paid for itself.",
+  body = "Santa, owner of Healing Hands by Santa, a licensed massage therapist in Laguna Niguel, went from digital patchwork to a system that followed up, reminded clients, and protected her calendar. Inside 14 days, the system had paid for itself.",
   ctaLabel = "Book your free audit",
   ctaHref = "/book",
   sourcePage,

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -60,7 +60,8 @@ export type SourcePage =
   | "footer"
   | "global_chat"
   | "predictive-customer-intelligence"
-  | "revenue_calculator";
+  | "revenue_calculator"
+  | "what_you_get";
 
 /**
  * Semantic section where the click happened. Keep values kebab_case and


### PR DESCRIPTION
## Summary

Three coordinated changes:

1. **Professional language pass** — replace massage-context phrases that read as sensual/euphemistic with neutral, clinical wording (parallel register to PT, dental, chiropractic).
2. **Santa naming convention** — first mention is "Santa, owner of Healing Hands by Santa"; subsequent are "Santa E." or "Santa". Owner's last name removed from all non-frozen surfaces (alt text, metadata, OG, JSON-LD, prose, comments).
3. **New `/what-you-get` page** — cream + blush + #6A2C3E wine palette with Playfair Display headings and Inter body, hero + six-item product grid + tap-in callout + three-card differentiator + three-tier pricing teaser + FAQ + CTA. Wired into desktop nav, mobile nav, sitemap, and JSON-LD (Service + FAQPage + Breadcrumb).

A2P-frozen paths and PR #14 not touched. See "Frozen paths confirmation" below.

---

## 1. Replaced phrases (file:line)

| File | Line | Before | After |
|---|---|---|---|
| `src/app/verticals/massage/page.tsx` | 31 | `Hands on a client while the phone rings.` (meta description) | `In session with a client while the phone rings.` |
| `src/app/verticals/massage/page.tsx` | 63 | `tag: "On the table"` | `tag: "In session with a client"` |
| `src/app/verticals/massage/page.tsx` | 64 | `title: "Hands on a client while the phone rings."` | `title: "In session with a client while the phone rings."` |
| `src/app/verticals/massage/page.tsx` | 66 | `By the time your client is off the table and the sheets are changed,` | `By the time the appointment ends and the room is reset,` |
| `src/app/verticals/massage/page.tsx` | 170 | `Missed call, on the table` | `Missed call, with a client` |
| `src/app/verticals/massage/page.tsx` | 221–222 | hero `Hands on / a client.` | `In session / with a client.` |
| `src/app/case-studies/santa-e/page.tsx` | 58–63 | `Santa has run a solo massage practice in Orange County … Hands on a client, phone ringing in the next room` | `Santa, owner of Healing Hands by Santa, has run a solo licensed massage practice in Orange County … In session with a client, phone ringing in the next room` |
| `MANUAL_STEPS.md` | 225 (WhatsApp `healing_hands_reactivation` template body) | `back on my table` | `back in for an appointment` |

**Idiomatic "leaving on the table" preserved** at `src/app/predictive-customer-intelligence/page.tsx:198` — that's the standard revenue idiom, not a massage reference.

**Default vocabulary** (appointment, session, service, client, licensed) carries through every rewrite. Massage is framed as a licensed therapeutic practice throughout.

---

## 2. Santa's last name removed from these files

| File | Line | Change |
|---|---|---|
| `src/components/santa-proof-block.tsx` | 21 | `Santa Essenberge has been a licensed massage therapist for 25 years.` → `Santa, owner of Healing Hands by Santa, has been a licensed massage therapist for 25 years.` (also satisfies first-mention rule for the homepage, where this block is the first Santa reference) |
| `src/components/revenue-calculator.tsx` | 337 | `Santa Essenberge saw 75% no-show reduction and $960 recovered in 14 days.` → `Healing Hands by Santa saw 75% no-show reduction and $960 recovered in 14 days.` |

Verification: `grep -rnIE -i 'essenberge'` over `src/`, `MANUAL_STEPS.md`, and the docs (excluding `docs/template-source/`) returns zero matches.

No image filenames contained the last name. No JSON-LD Person/Organization schema referenced it. No HTML comments referenced it.

---

## 3. Santa naming-convention applied (first-mention coverage)

| File | First mention now reads |
|---|---|
| `src/components/santa-proof-block.tsx` | "Santa, owner of Healing Hands by Santa" (used as homepage first mention via `/`) |
| `src/components/testimonials.tsx` | Default body: "Santa, owner of Healing Hands by Santa, a licensed massage therapist in Laguna Niguel…" |
| `src/app/predictive-customer-intelligence/page.tsx` (line 619, body override) | "Santa, owner of Healing Hands by Santa, a licensed massage therapist in Laguna Niguel…" |
| `src/app/case-studies/santa-e/page.tsx` (line 58) | "Santa, owner of Healing Hands by Santa, has run a solo licensed massage practice in Orange County…" |
| `src/app/book/page.tsx` (line 157) | "Currently keeping the front desk moving for Healing Hands by Santa — a solo licensed therapeutic massage practice in Laguna Niguel run by Santa, the owner." |
| `src/components/revenue-calculator.tsx` | Refers to "Healing Hands by Santa" (brand) — first mention on its host page (`/resources/revenue-calculator`) is already "Healing Hands by Santa — Laguna Niguel, CA" in the page hero (unchanged). |

Subsequent mentions across the site use "Santa E." or "Santa" only.

The case-study slug `/case-studies/santa-e` is left as-is per scope (registered URL, Santa E. is an initial). The internal identifier `case: santa_e` in `src/components/proof-bar.tsx` is left as-is for the same reason.

---

## 4. /what-you-get page

- New file: `src/app/what-you-get/page.tsx`
- Brand styling: cream + blush + #6A2C3E wine palette, Playfair Display headings, Inter body, identical hero gradient pattern as `/pricing` and `/resources/revenue-calculator`.
- Sections (copy verbatim from brief):
  - HERO with `Stay focused on the client in front of you. We'll handle the phone.` headline + walkthrough CTA
  - "What you actually get when you sign up" — six-item card grid (business line, three AI agents, dashboard, tap-in feature with example callout, done-for-you setup, compliance built in)
  - "How we're different" — three differentiator cards
  - "Pricing" — three placeholder cards (Starter / Growth / Pro) per the brief copy, with CTAs to `/book` and `/pricing`
  - "FAQ" — five questions
  - Closing CTA
- JSON-LD: Service, FAQPage, BreadcrumbList. Validates against schema.org during `next build`.
- Nav entry added in **both** desktop and mobile navbar (`src/components/navbar.tsx`, single `navItems` array drives both).
- Sitemap entry added (`src/app/sitemap.ts`, `weekly` / `0.9`).
- Analytics: added `"what_you_get"` to the `SourcePage` union in `src/lib/analytics.ts` so the page's CTA tracking is type-safe.

Confirmed live: `next build` includes `/what-you-get` in the prerendered routes table (`○ /what-you-get`).

---

## 5. FLAGGED — REQUIRES REVIEW

**No findings inside A2P-frozen paths.** The frozen surface (`src/app/contact/**`, `src/app/sms-policy/**`, `src/app/privacy/**`, `src/app/terms/**`, `src/app/legal/**`, `src/components/noell-support-chat.tsx`, `src/components/agent-chat-widget.tsx`) was audited (greps for the flagged language patterns and for `essenberge`/`santa`/`healing hands`) and contains zero hits. See the prior audit report at `docs/legal-audit-2026-05-02.md` (PR #58) for the full read-only audit.

**Out-of-scope but worth flagging:**
- `MANUAL_STEPS.md:225` was edited (it's not a frozen path), but the corresponding **already-deployed Meta WhatsApp template** `healing_hands_reactivation` carries the old body text and will need to be re-submitted to Meta with the new body before the doc and the live template match. This is a manual carrier step, not a code change.

---

## 6. GHL / GoHighLevel / SaaS Pro mentions

Verified: no user-facing marketing copy mentions GHL, GoHighLevel, LeadConnector, or SaaS Pro on any non-frozen page or component.

The strings appear only in:
- A2P-frozen pages (`/privacy`, `/terms`) — vendor disclosure, **not edited** (frozen)
- Internal API route handlers and code comments (`src/app/api/ghl/**`, `src/app/api/twilio/**`, etc.) — not user-facing
- `MANUAL_STEPS.md` — developer setup doc

---

## 7. Build / lint / tests

- `npm run build` — passes; `/what-you-get` appears in the static routes table.
- `npx eslint <touched files>` — zero new errors. One pre-existing warning (`IconHandStop` unused import in `src/app/verticals/massage/page.tsx:3`) not introduced by this PR.
- `npm test` — 189/190 pass. The single failing test (`src/lib/agents/request-security.test.ts`) fails on `main` with the same `ERR_MODULE_NOT_FOUND` for `next/server` and is unrelated to this PR (test loader / ESM resolution issue).
- Schema: JSON-LD on `/what-you-get` validates as Service + FAQPage + BreadcrumbList during the build.
- Internal links: `/pricing`, `/book`, `/noell-support` — all existing routes.

---

## Test plan

- [ ] Visit `/what-you-get` on the preview deploy and walk the page top to bottom: hero CTA → 6-card grid → tap-in example → differentiator cards → 3-tier pricing teaser → FAQ → final CTA.
- [ ] Confirm "What You Get" is visible in the desktop nav and the mobile burger menu.
- [ ] Visit `/`, `/case-studies/santa-e`, `/book`, `/predictive-customer-intelligence`, `/resources/revenue-calculator`, `/verticals/massage` and confirm all Santa references read as "Santa, owner of Healing Hands by Santa" on first mention and "Santa" / "Santa E." after.
- [ ] Confirm no "Essenberge" anywhere via in-browser source view.
- [ ] Confirm `/contact`, `/sms-policy`, `/privacy`, `/terms`, `/legal/*`, the Noell Support chat widget, and the agent chat widget render exactly as before (untouched).


---
_Generated by [Claude Code](https://claude.ai/code/session_01F96ZZSJVU3k1xoYyNEqjd4)_