### PR TITLE
Launch fixes: SEO, PCI structured data, a11y, hero positioning

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -7,7 +7,11 @@ import {
 import { Button } from "@/components/button";
 import { JsonLd } from "@/components/json-ld";
 import { pageMetadata } from "@/lib/seo";
-import { breadcrumbSchema, personSchema } from "@/lib/schema";
+import {
+  breadcrumbSchema,
+  jamesPersonSchema,
+  personSchema,
+} from "@/lib/schema";
 
 const FAMILY_PHOTO = "/images/about-noell-family.jpg";
 const FAMILY_PHOTO_ALT =
@@ -17,7 +21,7 @@ export const metadata = pageMetadata({
   path: "/about",
   title: "About James & Nikki Noell",
   description:
-    "A family-run studio from Mission Viejo, CA, founded by James and Nikki Noell. We help service-business owners keep more of the money they are already making, with a managed AI front desk that works quietly in the background.",
+    "A family-run studio from Mission Viejo, CA, founded by James and Nikki Noell. We help service-business owners keep more of the revenue they are already earning.",
   image: FAMILY_PHOTO,
   imageAlt: FAMILY_PHOTO_ALT,
 });
@@ -43,6 +47,7 @@ export default function AboutPage() {
       <JsonLd
         data={[
           personSchema(),
+          jamesPersonSchema(),
           breadcrumbSchema([
             { name: "Home", path: "/" },
             { name: "About", path: "/about" },

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -22,7 +22,7 @@ export const metadata = pageMetadata({
   path: "/agents",
   title: "Noell Agents — AI Operations for Service Businesses",
   description:
-    "Three managed AI agents covering website chat, calls and scheduling, and existing-client support. Works alongside the booking tool you already use. Founding rate $197/mo, locked for 24 months.",
+    "Three managed AI agents covering website chat, calls and scheduling, and existing-client support. Works alongside your booking tool. Founding rate $197/mo.",
   ogTitle: "Noell Agents — AI Operations for Service Businesses",
   ogDescription:
     "Three managed AI agents covering website chat, calls and scheduling, and existing-client support. Works alongside any booking tool.",
@@ -224,7 +224,7 @@ export default function AgentsPage() {
                     </span>
                   </div>
                 </div>
-                <p className="text-[11px] uppercase tracking-[0.2em] text-wine/70 mb-1">
+                <p className="text-[11px] uppercase tracking-[0.2em] text-wine/85 mb-1">
                   {agent.eyebrow}
                 </p>
                 <h3 className="font-serif text-2xl font-semibold text-charcoal mb-3">

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -10,9 +10,9 @@ import { breadcrumbSchema, faqPageSchema } from "@/lib/schema";
 
 export const metadata = pageMetadata({
   path: "/book",
-  title: "Request a working call with Ops by Noell.",
+  title: "Book a Free Audit Call",
   description:
-    "Audits are scheduled personally right now. Tell us about your front desk. We reply within one business day with two or three times that work for a focused twenty-minute walkthrough.",
+    "Tell us about your front desk. We reply within one business day with two or three times that work for a focused twenty-minute walkthrough.",
 });
 
 const bookFaqs: FaqItem[] = [

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,11 @@ import { organizationSchema, websiteSchema } from "@/lib/schema";
 import { SITE_URL, SITE_NAME, DEFAULT_OG_IMAGE, absoluteUrl } from "@/lib/seo";
 import "./globals.css";
 
+// Block Vercel preview/branch deployments from being indexed. Production
+// (VERCEL_ENV=production or absent in local builds) stays indexable.
+const IS_NON_PROD_VERCEL_ENV =
+  !!process.env.VERCEL_ENV && process.env.VERCEL_ENV !== "production";
+
 const playfair = Playfair_Display({
   subsets: ["latin"],
   style: ["normal", "italic"],
@@ -66,17 +71,19 @@ export const metadata: Metadata = {
       "Done-for-you AI operations for service businesses. Catch missed calls, follow up instantly, keep the calendar full.",
     images: [absoluteUrl(DEFAULT_OG_IMAGE)],
   },
-  robots: {
-    index: true,
-    follow: true,
-    googleBot: {
-      index: true,
-      follow: true,
-      "max-image-preview": "large",
-      "max-snippet": -1,
-      "max-video-preview": -1,
-    },
-  },
+  robots: IS_NON_PROD_VERCEL_ENV
+    ? { index: false, follow: false, googleBot: { index: false, follow: false } }
+    : {
+        index: true,
+        follow: true,
+        googleBot: {
+          index: true,
+          follow: true,
+          "max-image-preview": "large",
+          "max-snippet": -1,
+          "max-video-preview": -1,
+        },
+      },
 };
 
 export default function RootLayout({

--- a/src/app/noell-front-desk/page.tsx
+++ b/src/app/noell-front-desk/page.tsx
@@ -128,7 +128,7 @@ const frontDeskScreen = (
 
     {/* Confirmation */}
     <div className="bg-white rounded-2xl p-3 mx-1 border border-warm-border/60 shadow-sm">
-      <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
+      <p className="text-[10px] uppercase tracking-widest text-wine/85 font-medium">
         Booking confirmed
       </p>
       <p className="text-sm text-charcoal font-medium mt-0.5">
@@ -139,7 +139,7 @@ const frontDeskScreen = (
 
     {/* Reminder */}
     <div className="bg-cream-dark rounded-2xl p-3 mx-1 mt-2 border border-warm-border/60 shadow-sm">
-      <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
+      <p className="text-[10px] uppercase tracking-widest text-wine/85 font-medium">
         Reminder sent
       </p>
       <p className="text-[11px] text-charcoal/80 mt-1 leading-snug">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,12 +21,13 @@ import {
 
 export const metadata = pageMetadata({
   path: "/",
+  absoluteTitle: true,
   title: "AI Front Desk for Local Service Businesses — Ops by Noell",
   description:
-    "Done-for-you AI front desk for massage therapists, dental practices, med spas, and local service businesses. Missed-call recovery, booking automation, client reactivation — installed in 14 days.",
-  ogTitle: "Ops by Noell — AI Front Desk That Keeps Your Business Moving",
+    "Predictive Customer Intelligence for service businesses. Catch missed revenue, prioritize high-intent leads, and recover bookings before demand cools. Live in 14 days.",
+  ogTitle: "Ops by Noell — Predictive Customer Intelligence for Service Businesses",
   ogDescription:
-    "$960 recovered in 14 days. 75% fewer no-shows. We build the front desk layer your business needs.",
+    "$960 recovered in 14 days. 75% fewer no-shows. The intelligence layer that catches revenue your booking software misses.",
 });
 
 const homepageFaqs: FaqItem[] = [
@@ -85,15 +86,15 @@ export default function Home() {
 
       {/* 1. Hero */}
       <Hero
-        headlineLine1Start="You’re losing clients between"
-        headlineLine1Accent="appointments."
-        headlineLine2Start="We build the systems"
-        headlineLine2Accent="that stop that."
+        headlineLine1Start="The revenue your booking software"
+        headlineLine1Accent="never sees."
+        headlineLine2Start="We catch it before it"
+        headlineLine2Accent="walks out the door."
         headlineLine2Smaller={false}
-        body="Every missed call, every no-show, every slow follow-up is revenue walking out the door. We build done-for-you AI front desks for massage therapists, dental practices, med spas, and local service businesses — installed in 14 days, running in the background while you do the work you’re actually good at."
-        footnote="Done for you. Built around the booking and practice management software your business already uses."
-        primaryCta={{ label: "See What You’re Losing", href: "/resources/revenue-calculator" }}
-        secondaryCta={{ label: "Book a Free Audit", href: "/book" }}
+        body="Predictive Customer Intelligence for service businesses. We score every client, lead, and rebooking four times a day, surface the ones about to slip, and recover them before they cool. Live in 14 days, running quietly around the booking system you already use."
+        footnote="Built for massage therapists, dental practices, med spas, salons, estheticians, and HVAC."
+        primaryCta={{ label: "Get Your Free Audit", href: "/book" }}
+        secondaryCta={{ label: "See what you’re losing", href: "/resources/revenue-calculator" }}
         showProofBar={false}
       />
 

--- a/src/app/predictive-customer-intelligence/page.tsx
+++ b/src/app/predictive-customer-intelligence/page.tsx
@@ -5,19 +5,27 @@ import { Testimonials } from "@/components/testimonials";
 import CTA from "@/components/cta";
 import { FAQ, type FaqItem } from "@/components/faq";
 import { Button } from "@/components/button";
+import { JsonLd } from "@/components/json-ld";
+import { pageMetadata } from "@/lib/seo";
+import {
+  breadcrumbSchema,
+  faqPageSchema,
+  servicePageSchema,
+} from "@/lib/schema";
 
-export const metadata = {
-  title: "Predictive Customer Intelligence | Ops by Noell",
+const PATH = "/predictive-customer-intelligence";
+
+export const metadata = pageMetadata({
+  path: PATH,
+  title: "Predictive Customer Intelligence for Service Businesses",
   description:
-    "We find the revenue your booking software is missing. Then we deploy the agents and the ads that recover it. Free 30-minute audit.",
-  openGraph: {
-    title: "Predictive Customer Intelligence | Ops by Noell",
-    description:
-      "The intelligence layer behind your agents, your system, and your ads.",
-    url: "https://www.opsbynoell.com/predictive-customer-intelligence",
-    type: "website" as const,
-  },
-};
+    "Score every client, lead, and rebooking 4x daily. Surface revenue your booking software misses, then recover it before it cools. Free 30-minute audit.",
+  ogTitle: "Predictive Customer Intelligence for Service Businesses",
+  ogDescription:
+    "Score every client, lead, and rebooking 4x daily. Recover revenue before it cools. Free audit.",
+  imageAlt:
+    "Predictive Customer Intelligence by Ops by Noell — score every client, lead, and rebooking before revenue walks out the door.",
+});
 
 const SOURCE_PAGE = "predictive-customer-intelligence" as const;
 
@@ -244,7 +252,7 @@ function CaseSummaryPanel() {
   return (
     <div className="mt-10 grid grid-cols-1 md:grid-cols-3 gap-4 max-w-3xl mx-auto">
       <div className="rounded-[18px] border border-warm-border bg-white p-5 text-center">
-        <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-wine/70 mb-2">
+        <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-wine/85 mb-2">
           Pattern caught
         </p>
         <p className="text-sm font-medium text-charcoal">Marina D.</p>
@@ -254,7 +262,7 @@ function CaseSummaryPanel() {
         <p className="text-[11px] text-charcoal/70 mt-1">ghost-risk score</p>
       </div>
       <div className="rounded-[18px] border border-warm-border bg-white p-5 text-center">
-        <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-wine/70 mb-2">
+        <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-wine/85 mb-2">
           Reactivation queued
         </p>
         <p className="text-sm font-medium text-charcoal">SMS</p>
@@ -263,7 +271,7 @@ function CaseSummaryPanel() {
         </p>
       </div>
       <div className="rounded-[18px] border border-warm-border bg-white p-5 text-center">
-        <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-wine/70 mb-2">
+        <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-wine/85 mb-2">
           Outcome
         </p>
         <p className="font-serif text-3xl font-semibold text-wine mt-1">
@@ -304,7 +312,7 @@ function ProblemSection() {
               key={p.n}
               className="rounded-[22px] border border-warm-border bg-white p-6 md:p-7 shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
             >
-              <p className="font-mono text-[10px] tracking-[0.22em] text-wine/70 mb-3">
+              <p className="font-mono text-[10px] tracking-[0.22em] text-wine/85 mb-3">
                 {p.n}
               </p>
               <h3 className="font-serif text-xl md:text-2xl font-semibold text-charcoal mb-3 leading-snug">
@@ -349,7 +357,7 @@ function SolutionSection() {
               key={s.n}
               className="rounded-[22px] border border-warm-border bg-white p-6 md:p-7 shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)] flex flex-col"
             >
-              <p className="font-mono text-[10px] tracking-[0.22em] text-wine/70 mb-3">
+              <p className="font-mono text-[10px] tracking-[0.22em] text-wine/85 mb-3">
                 {s.n}
               </p>
               <h3 className="font-serif text-xl md:text-2xl font-semibold text-charcoal mb-3 leading-snug">
@@ -397,7 +405,7 @@ function DeploymentSection() {
               className="rounded-[22px] border border-warm-border bg-white p-7 md:p-8 shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)] flex flex-col"
             >
               <div className="flex items-center justify-between mb-5">
-                <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-wine/70">
+                <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-wine/85">
                   {d.label}
                 </p>
                 <span className="font-mono text-[10px] text-charcoal/70">
@@ -465,7 +473,7 @@ function HowItWorksSection() {
               key={s.n}
               className="rounded-[22px] border border-warm-border bg-white p-6 md:p-7 shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
             >
-              <p className="font-mono text-[10px] tracking-[0.22em] text-wine/70 mb-3">
+              <p className="font-mono text-[10px] tracking-[0.22em] text-wine/85 mb-3">
                 step {s.n}
               </p>
               <h3 className="font-serif text-xl md:text-2xl font-semibold text-charcoal mb-3 leading-snug">
@@ -528,7 +536,7 @@ function IntelligenceRunsSection() {
               key={s.n}
               className="rounded-[22px] border border-warm-border bg-white p-6 md:p-7 shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
             >
-              <p className="font-mono text-[10px] tracking-[0.22em] text-wine/70 mb-3">
+              <p className="font-mono text-[10px] tracking-[0.22em] text-wine/85 mb-3">
                 {s.n}
               </p>
               <h3 className="font-serif text-xl md:text-2xl font-semibold text-charcoal mb-3 leading-snug">
@@ -576,6 +584,25 @@ function PricingTeaserSection() {
 export default function PredictiveCustomerIntelligencePage() {
   return (
     <div>
+      <JsonLd
+        id="pci-page"
+        data={[
+          servicePageSchema({
+            name: "Predictive Customer Intelligence",
+            description:
+              "Score every active client, lead, and rebooking 4x daily. Surface revenue your booking software misses, then queue the outreach that recovers it before demand cools.",
+            path: PATH,
+            serviceType: "Predictive customer intelligence for service businesses",
+          }),
+          faqPageSchema(
+            pciFaqs.map((f) => ({ question: f.question, answer: f.answer })),
+          ),
+          breadcrumbSchema([
+            { name: "Home", path: "/" },
+            { name: "Predictive Customer Intelligence", path: PATH },
+          ]),
+        ]}
+      />
       <Hero
         eyebrow="A systems agency · Ops by Noell · Intelligence layer"
         headlineLine1Start="Predictive Customer"

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -19,9 +19,9 @@ import {
 
 export const metadata = pageMetadata({
   path: "/pricing",
-  title: "Pricing",
+  title: "Pricing — AI Front Desk for Service Businesses",
   description:
-    "Two tracks. Noell Agents at $197/mo founding rate, or the full Noell System — Essentials $197/mo, Growth $797/mo, Custom Ops $1,497/mo. Each tier includes a one-time setup.",
+    "Two tracks. Noell Agents at $197/mo founding rate, or the full Noell System — Essentials $197, Growth $797, Custom Ops $1,497/mo.",
 });
 
 const pricingFaqs: FaqItem[] = [

--- a/src/app/resources/massage-therapist-no-show-cost/page.tsx
+++ b/src/app/resources/massage-therapist-no-show-cost/page.tsx
@@ -1,0 +1,195 @@
+import { ArticleLayout } from "@/components/article-layout";
+import { JsonLd } from "@/components/json-ld";
+import { pageMetadata } from "@/lib/seo";
+import { articleSchema, breadcrumbSchema } from "@/lib/schema";
+
+const PATH = "/resources/massage-therapist-no-show-cost";
+const TITLE =
+  "How much are massage therapist no-shows actually costing you? The real math";
+const DESCRIPTION =
+  "An honest, math-first read for solo and small-team massage practices. The real no-show rate, the lost-revenue numbers, and what to do in the 48 hours after a missed appointment.";
+const PUBLISHED = "2026-05-04";
+
+export const metadata = pageMetadata({
+  path: PATH,
+  title:
+    "Massage Therapist No-Show Cost — The Real Math",
+  description:
+    "The real no-show rate for massage therapists is around 18% without reminders. Here is the lost-revenue math, and the 48-hour playbook to recover it.",
+  type: "article",
+  publishedTime: PUBLISHED,
+});
+
+export default function Article() {
+  return (
+    <>
+      <JsonLd
+        data={[
+          articleSchema({
+            title: TITLE,
+            description: DESCRIPTION,
+            path: PATH,
+            datePublished: PUBLISHED,
+          }),
+          breadcrumbSchema([
+            { name: "Home", path: "/" },
+            { name: "Resources", path: "/resources" },
+            { name: TITLE, path: PATH },
+          ]),
+        ]}
+        id="article-massage-no-show-cost"
+      />
+      <ArticleLayout
+        eyebrow="Article · 7 min"
+        title={TITLE}
+        lead="The real no-show rate for massage practices is closer to 18% than 5%. Here is what that costs over a year, and what to do in the 48 hours that decide whether you ever see that client again."
+        meta="Published May 4, 2026 · Nikki Noell"
+      >
+        <p>
+          The first time a massage therapist tells me her no-show rate is
+          {" "}
+          &ldquo;not that bad,&rdquo; I ask one question: are you counting the
+          quiet ones? The client who texted at 9pm to say something came up.
+          The one who confirmed Sunday and never showed Tuesday. The
+          regular who used to come every six weeks and now comes every
+          twelve. Most no-show conversations stop at the obvious gaps. The
+          real number is hiding in the soft ones, and the math is sharper
+          than most owners realize.
+        </p>
+
+        <h2>The real no-show rate</h2>
+        <p>
+          Industry data consistently puts massage no-show rates around
+          {" "}
+          <strong>18% without reminders</strong>, dropping into the 5 to 10%
+          range with a real reminder system. The 18% figure is not the
+          headline-grabbing version of the number. It is the steady,
+          unglamorous baseline of what happens when a busy solo therapist
+          is in session and cannot personally babysit her schedule.
+        </p>
+        <p>
+          For a practice charging an industry-average{" "}
+          <strong>$120 per 60-minute session</strong>, the math gets uncomfortable
+          fast. Five no-shows a week, every week, is{" "}
+          <strong>$31,200 a year</strong> of revenue you never see. Most
+          practices do not run five no-shows a week as a steady rate, but
+          most practices also do not realize that &ldquo;a couple a week&rdquo; lands
+          in the same neighborhood once you count the soft cancels and the
+          regulars who just stopped booking.
+        </p>
+
+        <h2>The math nobody walks through</h2>
+        <p>
+          A solo massage therapist with 30 booked sessions a week and an 18%
+          no-show rate is losing about{" "}
+          <strong>5.4 sessions a week</strong> to no-shows. At $120 a session,
+          that is{" "}
+          <strong>$648 a week</strong>, or{" "}
+          <strong>$33,696 a year</strong>. That is before factoring in the
+          downstream loss of the rebookings that didn&rsquo;t happen because the
+          client never came back.
+        </p>
+        <p>
+          Once you include the <strong>lifetime value</strong> of a quiet client
+          who churns out, the number gets worse. A regular client at six-week
+          cadence is worth roughly $1,000 a year. Lose three of those a year
+          to silent churn, and the no-show problem is not a $30k problem,
+          it&rsquo;s a $40k problem. The number does not need to be exact to make
+          the point: this is the largest unaccounted-for expense in most
+          single-therapist practices.
+        </p>
+
+        <h2>What most therapists do wrong after a no-show</h2>
+        <p>
+          The default response to a no-show is to wait. Most therapists send
+          one polite text the day-of, then leave the rebooking up to the
+          client. The problem with that is structural: the same client who
+          forgot the appointment is unlikely to remember to rebook. Without a
+          deliberate follow-up sequence, that no-show becomes a churn event
+          that you do not see coming.
+        </p>
+        <p>
+          The other common mistake is to overcorrect into a heavy-handed
+          policy. Charging a client for a missed session can be the right
+          choice once. Doing it without warmth, without the option to
+          rebook, or without a follow-up that protects the relationship is
+          where good clients quietly migrate to the therapist down the
+          street. The recovery sequence matters more than the policy.
+        </p>
+
+        <h2>The 48-hour window</h2>
+        <p>
+          The first <strong>48 hours</strong> after a no-show is the window where
+          the client is still aware they missed something. After that, the
+          appointment fades. Their guilt fades with it, and so does any
+          intent to rebook. A practice that recovers no-shows is not the one
+          with the strictest policy; it is the one that follows up well
+          inside that window with two things: a soft acknowledgement, and a
+          concrete next step.
+        </p>
+        <p>
+          The pattern that works on a solo practice looks like this:
+        </p>
+        <ul>
+          <li>
+            <strong>Hour 0 to 4.</strong> A short, warm text. No guilt, no
+            policy quote. &ldquo;Hi {"{name}"}, looks like we missed you today.
+            Want me to grab Saturday 2pm or 3pm to make it up?&rdquo; Two named
+            time options matter. Open-ended &ldquo;let me know when works&rdquo; is
+            the message that gets ignored.
+          </li>
+          <li>
+            <strong>Hour 24 to 48.</strong> If no response, one follow-up.
+            This is the moment most front desks miss. The second touch is
+            where the recovery actually happens. Same warmth, slightly
+            firmer offer. &ldquo;I have one slot Friday at 4. Want it?&rdquo;
+          </li>
+          <li>
+            <strong>Day 7 to 10.</strong> If still no response, the client is
+            now in &ldquo;quiet&rdquo; territory. They have not churned formally,
+            but they have stopped engaging. A gentle check-in here, not a
+            promo blast, recovers a meaningful share of these.
+          </li>
+        </ul>
+
+        <h2>What &ldquo;done-for-you&rdquo; recovery looks like</h2>
+        <p>
+          The recovery sequence above is straightforward to describe and
+          almost impossible to run consistently while you are under a client.
+          That is the actual problem with no-shows: the moment recovery is
+          most valuable is the same moment your hands are on someone&rsquo;s
+          shoulders. You can&rsquo;t pause a session to send a follow-up. So the
+          follow-up doesn&rsquo;t go.
+        </p>
+        <p>
+          A managed AI front desk closes that gap. Every no-show fires a
+          recovery sequence automatically: the warm acknowledgement at hour
+          one, the concrete reschedule offer with two real time options, the
+          quiet second touch at 24 to 48 hours, the gentle check-in at day
+          seven if needed. None of it requires you to remember. None of it
+          interrupts the client in front of you. The system runs the
+          recovery; you run the practice.
+        </p>
+        <p>
+          For a 30-session-a-week practice running at 18% no-shows,
+          recovering even half of those sessions is{" "}
+          <strong>$324 a week</strong>, or roughly{" "}
+          <strong>$16,800 a year</strong>. That number is bigger than what most
+          practices spend on every other operational tool combined. It is the
+          single largest revenue lever a solo or small-team practice has, and
+          it lives entirely in the 48 hours after the empty chair.
+        </p>
+
+        <h2>The honest summary</h2>
+        <p>
+          Most therapists underestimate their no-show rate, undercount the
+          revenue lost, and miss the 48-hour window where recovery actually
+          works. The math is simple, the discipline is hard, and the gap
+          between &ldquo;I should follow up&rdquo; and &ldquo;the follow-up actually
+          went out&rdquo; is where most of the money lives. Close that gap and
+          the calendar fills back in.
+        </p>
+      </ArticleLayout>
+    </>
+  );
+}

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -24,6 +24,16 @@ const resources: Resource[] = [
   {
     kind: "Article",
     status: "live",
+    title:
+      "How much are massage therapist no-shows actually costing you? The real math",
+    excerpt:
+      "Industry data puts massage no-show rates near 18% without reminders. The real revenue math, the 48-hour recovery window, and what to do inside it.",
+    href: "/resources/massage-therapist-no-show-cost",
+    minutes: "7 min",
+  },
+  {
+    kind: "Article",
+    status: "live",
     title: "From missed calls to missed bookings",
     excerpt:
       "Warm intent cools off quietly. The leak between the first ring and the empty chair — and what a full front desk layer actually does about it.",

--- a/src/app/resources/revenue-calculator/page.tsx
+++ b/src/app/resources/revenue-calculator/page.tsx
@@ -3,7 +3,10 @@ import { SantaProofBlock } from "@/components/santa-proof-block";
 import CTA from "@/components/cta";
 import { JsonLd } from "@/components/json-ld";
 import { pageMetadata } from "@/lib/seo";
-import { breadcrumbSchema } from "@/lib/schema";
+import {
+  breadcrumbSchema,
+  calculatorApplicationSchema,
+} from "@/lib/schema";
 
 export const metadata = pageMetadata({
   path: "/resources/revenue-calculator",
@@ -19,11 +22,19 @@ export default function RevenueCalculatorPage() {
   return (
     <div id="main-content">
       <JsonLd
-        data={breadcrumbSchema([
-          { name: "Home", path: "/" },
-          { name: "Resources", path: "/resources" },
-          { name: "Revenue Calculator", path: "/resources/revenue-calculator" },
-        ])}
+        data={[
+          calculatorApplicationSchema({
+            name: "Service Business Revenue Calculator",
+            description:
+              "Estimate revenue lost to missed calls and no-shows for service businesses, with the recovery a managed AI front desk would return.",
+            path: "/resources/revenue-calculator",
+          }),
+          breadcrumbSchema([
+            { name: "Home", path: "/" },
+            { name: "Resources", path: "/resources" },
+            { name: "Revenue Calculator", path: "/resources/revenue-calculator" },
+          ]),
+        ]}
         id="revenue-calculator"
       />
 

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -7,7 +7,11 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: "/",
-        disallow: ["/admin", "/admin/", "/api/", "/privacy", "/terms"],
+        // Block admin + API only. Legal pages (/legal/*) are public-facing
+        // and intentionally indexable. The earlier /privacy and /terms
+        // rules pointed at non-existent paths and gave a false sense of
+        // protection — they are removed here.
+        disallow: ["/admin", "/admin/", "/api/"],
       },
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,

--- a/src/app/roi/page.tsx
+++ b/src/app/roi/page.tsx
@@ -3,23 +3,34 @@ import { ROICalculator } from "@/components/roi-calculator";
 import CTA from "@/components/cta";
 import { JsonLd } from "@/components/json-ld";
 import { pageMetadata } from "@/lib/seo";
-import { breadcrumbSchema } from "@/lib/schema";
+import {
+  breadcrumbSchema,
+  calculatorApplicationSchema,
+} from "@/lib/schema";
 
 export const metadata = pageMetadata({
   path: "/roi",
-  title: "ROI Calculator",
+  title: "Missed-Call Recovery ROI Calculator",
   description:
-    "Estimate what a missed-call recovery system could return for your service business. Enter your missed calls per week and average ticket to see monthly recovery and payback by tier.",
+    "Estimate the monthly recovery a missed-call system could return for your service business. Enter calls per week and average ticket to see payback by tier.",
 });
 
 export default function RoiPage() {
   return (
     <div>
       <JsonLd
-        data={breadcrumbSchema([
-          { name: "Home", path: "/" },
-          { name: "ROI calculator", path: "/roi" },
-        ])}
+        data={[
+          calculatorApplicationSchema({
+            name: "Missed-Call Recovery ROI Calculator",
+            description:
+              "Estimate monthly missed-call recovery and payback by tier for a local service business.",
+            path: "/roi",
+          }),
+          breadcrumbSchema([
+            { name: "Home", path: "/" },
+            { name: "ROI calculator", path: "/roi" },
+          ]),
+        ]}
         id="roi"
       />
       <section className="relative flex max-w-7xl rounded-b-3xl my-2 md:my-8 mx-auto flex-col items-center justify-center pt-24 md:pt-28 pb-6 px-4 md:px-8 bg-gradient-to-t from-[rgba(107,45,62,0.35)] via-[rgba(240,224,214,0.60)] to-[rgba(250,246,241,1)]">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,103 +5,128 @@ type Entry = {
   path: string;
   changeFrequency: MetadataRoute.Sitemap[number]["changeFrequency"];
   priority: number;
+  /** ISO date for the last meaningful content change on the page. */
+  lastmod: string;
 };
 
+// Per-page lastmod dates. Update these alongside content changes so search
+// crawlers can prioritize freshly updated pages instead of seeing every
+// page share a single build timestamp.
+const TODAY = "2026-05-04";
+const LAUNCH_FIXES = "2026-05-04";
+
 const entries: Entry[] = [
-  { path: "/", changeFrequency: "weekly", priority: 1.0 },
-  { path: "/about", changeFrequency: "monthly", priority: 0.8 },
-  { path: "/agents", changeFrequency: "weekly", priority: 0.9 },
-  { path: "/systems", changeFrequency: "weekly", priority: 0.9 },
+  { path: "/", changeFrequency: "weekly", priority: 1.0, lastmod: LAUNCH_FIXES },
+  { path: "/about", changeFrequency: "monthly", priority: 0.8, lastmod: "2026-05-02" },
+  { path: "/agents", changeFrequency: "weekly", priority: 0.9, lastmod: LAUNCH_FIXES },
+  { path: "/systems", changeFrequency: "weekly", priority: 0.9, lastmod: LAUNCH_FIXES },
   {
     path: "/predictive-customer-intelligence",
     changeFrequency: "weekly",
-    priority: 0.9,
+    priority: 0.95,
+    lastmod: LAUNCH_FIXES,
   },
-  { path: "/pricing", changeFrequency: "weekly", priority: 0.9 },
-  { path: "/what-you-get", changeFrequency: "weekly", priority: 0.9 },
-  { path: "/roi", changeFrequency: "monthly", priority: 0.7 },
+  { path: "/pricing", changeFrequency: "weekly", priority: 0.9, lastmod: LAUNCH_FIXES },
+  { path: "/what-you-get", changeFrequency: "weekly", priority: 0.9, lastmod: LAUNCH_FIXES },
+  { path: "/roi", changeFrequency: "monthly", priority: 0.7, lastmod: LAUNCH_FIXES },
   {
     path: "/resources/revenue-calculator",
     changeFrequency: "monthly",
     priority: 0.9,
+    lastmod: "2026-04-18",
   },
-  { path: "/contact", changeFrequency: "monthly", priority: 0.6 },
-  { path: "/book", changeFrequency: "weekly", priority: 0.95 },
+  { path: "/contact", changeFrequency: "monthly", priority: 0.6, lastmod: "2026-04-18" },
+  { path: "/book", changeFrequency: "weekly", priority: 0.95, lastmod: LAUNCH_FIXES },
 
-  { path: "/noell-support", changeFrequency: "weekly", priority: 0.85 },
-  { path: "/noell-front-desk", changeFrequency: "weekly", priority: 0.85 },
-  { path: "/noell-care", changeFrequency: "weekly", priority: 0.85 },
+  { path: "/noell-support", changeFrequency: "weekly", priority: 0.85, lastmod: "2026-04-18" },
+  { path: "/noell-front-desk", changeFrequency: "weekly", priority: 0.85, lastmod: "2026-04-18" },
+  { path: "/noell-care", changeFrequency: "weekly", priority: 0.85, lastmod: "2026-04-18" },
 
-  { path: "/verticals", changeFrequency: "weekly", priority: 0.85 },
-  { path: "/verticals/dental", changeFrequency: "weekly", priority: 0.8 },
-  { path: "/verticals/med-spas", changeFrequency: "weekly", priority: 0.8 },
-  { path: "/verticals/salons", changeFrequency: "weekly", priority: 0.8 },
-  { path: "/verticals/massage", changeFrequency: "weekly", priority: 0.8 },
-  { path: "/verticals/estheticians", changeFrequency: "weekly", priority: 0.8 },
-  { path: "/verticals/hvac", changeFrequency: "weekly", priority: 0.8 },
+  { path: "/verticals", changeFrequency: "weekly", priority: 0.85, lastmod: "2026-04-18" },
+  { path: "/verticals/dental", changeFrequency: "weekly", priority: 0.8, lastmod: "2026-04-18" },
+  { path: "/verticals/med-spas", changeFrequency: "weekly", priority: 0.8, lastmod: LAUNCH_FIXES },
+  { path: "/verticals/salons", changeFrequency: "weekly", priority: 0.8, lastmod: "2026-04-18" },
+  { path: "/verticals/massage", changeFrequency: "weekly", priority: 0.8, lastmod: "2026-04-18" },
+  { path: "/verticals/estheticians", changeFrequency: "weekly", priority: 0.8, lastmod: "2026-04-18" },
+  { path: "/verticals/hvac", changeFrequency: "weekly", priority: 0.8, lastmod: "2026-04-18" },
 
-  { path: "/resources", changeFrequency: "weekly", priority: 0.7 },
+  { path: "/resources", changeFrequency: "weekly", priority: 0.7, lastmod: LAUNCH_FIXES },
   {
     path: "/resources/missed-call-recovery-for-service-businesses",
     changeFrequency: "monthly",
     priority: 0.7,
+    lastmod: "2026-04-18",
   },
   {
     path: "/resources/ai-front-desk-vs-human-receptionist",
     changeFrequency: "monthly",
     priority: 0.7,
+    lastmod: "2026-04-18",
   },
   {
     path: "/resources/missed-calls-to-missed-bookings",
     changeFrequency: "monthly",
     priority: 0.7,
+    lastmod: "2026-04-18",
   },
   {
     path: "/resources/ai-front-desk-vs-answering-service",
     changeFrequency: "monthly",
     priority: 0.7,
+    lastmod: "2026-04-18",
   },
   {
     path: "/resources/rebooking-and-reactivation-for-med-spas-and-massage",
     changeFrequency: "monthly",
     priority: 0.7,
+    lastmod: "2026-04-18",
   },
   {
     path: "/resources/dental-missed-call-leakage",
     changeFrequency: "monthly",
     priority: 0.7,
+    lastmod: "2026-04-18",
   },
   {
     path: "/resources/salon-after-hours-booking",
     changeFrequency: "monthly",
     priority: 0.7,
+    lastmod: "2026-04-18",
   },
   {
     path: "/resources/review-velocity-local-seo-service-business",
     changeFrequency: "monthly",
     priority: 0.7,
+    lastmod: "2026-04-18",
+  },
+  {
+    path: "/resources/massage-therapist-no-show-cost",
+    changeFrequency: "monthly",
+    priority: 0.75,
+    lastmod: LAUNCH_FIXES,
   },
 
-  { path: "/case-studies/santa-e", changeFrequency: "monthly", priority: 0.7 },
+  { path: "/case-studies/santa-e", changeFrequency: "monthly", priority: 0.7, lastmod: "2026-04-18" },
 
-  { path: "/compare/my-ai-front-desk", changeFrequency: "monthly", priority: 0.65 },
-  { path: "/compare/podium", changeFrequency: "monthly", priority: 0.65 },
-  { path: "/compare/diy-ai-receptionist", changeFrequency: "monthly", priority: 0.65 },
-  { path: "/compare/human-answering-services", changeFrequency: "monthly", priority: 0.65 },
-  { path: "/compare/local-business-messaging-platforms", changeFrequency: "monthly", priority: 0.65 },
-  { path: "/compare/ai-front-desk-alternatives", changeFrequency: "monthly", priority: 0.65 },
+  { path: "/compare/my-ai-front-desk", changeFrequency: "monthly", priority: 0.65, lastmod: "2026-04-18" },
+  { path: "/compare/podium", changeFrequency: "monthly", priority: 0.65, lastmod: "2026-04-18" },
+  { path: "/compare/diy-ai-receptionist", changeFrequency: "monthly", priority: 0.65, lastmod: "2026-04-18" },
+  { path: "/compare/human-answering-services", changeFrequency: "monthly", priority: 0.65, lastmod: "2026-04-18" },
+  { path: "/compare/local-business-messaging-platforms", changeFrequency: "monthly", priority: 0.65, lastmod: "2026-04-18" },
+  { path: "/compare/ai-front-desk-alternatives", changeFrequency: "monthly", priority: 0.65, lastmod: "2026-04-18" },
 
-  { path: "/legal/privacy", changeFrequency: "yearly", priority: 0.3 },
-  { path: "/legal/terms", changeFrequency: "yearly", priority: 0.3 },
-  { path: "/legal/cookies", changeFrequency: "yearly", priority: 0.3 },
-  { path: "/sms-policy", changeFrequency: "yearly", priority: 0.3 },
+  { path: "/legal/privacy", changeFrequency: "yearly", priority: 0.3, lastmod: "2026-05-02" },
+  { path: "/legal/terms", changeFrequency: "yearly", priority: 0.3, lastmod: "2026-05-02" },
+  { path: "/legal/cookies", changeFrequency: "yearly", priority: 0.3, lastmod: "2026-05-02" },
+  { path: "/sms-policy", changeFrequency: "yearly", priority: 0.3, lastmod: "2026-05-02" },
 ];
 
+void TODAY;
+
 export default function sitemap(): MetadataRoute.Sitemap {
-  const now = new Date();
   return entries.map((e) => ({
     url: `${SITE_URL}${e.path === "/" ? "" : e.path}`,
-    lastModified: now,
+    lastModified: new Date(e.lastmod),
     changeFrequency: e.changeFrequency,
     priority: e.priority,
   }));

--- a/src/app/systems/page.tsx
+++ b/src/app/systems/page.tsx
@@ -16,10 +16,9 @@ import { breadcrumbSchema, servicePageSchema } from "@/lib/schema";
 
 export const metadata = pageMetadata({
   path: "/systems",
-  title:
-    "The Noell System — One System. Three Agents. Managed End-to-End.",
+  title: "The Noell System — One System, Three Agents, Managed",
   description:
-    "The Noell system is a done-for-you front desk, intake, and retention layer for service businesses. Three managed agents run in the background, layered on top of the tools you already use. Audit, install, live in 14 days.",
+    "A done-for-you front desk, intake, and retention layer for service businesses. Three managed agents on top of your existing tools. Live in 14 days.",
 });
 
 type Agent = {
@@ -201,7 +200,7 @@ export default function SystemsPage() {
                     </span>
                   </div>
                 </div>
-                <p className="text-[11px] uppercase tracking-[0.2em] text-wine/70 mb-1">
+                <p className="text-[11px] uppercase tracking-[0.2em] text-wine/85 mb-1">
                   {agent.eyebrow}
                 </p>
                 <h3 className="font-serif text-2xl font-semibold text-charcoal mb-1">

--- a/src/app/verticals/dental/page.tsx
+++ b/src/app/verticals/dental/page.tsx
@@ -204,7 +204,7 @@ const dentalScreen = (
     <div className="bg-white rounded-2xl p-3 mx-1 border border-warm-border/60 shadow-sm">
       <div className="flex items-start justify-between">
         <div>
-          <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
+          <p className="text-[10px] uppercase tracking-widest text-wine/85 font-medium">
             New patient, missed call
           </p>
           <p className="text-sm text-charcoal font-medium mt-0.5">
@@ -239,7 +239,7 @@ const dentalScreen = (
     <div className="bg-blush-light rounded-2xl p-3 mx-1 mt-2 border border-wine/10 shadow-sm">
       <div className="flex items-center justify-between">
         <div>
-          <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
+          <p className="text-[10px] uppercase tracking-widest text-wine/85 font-medium">
             Hygiene recall, confirmed
           </p>
           <p className="text-sm text-charcoal font-medium mt-0.5">

--- a/src/app/verticals/estheticians/page.tsx
+++ b/src/app/verticals/estheticians/page.tsx
@@ -166,7 +166,7 @@ const estheticianScreen = (
     <div className="bg-white rounded-2xl p-3 mx-1 border border-warm-border/60 shadow-sm">
       <div className="flex items-start justify-between">
         <div>
-          <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
+          <p className="text-[10px] uppercase tracking-widest text-wine/85 font-medium">
             Treatment plan, visit 4 of 6
           </p>
           <p className="text-sm text-charcoal font-medium mt-0.5">Lena K.</p>

--- a/src/app/verticals/hvac/page.tsx
+++ b/src/app/verticals/hvac/page.tsx
@@ -166,7 +166,7 @@ const hvacScreen = (
     <div className="bg-white rounded-2xl p-3 mx-1 border border-warm-border/60 shadow-sm">
       <div className="flex items-start justify-between">
         <div>
-          <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
+          <p className="text-[10px] uppercase tracking-widest text-wine/85 font-medium">
             Emergency, no cool
           </p>
           <p className="text-sm text-charcoal font-medium mt-0.5">

--- a/src/app/verticals/massage/page.tsx
+++ b/src/app/verticals/massage/page.tsx
@@ -166,7 +166,7 @@ const massageScreen = (
     <div className="bg-white rounded-2xl p-3 mx-1 border border-warm-border/60 shadow-sm">
       <div className="flex items-start justify-between">
         <div>
-          <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
+          <p className="text-[10px] uppercase tracking-widest text-wine/85 font-medium">
             Missed call, with a client
           </p>
           <p className="text-sm text-charcoal font-medium mt-0.5">Santa E.</p>

--- a/src/app/verticals/med-spas/page.tsx
+++ b/src/app/verticals/med-spas/page.tsx
@@ -167,7 +167,7 @@ const medSpaScreen = (
     <div className="bg-white rounded-2xl p-3 mx-1 border border-warm-border/60 shadow-sm">
       <div className="flex items-start justify-between">
         <div>
-          <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
+          <p className="text-[10px] uppercase tracking-widest text-wine/85 font-medium">
             New inquiry, Botox
           </p>
           <p className="text-sm text-charcoal font-medium mt-0.5">Jasmine R.</p>

--- a/src/app/verticals/salons/page.tsx
+++ b/src/app/verticals/salons/page.tsx
@@ -166,7 +166,7 @@ const salonScreen = (
     <div className="bg-white rounded-2xl p-3 mx-1 border border-warm-border/60 shadow-sm">
       <div className="flex items-start justify-between">
         <div>
-          <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
+          <p className="text-[10px] uppercase tracking-widest text-wine/85 font-medium">
             Rebook nudge, color
           </p>
           <p className="text-sm text-charcoal font-medium mt-0.5">

--- a/src/app/what-you-get/page.tsx
+++ b/src/app/what-you-get/page.tsx
@@ -22,12 +22,12 @@ const PATH = "/what-you-get";
 
 export const metadata = pageMetadata({
   path: PATH,
-  title: "What You Get — Ops by Noell",
+  title: "What's Included — Done-for-You AI Front Desk",
   description:
-    "What you actually get when you sign up for Ops by Noell: a business line that never misses a call, three AI agents working in the background, the dashboard that runs your front office, the tap-in feature, done-for-you setup, and compliance built in.",
+    "A business line that never misses a call, three AI agents in the background, the dashboard that runs your front office, and done-for-you setup.",
   ogTitle: "Stay focused on the client in front of you. We'll handle the phone.",
   ogDescription:
-    "An AI front desk that answers your calls, books your appointments, and texts your customers — so you can be present with the client you're serving without losing the next booking.",
+    "An AI front desk that answers your calls, books appointments, and texts customers — without losing the next booking.",
 });
 
 type GetItem = {

--- a/src/components/agent-chat-widget.tsx
+++ b/src/components/agent-chat-widget.tsx
@@ -199,6 +199,7 @@ export function AgentChatWidget(props: AgentChatWidgetProps) {
   return (
     <>
       <motion.button
+        type="button"
         initial={{ scale: 0, opacity: 0 }}
         animate={{ scale: 1, opacity: 1 }}
         transition={{ delay: 1, type: "spring", stiffness: 260, damping: 20 }}
@@ -219,7 +220,7 @@ export function AgentChatWidget(props: AgentChatWidgetProps) {
               exit={{ rotate: 90, opacity: 0 }}
               transition={{ duration: 0.2 }}
             >
-              <IconX size={22} />
+              <IconX size={22} aria-hidden="true" />
             </motion.div>
           ) : (
             <motion.div
@@ -229,7 +230,7 @@ export function AgentChatWidget(props: AgentChatWidgetProps) {
               exit={{ rotate: 90, opacity: 0 }}
               transition={{ duration: 0.2 }}
             >
-              <IconMessageCircle size={22} />
+              <IconMessageCircle size={22} aria-hidden="true" />
             </motion.div>
           )}
         </AnimatePresence>
@@ -265,11 +266,12 @@ export function AgentChatWidget(props: AgentChatWidgetProps) {
                 </div>
               </div>
               <button
+                type="button"
                 onClick={() => setIsOpen(false)}
                 className="text-white/70 hover:text-white"
                 aria-label="Close"
               >
-                <IconX size={18} />
+                <IconX size={18} aria-hidden="true" />
               </button>
             </div>
 
@@ -321,6 +323,7 @@ export function AgentChatWidget(props: AgentChatWidgetProps) {
                   {props.starterChips.map((chip) => (
                     <button
                       key={chip}
+                      type="button"
                       onClick={() => void send(chip)}
                       className="text-xs px-3 py-1.5 rounded-full bg-white border border-warm-border text-charcoal/70 hover:bg-lilac-light transition-all"
                     >
@@ -342,6 +345,7 @@ export function AgentChatWidget(props: AgentChatWidgetProps) {
                   className="flex-1 h-10 px-3.5 text-sm bg-cream-dark rounded-[10px] border border-warm-border focus:outline-none text-charcoal placeholder:text-charcoal/70"
                 />
                 <button
+                  type="button"
                   onClick={handleSend}
                   className={cn(
                     "w-10 h-10 rounded-[10px] text-white flex items-center justify-center shadow-md",
@@ -349,7 +353,7 @@ export function AgentChatWidget(props: AgentChatWidgetProps) {
                   )}
                   aria-label="Send"
                 >
-                  <IconSend size={15} />
+                  <IconSend size={15} aria-hidden="true" />
                 </button>
               </div>
               <p className="text-xs text-muted-medium mt-2 px-1">

--- a/src/components/book-request-form.tsx
+++ b/src/components/book-request-form.tsx
@@ -94,12 +94,19 @@ export function BookRequestForm({ className }: BookRequestFormProps) {
       aria-label="Request a working call"
     >
       <div className="rounded-[22px] border border-warm-border bg-white p-7 md:p-9 max-w-2xl mx-auto shadow-[0px_15px_15px_0px_rgba(28,25,23,0.04),0px_4px_8px_0px_rgba(28,25,23,0.05)]">
+        <p className="text-xs text-charcoal/70 mb-5">
+          All fields marked <span aria-hidden="true" className="text-wine">*</span> are required.
+        </p>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
           <label className="block">
-            <span className="block text-sm text-charcoal/80 mb-2">Name</span>
+            <span className="block text-sm text-charcoal/80 mb-2">
+              Name <span aria-hidden="true" className="text-wine">*</span>
+              <span className="sr-only"> (required)</span>
+            </span>
             <input
               type="text"
               required
+              aria-required="true"
               value={name}
               onChange={(e) => setName(e.target.value)}
               autoComplete="name"
@@ -107,10 +114,14 @@ export function BookRequestForm({ className }: BookRequestFormProps) {
             />
           </label>
           <label className="block">
-            <span className="block text-sm text-charcoal/80 mb-2">Business name</span>
+            <span className="block text-sm text-charcoal/80 mb-2">
+              Business name <span aria-hidden="true" className="text-wine">*</span>
+              <span className="sr-only"> (required)</span>
+            </span>
             <input
               type="text"
               required
+              aria-required="true"
               value={business}
               onChange={(e) => setBusiness(e.target.value)}
               autoComplete="organization"
@@ -118,10 +129,14 @@ export function BookRequestForm({ className }: BookRequestFormProps) {
             />
           </label>
           <label className="block">
-            <span className="block text-sm text-charcoal/80 mb-2">Phone</span>
+            <span className="block text-sm text-charcoal/80 mb-2">
+              Phone <span aria-hidden="true" className="text-wine">*</span>
+              <span className="sr-only"> (required)</span>
+            </span>
             <input
               type="tel"
               required
+              aria-required="true"
               value={phone}
               onChange={(e) => setPhone(e.target.value)}
               autoComplete="tel"
@@ -129,10 +144,14 @@ export function BookRequestForm({ className }: BookRequestFormProps) {
             />
           </label>
           <label className="block">
-            <span className="block text-sm text-charcoal/80 mb-2">Email</span>
+            <span className="block text-sm text-charcoal/80 mb-2">
+              Email <span aria-hidden="true" className="text-wine">*</span>
+              <span className="sr-only"> (required)</span>
+            </span>
             <input
               type="email"
               required
+              aria-required="true"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               autoComplete="email"
@@ -143,11 +162,14 @@ export function BookRequestForm({ className }: BookRequestFormProps) {
 
         <label className="block mt-5">
           <span className="block text-sm text-charcoal/80 mb-2">
-            Current booking or practice management software
+            Current booking or practice management software{" "}
+            <span aria-hidden="true" className="text-wine">*</span>
+            <span className="sr-only"> (required)</span>
           </span>
           <input
             type="text"
             required
+            aria-required="true"
             value={bookingSystem}
             onChange={(e) => setBookingSystem(e.target.value)}
             placeholder="What you use to manage appointments"
@@ -158,10 +180,13 @@ export function BookRequestForm({ className }: BookRequestFormProps) {
 
         <label className="block mt-5">
           <span className="block text-sm text-charcoal/80 mb-2">
-            One sentence on what is leaking at the front desk right now.
+            One sentence on what is leaking at the front desk right now.{" "}
+            <span aria-hidden="true" className="text-wine">*</span>
+            <span className="sr-only"> (required)</span>
           </span>
           <textarea
             required
+            aria-required="true"
             value={leakDescription}
             onChange={(e) => setLeakDescription(e.target.value)}
             rows={3}

--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -77,9 +77,16 @@ export function Features({
               <p className="text-[10px] font-mono uppercase tracking-widest text-charcoal/70 mb-2">
                 {stat.label}
               </p>
-              <h3 className="font-serif text-4xl md:text-5xl font-bold mb-2 text-charcoal">
+              {/* Visually a heading-sized number, but it is a metric callout,
+                  not a real document heading. Using <p> keeps the heading
+                  outline accurate so screen readers do not announce
+                  "72h", "3x", "<90s" as section headings. */}
+              <p
+                className="font-serif text-4xl md:text-5xl font-bold mb-2 text-charcoal"
+                aria-label={`${stat.value} ${stat.label}`}
+              >
                 {stat.value}
-              </h3>
+              </p>
               <p className="text-sm text-charcoal/75 leading-relaxed">
                 {stat.detail}
               </p>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -114,6 +114,10 @@ export function Hero({
                 </span>
               </>
             )}
+            {/* Whitespace before the line break ensures screen readers and
+                text extractors do not join the last word of line 1 with the
+                first word of line 2 (e.g. "Intelligencefor"). */}
+            {" "}
             <br />
             <span
               className={cn(
@@ -305,7 +309,7 @@ function DefaultMockScreen() {
       <div className="bg-white rounded-2xl p-3 mx-1 border border-warm-border/60 shadow-sm">
         <div className="flex items-start justify-between">
           <div>
-            <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
+            <p className="text-[10px] uppercase tracking-widest text-wine/85 font-medium">
               Missed-call recovery
             </p>
             <p className="text-sm text-charcoal font-medium mt-0.5">Santa E.</p>
@@ -334,7 +338,7 @@ function DefaultMockScreen() {
       <div className="bg-blush-light rounded-2xl p-3 mx-1 mt-2 border border-wine/10 shadow-sm">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-[10px] uppercase tracking-widest text-wine/70 font-medium">
+            <p className="text-[10px] uppercase tracking-widest text-wine/85 font-medium">
               Booking confirmed
             </p>
             <p className="text-sm text-charcoal font-medium mt-0.5">

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -211,7 +211,7 @@ const DesktopNav = ({ navItems, visible }: NavbarProps) => {
                         <Link
                           href="/verticals"
                           onClick={() => setVerticalsOpen(false)}
-                          className="block px-3 py-2 text-xs text-wine/70 hover:text-wine hover:bg-blush rounded-xl transition-colors font-medium"
+                          className="block px-3 py-2 text-xs text-wine/85 hover:text-wine hover:bg-blush rounded-xl transition-colors font-medium"
                         >
                           View all verticals &rarr;
                         </Link>

--- a/src/components/noell-support-chat.tsx
+++ b/src/components/noell-support-chat.tsx
@@ -261,6 +261,7 @@ export function NoellSupportChat() {
   // Shared launcher button (orb) used on /book and whenever closed
   const OrbButton = (
     <motion.button
+      type="button"
       {...launcherMotion}
       onClick={() => setIsOpen((v) => !v)}
       className={cn(
@@ -280,7 +281,7 @@ export function NoellSupportChat() {
             exit={prefersReducedMotion ? undefined : { rotate: 90, opacity: 0 }}
             transition={{ duration: 0.2 }}
           >
-            <IconX size={22} />
+            <IconX size={22} aria-hidden="true" />
           </motion.div>
         ) : (
           <motion.div
@@ -290,7 +291,7 @@ export function NoellSupportChat() {
             exit={prefersReducedMotion ? undefined : { rotate: 90, opacity: 0 }}
             transition={{ duration: 0.2 }}
           >
-            <IconMessageCircle size={22} />
+            <IconMessageCircle size={22} aria-hidden="true" />
           </motion.div>
         )}
       </AnimatePresence>
@@ -300,6 +301,7 @@ export function NoellSupportChat() {
   // Pill launcher (default on non-/book pages when closed)
   const PillButton = (
     <motion.button
+      type="button"
       {...launcherMotion}
       onClick={() => setIsOpen(true)}
       className={cn(
@@ -311,7 +313,7 @@ export function NoellSupportChat() {
       aria-label="Open Noell Support chat"
     >
       <span className="w-6 h-6 rounded-full bg-gradient-to-b from-lilac via-lilac-dark to-[#6b4f80] text-white flex items-center justify-center">
-        <IconMessageCircle size={14} />
+        <IconMessageCircle size={14} aria-hidden="true" />
       </span>
       Have a question? Chat with Noell
     </motion.button>
@@ -363,11 +365,12 @@ export function NoellSupportChat() {
                 </div>
               </div>
               <button
+                type="button"
                 onClick={handleClose}
                 className="text-white/70 hover:text-white tap-target flex items-center justify-center"
                 aria-label="Close"
               >
-                <IconX size={18} />
+                <IconX size={18} aria-hidden="true" />
               </button>
             </div>
 
@@ -391,6 +394,7 @@ export function NoellSupportChat() {
                   {starterChips.map((chip) => (
                     <button
                       key={chip}
+                      type="button"
                       onClick={() => handleChip(chip)}
                       className="text-xs px-3 py-1.5 rounded-full bg-white border border-warm-border text-charcoal/70 hover:bg-lilac-light hover:border-lilac-dark hover:text-lilac-dark transition-all"
                     >
@@ -414,12 +418,13 @@ export function NoellSupportChat() {
                   className="flex-1 h-10 px-3.5 text-sm bg-cream-dark rounded-[10px] border border-warm-border focus:outline-none focus:border-lilac-dark/60 focus:bg-white text-charcoal placeholder:text-charcoal/70 disabled:opacity-60"
                 />
                 <button
+                  type="button"
                   onClick={handleSend}
                   disabled={sending || !inputValue.trim()}
                   className="w-10 h-10 rounded-[10px] bg-gradient-to-b from-lilac via-lilac-dark to-[#6b4f80] text-white flex items-center justify-center hover:scale-105 transition-transform shadow-md disabled:opacity-50 disabled:hover:scale-100"
                   aria-label="Send"
                 >
-                  <IconSend size={15} />
+                  <IconSend size={15} aria-hidden="true" />
                 </button>
               </div>
               <p className="text-[9px] text-muted-medium mt-2 text-center">

--- a/src/components/pick-your-path.tsx
+++ b/src/components/pick-your-path.tsx
@@ -66,7 +66,7 @@ function Card({ card }: { card: CardProps }) {
           : "border border-warm-border"
       )}
     >
-      <p className="text-[11px] uppercase tracking-[0.2em] text-wine/70 mb-2">
+      <p className="text-[11px] uppercase tracking-[0.2em] text-wine/85 mb-2">
         {card.eyebrow}
       </p>
       <h3 className="font-serif text-2xl md:text-3xl font-semibold text-charcoal mb-3">

--- a/src/components/santa-proof-block.tsx
+++ b/src/components/santa-proof-block.tsx
@@ -43,7 +43,7 @@ export function SantaProofBlock({ className }: SantaProofBlockProps) {
             Now I open my calendar and it’s just full. The reminders go out and people show up.
             I don’t think about it anymore.”
           </p>
-          <footer className="mt-3 text-[11px] uppercase tracking-[0.2em] text-charcoal/60">
+          <footer className="mt-3 text-[11px] uppercase tracking-[0.2em] text-charcoal/80">
             Santa E. · Licensed Massage Therapist · Laguna Niguel CA
           </footer>
         </blockquote>

--- a/src/components/systems.tsx
+++ b/src/components/systems.tsx
@@ -97,7 +97,7 @@ export function Systems() {
                   </span>
                 </div>
               </div>
-              <p className="text-[11px] uppercase tracking-[0.2em] text-wine/70 mb-1">
+              <p className="text-[11px] uppercase tracking-[0.2em] text-wine/85 mb-1">
                 {agent.eyebrow}
               </p>
               <h3 className="font-serif text-2xl font-semibold text-charcoal mb-1">

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -131,6 +131,41 @@ export function personSchema() {
   };
 }
 
+export function jamesPersonSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "James Noell",
+    jobTitle: "Co-founder",
+    worksFor: { "@id": `${SITE_URL}/#organization` },
+    affiliation: { "@id": `${SITE_URL}/#organization` },
+    url: `${SITE_URL}/about`,
+  };
+}
+
+export function calculatorApplicationSchema(input: {
+  name: string;
+  description: string;
+  path: string;
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    name: input.name,
+    description: input.description,
+    url: absoluteUrl(input.path),
+    applicationCategory: "BusinessApplication",
+    operatingSystem: "Any (browser)",
+    isAccessibleForFree: true,
+    offers: {
+      "@type": "Offer",
+      price: 0,
+      priceCurrency: "USD",
+    },
+    publisher: { "@id": `${SITE_URL}/#organization` },
+  };
+}
+
 export function servicePageSchema(input: {
   name: string;
   description: string;

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -22,6 +22,12 @@ export type PageSeoInput = {
   type?: "website" | "article";
   publishedTime?: string;
   modifiedTime?: string;
+  /**
+   * If true, the page's title is rendered exactly as given without the
+   * parent layout's "%s | Ops by Noell" suffix template. Use for the
+   * homepage and any page whose title already contains the brand name.
+   */
+  absoluteTitle?: boolean;
 };
 
 export function pageMetadata(input: PageSeoInput): Metadata {
@@ -32,7 +38,9 @@ export function pageMetadata(input: PageSeoInput): Metadata {
   const ogDescription = input.ogDescription ?? input.description;
 
   const meta: Metadata = {
-    title: input.title,
+    title: input.absoluteTitle
+      ? { absolute: input.title }
+      : input.title,
     description: input.description,
     alternates: { canonical: url },
     openGraph: {


### PR DESCRIPTION
## Summary

Implements the launch-critical fixes from `opsbynoell_launch_implementation_brief.md`. Production is otherwise unchanged — these are tightly scoped corrections, not a redesign.

## What changed

### SEO and metadata
- Fix `/predictive-customer-intelligence` canonical to self-reference (was pointing at the homepage, the single highest-priority SEO bug on the site).
- Drop duplicated `| Ops by Noell` suffix on PCI, `/book`, `/what-you-get` titles. Adds an `absoluteTitle` option in `pageMetadata` so the homepage title escapes the parent template.
- Shorten over-long meta descriptions on Home, About, Systems, Agents, What You Get, Book, Pricing, ROI, PCI to ~140–155 chars.
- Per-page `lastmod` in `sitemap.xml`, plus an entry for the new article.
- Drop stale `/privacy` and `/terms` `Disallow` rules in `robots.txt` — the real paths are `/legal/*`, the existing rules pointed nowhere.
- Apply `noindex, nofollow` when `VERCEL_ENV` is non-production so the `opsbynoell-marketing-preview` and `-review` Vercel domains stop competing with production.

### Structured data
- PCI page: `Service`, `FAQPage`, `BreadcrumbList` JSON-LD.
- About: add a `Person` schema for James Noell alongside Nikki.
- ROI and Revenue Calculator: add `WebApplication` schema.

### Positioning and conversion
- Rewrite the homepage hero around revenue intelligence / Predictive Customer Intelligence ("the revenue your booking software never sees" / "we catch it before it walks out the door"). Primary CTA promoted back to `/book`.
- Add `/resources/massage-therapist-no-show-cost` — the highest-priority article from the content strategy audit (real no-show math, the 48-hour recovery window). Wired into `/resources` index, sitemap, and Article + breadcrumb JSON-LD.

### Accessibility
- PCI H1: insert whitespace before the inline line break so screen readers and text extractors do not run `Intelligence` into `for service businesses`.
- Floating chat widgets: `type="button"` on every button, `aria-hidden="true"` on Tabler icons.
- Med-spa metric callouts: replace `<h3>` wrappers around `72h`, `3x`, `<90s` with styled `<p>` + `aria-label` so they stop registering as document headings.
- Booking form: visible required-field indicators (`*` with `sr-only` label and a legend), `aria-required` on all required inputs.
- Bump `text-wine/70` → `text-wine/85` across pages for WCAG AA contrast on small uppercase labels.
- Bump `charcoal/60` → `charcoal/80` on the homepage Santa attribution caption.

## Test plan

- [x] `npm run build` passes (all 50+ routes generated, no errors).
- [x] `npx tsc --noEmit` clean except for pre-existing TS5097 errors in test files (`.ts` import paths) unrelated to this change.
- [x] `npm run lint` shows only pre-existing errors (`docs/template-source/*` and `react/no-unescaped-entities` in DefaultMockScreen quotes that predate this branch).
- [x] Audit-language grep on changed files: no new vendor / platform-implementation language introduced.
- [ ] After merge to main and Vercel deploy, spot-check live HTML for the PCI canonical, OG image, and JSON-LD blocks.
- [ ] Run the live URL through https://search.google.com/test/rich-results to verify the new Service / FAQPage / BreadcrumbList schemas parse cleanly.

## Deferred

- `sameAs` arrays on Organization / LocalBusiness still empty — needs verified social URLs from the team.
- Healing Hands case-study `Review` schema — left for a follow-up since the homepage Santa block currently uses an unattributed editorial blockquote, not a testimonial component.
- GA4 / privacy-first analytics provider — Meta Pixel remains the only analytics today; existing scaffolding in `src/lib/analytics.ts` is provider-agnostic and ready when an ID is provisioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)