### PR TITLE
Relaunch site around Predictive Customer Intelligence + Revenue Signal Report

### DIFF
--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -10,9 +10,9 @@ import { breadcrumbSchema, faqPageSchema } from "@/lib/schema";
 
 export const metadata = pageMetadata({
   path: "/book",
-  title: "Book a Free Audit Call",
+  title: "Get Your Free Revenue Signal Report",
   description:
-    "Tell us about your front desk. We reply within one business day with two or three times that work for a focused twenty-minute walkthrough.",
+    "Tell us what you use to book, where the front desk is leaking, and what kind of business you run. We will review it personally and reply within one business day with two or three times for a focused walkthrough.",
 });
 
 const bookFaqs: FaqItem[] = [
@@ -20,7 +20,7 @@ const bookFaqs: FaqItem[] = [
     id: "is-this-a-sales-pitch",
     question: "Is this a sales pitch?",
     answer:
-      "No. It is a working call. You will leave with a clear picture of what is leaking at the front of your business and whether a done-for-you AI front desk is a fit. If it is not, we will say so.",
+      "No. The Revenue Signal Report is a working deliverable. You will leave with a clear map of where your front desk, booking flow, and follow-up system are leaking revenue, and whether Ops by Noell is a fit. If it is not, we will say so.",
   },
   {
     id: "switch-booking-systems",
@@ -57,21 +57,27 @@ const bookFaqs: FaqItem[] = [
 const whatHappensNext = [
   {
     number: "01",
-    title: "You send the form.",
+    title: "A real person reviews your booking flow.",
     detail:
-      "A real person on our team reads it, usually the same day, within one business day always.",
+      "Someone on our team reads what you sent, usually the same day, within one business day always.",
   },
   {
     number: "02",
-    title: "We reply with two or three times.",
+    title: "We reply with two or three working-call times.",
     detail:
       "By email or text, with windows that fit your schedule. You pick one.",
   },
   {
     number: "03",
-    title: "We walk your front desk.",
+    title: "We walk through the leaks on the call.",
     detail:
-      "On the call, we cover the leaks we already spotted from your booking flow and what we would install around your booking system.",
+      "We cover what we already spotted, estimate what those leaks may be worth, and answer your questions.",
+  },
+  {
+    number: "04",
+    title: "If it is a fit, you get a recommended track.",
+    detail:
+      "We map the right Ops by Noell track and install path. If it is not a fit, we will say so.",
   },
 ];
 
@@ -97,36 +103,46 @@ export default function BookPage() {
           The first step
         </p>
         <h1 className="relative z-20 max-w-4xl text-center font-serif text-3xl md:text-5xl lg:text-6xl font-semibold tracking-tight text-charcoal">
-          Request a{" "}
+          Get your free{" "}
           <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
-            working call
-          </span>{" "}
-          with Ops by Noell.
+            Revenue Signal Report.
+          </span>
         </h1>
         <p className="relative z-20 mt-5 max-w-2xl text-center text-charcoal/80 text-base md:text-lg leading-relaxed">
-          Audits are scheduled personally right now. Tell us about your front
-          desk. We reply within one business day with two or three times that
-          work for a focused twenty-minute walkthrough.
+          Tell us what you use to book, where the front desk is leaking, and
+          what kind of business you run. We will review it personally and
+          reply within one business day with two or three times for a focused
+          walkthrough.
         </p>
       </section>
 
+      {/* Form intro */}
+      <section className="px-4 pt-8 pb-2">
+        <div className="max-w-2xl mx-auto text-center">
+          <p className="text-sm md:text-base text-charcoal/75 leading-relaxed">
+            The report starts here. Six quick details help us map your
+            missed-call, rebooking, and follow-up leaks before the call.
+          </p>
+        </div>
+      </section>
+
       {/* Form */}
-      <section className="px-4 pt-8 pb-10">
+      <section className="px-4 pt-4 pb-10">
         <BookRequestForm />
       </section>
 
-      {/* What happens next */}
+      {/* What happens after you send it */}
       <section className="px-4 py-14 md:py-16">
         <div className="max-w-5xl mx-auto">
           <div className="text-center mb-10">
             <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-3">
-              What happens next
+              What happens after you send it
             </p>
             <h2 className="font-serif text-2xl md:text-3xl font-semibold text-charcoal leading-tight">
               No widget. No queue. A human reply.
             </h2>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5">
             {whatHappensNext.map((step) => (
               <div
                 key={step.number}
@@ -144,6 +160,10 @@ export default function BookPage() {
               </div>
             ))}
           </div>
+          <p className="mt-8 text-center text-xs md:text-sm text-charcoal/70 italic max-w-xl mx-auto leading-relaxed">
+            We do not chase. We do not add you to a list. If it is not a fit,
+            we will say so.
+          </p>
         </div>
       </section>
 
@@ -205,10 +225,12 @@ export default function BookPage() {
 
       <CTA
         eyebrow="Still thinking"
-        headlineStart="The working call is"
+        headlineStart="The Revenue Signal Report is"
         headlineAccent="here when you are."
         body="You can always come back. We do not chase, and we do not add you to a list."
-        trustLine="Twenty focused minutes. Personally scheduled."
+        trustLine="Free · Reviewed personally · Reply within one business day"
+        primaryCta={{ label: "Get Your Free Revenue Signal Report", href: "/book" }}
+        secondaryCta={null}
         sourcePage="book"
       />
     </div>

--- a/src/app/case-studies/santa-e/page.tsx
+++ b/src/app/case-studies/santa-e/page.tsx
@@ -118,6 +118,31 @@ export default function CaseStudy() {
           </li>
         </ul>
 
+        <h2>What made the recovery possible</h2>
+        <p>
+          Santa did not need another dashboard. She needed a system that
+          could catch missed intent, respond quickly, and protect her
+          calendar while she was with clients.
+        </p>
+        <ul>
+          <li>
+            <strong>Noell Support</strong> — captured and qualified missed
+            inbound intent.
+          </li>
+          <li>
+            <strong>Noell Front Desk</strong> — helped turn missed calls into
+            booked appointments.
+          </li>
+          <li>
+            <strong>Noell Care</strong> — protected existing-client
+            follow-up and rebooking.
+          </li>
+          <li>
+            <strong>Predictive Customer Intelligence</strong> — identified
+            the patterns that should become recovery signals.
+          </li>
+        </ul>
+
         <h2>What Santa kept</h2>
         <p>
           Santa still runs her practice herself. She still takes real calls

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,12 +22,12 @@ import {
 export const metadata = pageMetadata({
   path: "/",
   absoluteTitle: true,
-  title: "AI Front Desk for Local Service Businesses — Ops by Noell",
+  title: "Predictive Customer Intelligence for Service Businesses — Ops by Noell",
   description:
-    "Predictive Customer Intelligence for service businesses. Catch missed revenue, prioritize high-intent leads, and recover bookings before demand cools. Live in 14 days.",
+    "We find the clients, leads, and rebookings your booking software is about to lose, then deploy the agents that recover them. Get your free Revenue Signal Report.",
   ogTitle: "Ops by Noell — Predictive Customer Intelligence for Service Businesses",
   ogDescription:
-    "$960 recovered in 14 days. 75% fewer no-shows. The intelligence layer that catches revenue your booking software misses.",
+    "$960 recovered in 14 days. The intelligence layer that catches revenue your booking software misses. Free Revenue Signal Report.",
 });
 
 const homepageFaqs: FaqItem[] = [
@@ -35,7 +35,13 @@ const homepageFaqs: FaqItem[] = [
     id: "is-this-a-sales-pitch",
     question: "Is this a sales pitch?",
     answer:
-      "No. It is a working call. You will leave with a clear picture of what is leaking at the front of your business and whether a done-for-you AI front desk is a fit. If it is not, we will say so.",
+      "No. The Revenue Signal Report is a working deliverable. You will leave with a clear map of where your front desk, booking flow, and follow-up system are leaking revenue, and whether Ops by Noell is a fit. If it is not, we will say so.",
+  },
+  {
+    id: "what-is-revenue-signal-report",
+    question: "What is the Revenue Signal Report?",
+    answer:
+      "A free review of where your front desk, booking flow, and follow-up system are leaking revenue. You tell us about your business and current tools, we review personally and reply within one business day with a focused walkthrough.",
   },
   {
     id: "switch-booking-systems",
@@ -86,15 +92,15 @@ export default function Home() {
 
       {/* 1. Hero */}
       <Hero
-        headlineLine1Start="The revenue your booking software"
-        headlineLine1Accent="never sees."
-        headlineLine2Start="We catch it before it"
-        headlineLine2Accent="walks out the door."
+        headlineLine1Start="Your booking software shows what happened."
+        headlineLine1Accent=""
+        headlineLine2Start="We show who is about to"
+        headlineLine2Accent="slip away."
         headlineLine2Smaller={false}
-        body="Predictive Customer Intelligence for service businesses. We score every client, lead, and rebooking four times a day, surface the ones about to slip, and recover them before they cool. Live in 14 days, running quietly around the booking system you already use."
-        footnote="Built for massage therapists, dental practices, med spas, salons, estheticians, and HVAC."
-        primaryCta={{ label: "Get Your Free Audit", href: "/book" }}
-        secondaryCta={{ label: "See what you’re losing", href: "/resources/revenue-calculator" }}
+        body="Ops by Noell finds the clients, leads, and rebookings your front desk is about to lose, then deploys AI agents that recover the revenue before it leaves your book."
+        footnote="Done for you. Built around the booking and practice management tools you already use. Live in 14 days."
+        primaryCta={{ label: "Get Your Free Revenue Signal Report", href: "/book" }}
+        secondaryCta={{ label: "See How It Works", href: "/predictive-customer-intelligence" }}
         showProofBar={false}
       />
 
@@ -104,32 +110,32 @@ export default function Home() {
       {/* 3. PCI band */}
       <PciBand />
 
-      {/* 4. ProofBar / #live-recovery */}
+      {/* 4. Predictive Customer Intelligence detail (moved up — PCI is the differentiator) */}
+      <PredictiveIntelligence />
+
+      {/* 5. ProofBar / #live-recovery */}
       <section className="w-full flex justify-center px-4 pb-12 md:pb-16">
         <ProofBar />
       </section>
 
-      {/* 5. Pick your path */}
+      {/* 6. Pick your path */}
       <PickYourPath />
 
-      {/* 6. Integration band */}
+      {/* 7. Integration band */}
       <IntegrationBand />
 
-      {/* 7. ROI Calculator */}
+      {/* 8. ROI Calculator */}
       <section className="w-full py-16 px-4">
         <div className="max-w-3xl mx-auto">
           <ROICalculator />
         </div>
       </section>
 
-      {/* 8. Systems. Three agents, tight. */}
+      {/* 9. Systems. Three agents, tight. */}
       <Systems />
 
-      {/* 9. Full system features (kept from prior layout) */}
+      {/* 10. Full system features (kept from prior layout) */}
       <FullSystemFeatures />
-
-      {/* 10. Predictive Customer Intelligence detail */}
-      <PredictiveIntelligence />
 
       {/* 11. Proof. Santa case study block. */}
       <Testimonials />
@@ -140,16 +146,18 @@ export default function Home() {
         eyebrow="Questions"
         headlineStart="Straight"
         headlineAccent="answers."
-        body="Real questions from service business owners before they book a working call."
+        body="Real questions from service business owners before they request a Revenue Signal Report."
       />
 
       {/* 13. Final CTA band */}
       <CTA
         eyebrow="The first step"
-        headlineStart="Start with a"
-        headlineAccent="working call."
-        body="No pitch. No pressure. We walk your front desk and show you where warm intent is cooling off in your business."
-        trustLine="Twenty focused minutes. Personally scheduled."
+        headlineStart="Find the revenue your booking software is"
+        headlineAccent="missing."
+        body="In your free Revenue Signal Report, we map the leaks in your front desk, booking flow, and follow-up system. You will know what is being missed, what it may be worth, and which Ops by Noell track fits."
+        trustLine="No pitch. No pressure. If it is not a fit, we will say so."
+        primaryCta={{ label: "Get Your Free Revenue Signal Report", href: "/book" }}
+        secondaryCta={{ label: "See How PCI Works", href: "/predictive-customer-intelligence" }}
         sourcePage="home"
       />
     </div>

--- a/src/app/predictive-customer-intelligence/page.tsx
+++ b/src/app/predictive-customer-intelligence/page.tsx
@@ -19,12 +19,12 @@ export const metadata = pageMetadata({
   path: PATH,
   title: "Predictive Customer Intelligence for Service Businesses",
   description:
-    "Score every client, lead, and rebooking 4x daily. Surface revenue your booking software misses, then recover it before it cools. Free 30-minute audit.",
+    "Know who is about to ghost before your calendar shows the gap. We watch your leads, clients, rebooking patterns, and service history for revenue signals your booking software does not surface. Get your free Revenue Signal Report.",
   ogTitle: "Predictive Customer Intelligence for Service Businesses",
   ogDescription:
-    "Score every client, lead, and rebooking 4x daily. Recover revenue before it cools. Free audit.",
+    "Know who is about to ghost before your calendar shows the gap. Free Revenue Signal Report.",
   imageAlt:
-    "Predictive Customer Intelligence by Ops by Noell — score every client, lead, and rebooking before revenue walks out the door.",
+    "Predictive Customer Intelligence by Ops by Noell — know who is about to ghost before your calendar shows the gap.",
 });
 
 const SOURCE_PAGE = "predictive-customer-intelligence" as const;
@@ -201,9 +201,15 @@ const pciFaqs: FaqItem[] = [
   },
   {
     id: "pci-no-action",
-    question: "What if I don't act on the audit?",
+    question: "What if I don't act on the Revenue Signal Report?",
     answer:
       "You still walk away with a free, prioritized list of revenue you're leaving on the table. Take it, fix it yourself, and we part as friends.",
+  },
+  {
+    id: "pci-what-do-i-get",
+    question: "What do I get from the free Revenue Signal Report?",
+    answer:
+      "A clear map of where your front desk, booking flow, and follow-up system are leaking revenue, plus the recommended Ops by Noell track for recovering it.",
   },
   {
     id: "pci-cancel",
@@ -282,6 +288,156 @@ function CaseSummaryPanel() {
         </p>
       </div>
     </div>
+  );
+}
+
+function ComparisonBlock() {
+  const rows: { booking: string; pci: string }[] = [
+    {
+      booking: "A client has not rebooked.",
+      pci: "Which clients are drifting before they disappear.",
+    },
+    {
+      booking: "A lead did not schedule.",
+      pci: "Which dead leads are still warm enough to recover.",
+    },
+    {
+      booking: "A no-show happened.",
+      pci: "Which no-show needs which follow-up sequence.",
+    },
+    {
+      booking: "A service was booked.",
+      pci: "Which service mix signals higher lifetime value.",
+    },
+    {
+      booking: "A calendar has gaps.",
+      pci: "Which recovery action should be queued first.",
+    },
+  ];
+  return (
+    <section className="w-full px-4 py-20 md:py-28 bg-cream-dark/40">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-14 max-w-3xl mx-auto">
+          <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+            Booking software vs. PCI
+          </p>
+          <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+            Your booking software tells you what happened.{" "}
+            <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+              PCI tells you what to do next.
+            </span>
+          </h2>
+        </div>
+
+        <div className="rounded-[22px] border border-warm-border bg-white overflow-hidden shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]">
+          <div className="grid grid-cols-1 md:grid-cols-2 border-b border-warm-border bg-cream/60">
+            <div className="px-6 py-4 md:px-8">
+              <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-charcoal/70">
+                Your booking software shows
+              </p>
+            </div>
+            <div className="px-6 py-4 md:px-8 border-t md:border-t-0 md:border-l border-warm-border">
+              <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-wine">
+                Predictive Customer Intelligence catches
+              </p>
+            </div>
+          </div>
+          <ul className="divide-y divide-warm-border">
+            {rows.map((r) => (
+              <li
+                key={r.booking}
+                className="grid grid-cols-1 md:grid-cols-2"
+              >
+                <div className="px-6 py-5 md:px-8 text-charcoal/75 leading-relaxed">
+                  {r.booking}
+                </div>
+                <div className="px-6 py-5 md:px-8 border-t md:border-t-0 md:border-l border-warm-border text-charcoal leading-relaxed">
+                  {r.pci}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SampleSignalModule() {
+  const fields: { label: string; value: string }[] = [
+    { label: "Client", value: "Marina D." },
+    { label: "Signal", value: "Ghost-risk" },
+    { label: "Score", value: "87 / 100" },
+    { label: "Pattern", value: "Monthly client · last visit 41 days ago" },
+    { label: "Recommended action", value: "Send warm rebooking text" },
+    { label: "Agent", value: "Noell Care" },
+    { label: "Owner control", value: "One-click approval" },
+    { label: "Expected recovery", value: "$240 appointment" },
+  ];
+  return (
+    <section
+      id="sample-signal"
+      className="w-full px-4 py-20 md:py-28 scroll-mt-24"
+    >
+      <div className="max-w-5xl mx-auto">
+        <div className="text-center mb-12 max-w-3xl mx-auto">
+          <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+            Sample Revenue Signal
+          </p>
+          <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+            Marina is three days past her usual{" "}
+            <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+              cadence.
+            </span>
+          </h2>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-5 gap-6 items-start">
+          <div className="md:col-span-3 rounded-[22px] border border-warm-border bg-white shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)] overflow-hidden">
+            <div className="px-6 py-4 md:px-7 bg-cream/60 border-b border-warm-border flex items-center justify-between">
+              <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-wine">
+                signal · ghost-risk
+              </p>
+              <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-charcoal/70">
+                queued for review
+              </p>
+            </div>
+            <ul className="divide-y divide-warm-border">
+              {fields.map((f) => (
+                <li
+                  key={f.label}
+                  className="grid grid-cols-3 gap-4 px-6 py-4 md:px-7"
+                >
+                  <span className="col-span-1 font-mono text-[10px] uppercase tracking-[0.22em] text-charcoal/70 self-center">
+                    {f.label}
+                  </span>
+                  <span className="col-span-2 text-sm md:text-base text-charcoal leading-relaxed">
+                    {f.value}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="md:col-span-2 rounded-[22px] border border-warm-border bg-cream-dark p-6 md:p-7">
+            <p className="font-serif text-lg md:text-xl text-charcoal leading-snug">
+              The owner does not need another dashboard. The signal appears
+              with the context, recommended message, and next action. Noell
+              Care can queue the outreach, send the approved follow-up, and
+              update the record when the client rebooks.
+            </p>
+            <div className="mt-6">
+              <Button
+                href="/book"
+                variant="primary"
+                className="h-11 px-6"
+              >
+                Show me my revenue signals
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -590,7 +746,7 @@ export default function PredictiveCustomerIntelligencePage() {
           servicePageSchema({
             name: "Predictive Customer Intelligence",
             description:
-              "Score every active client, lead, and rebooking 4x daily. Surface revenue your booking software misses, then queue the outreach that recovers it before demand cools.",
+              "Know who is about to ghost before your calendar shows the gap. Watches leads, clients, rebooking patterns, and service history for revenue signals your booking software does not surface, then queues the right recovery action for your agents.",
             path: PATH,
             serviceType: "Predictive customer intelligence for service businesses",
           }),
@@ -604,21 +760,25 @@ export default function PredictiveCustomerIntelligencePage() {
         ]}
       />
       <Hero
-        eyebrow="A systems agency · Ops by Noell · Intelligence layer"
-        headlineLine1Start="Predictive Customer"
-        headlineLine1Accent="Intelligence"
-        headlineLine2Start="for service businesses."
-        headlineLine2Accent=""
+        eyebrow="Predictive Customer Intelligence · Ops by Noell"
+        headlineLine1Start="Know who is about to"
+        headlineLine1Accent="ghost"
+        headlineLine2Start="before your calendar shows the"
+        headlineLine2Accent="gap."
         headlineLine2Smaller
-        body="We find the revenue your booking software is missing. Then we deploy the agents and the ads that recover it."
-        footnote=""
-        primaryCta={{ label: "Get Your Free Audit", href: "/book" }}
-        secondaryCta={{ label: "See how it works", href: "#how-it-works" }}
+        body="Ops by Noell watches your leads, clients, rebooking patterns, and service history for revenue signals your booking software does not surface. When a signal fires, the right recovery action is queued for your agents."
+        footnote="The same system recovered $960 in 14 days for a solo massage practice in Orange County."
+        primaryCta={{ label: "Get Your Free Revenue Signal Report", href: "/book" }}
+        secondaryCta={{ label: "See a Sample Signal", href: "#sample-signal" }}
         showProofBar={false}
         sourcePage={SOURCE_PAGE}
         sourceSection="hero"
         mockScreen={<PciMockScreen />}
       />
+
+      <ComparisonBlock />
+
+      <SampleSignalModule />
 
       <LiveSystemLog
         eyebrow="case: marina_d  /  signal > ghost-risk > 87"
@@ -641,21 +801,21 @@ export default function PredictiveCustomerIntelligencePage() {
 
       <Testimonials
         eyebrow="Proof"
-        headlineStart="The system that recovered $960 in 14 days for one massage therapist"
-        headlineAccent="runs the same way for you."
-        body="Santa, owner of Healing Hands by Santa, a licensed massage therapist in Laguna Niguel, went from digital patchwork to a system that watched her client patterns, caught her missed calls, and protected her calendar. Inside 14 days, the system had paid for itself."
-        ctaLabel="Book your free audit"
+        headlineStart="The first proof came from a"
+        headlineAccent="solo practice."
+        body="Healing Hands by Santa recovered $960 in 14 days after Ops by Noell caught missed-call and booking-flow leakage. The next step is turning that same recovery logic into Revenue Signal Reports for every service business vertical we serve."
+        ctaLabel="Get your Revenue Signal Report"
         sourcePage={SOURCE_PAGE}
         sourceSection="proof"
       />
 
       <CTA
         eyebrow="The first step"
-        headlineStart="Start with a"
-        headlineAccent="free 30-minute audit."
-        body="No pitch. No pressure. A clear map of where leads, clients, and rebookings are falling through, whether you work with us or not."
-        trustLine="Free · 30 minutes · Live in 14 days"
-        primaryCta={{ label: "Get Your Free Audit", href: "/book" }}
+        headlineStart="Find the revenue before it"
+        headlineAccent="leaves."
+        body="Your first Revenue Signal Report shows what your booking software is not telling you yet. No pitch. No pressure. If it is not a fit, we will say so."
+        trustLine="Free · Reviewed personally · Reply within one business day"
+        primaryCta={{ label: "Get Your Free Revenue Signal Report", href: "/book" }}
         secondaryCta={null}
         sourcePage={SOURCE_PAGE}
         sourceSection="offer"
@@ -675,9 +835,9 @@ export default function PredictiveCustomerIntelligencePage() {
         eyebrow=""
         headlineStart="The revenue is"
         headlineAccent="already yours."
-        body="Spend 30 minutes. Get the map of what's leaking. Decide what's next from there."
+        body="Spend a few minutes. Get the map of what's leaking. Decide what's next from there."
         trustLine=""
-        primaryCta={{ label: "Get Your Free Audit", href: "/book" }}
+        primaryCta={{ label: "Get Your Free Revenue Signal Report", href: "/book" }}
         secondaryCta={null}
         sourcePage={SOURCE_PAGE}
         sourceSection="final"

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -202,13 +202,15 @@ export default function PricingPage() {
           Pricing
         </p>
         <h1 className="relative z-20 max-w-4xl text-center font-serif text-3xl md:text-5xl lg:text-6xl font-semibold tracking-tight text-charcoal leading-tight">
-          Two tracks.{" "}
+          Two ways to recover the revenue your front desk is{" "}
           <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
-            Pick the one that fits.
+            missing.
           </span>
         </h1>
         <p className="relative z-20 mt-4 max-w-2xl text-center text-charcoal/75 text-sm md:text-base leading-relaxed">
-          Run only the agents, or install the full system end-to-end.
+          Start with the agents if you need coverage fast. Choose the full
+          system if you want Ops by Noell to install and manage the recovery
+          layer end to end.
         </p>
         <p className="relative z-20 mt-3 text-xs text-muted-medium">
           Curious what you could recover?{" "}
@@ -217,6 +219,13 @@ export default function PricingPage() {
             className="underline underline-offset-4 decoration-charcoal/55 hover:text-charcoal"
           >
             Run the ROI calculator
+          </Link>
+          {" · "}
+          <Link
+            href="/predictive-customer-intelligence"
+            className="underline underline-offset-4 decoration-charcoal/55 hover:text-charcoal"
+          >
+            See how PCI works
           </Link>
           .
         </p>

--- a/src/app/what-you-get/page.tsx
+++ b/src/app/what-you-get/page.tsx
@@ -171,19 +171,19 @@ type PricingCard = {
 
 const pricingCards: PricingCard[] = [
   {
-    name: "Starter",
-    body: "Dedicated line, NOELL Front Desk, dashboard, 500 conversations/mo.",
-    bestFor: "Best for solo operators.",
+    name: "Noell Agents",
+    body: "Three AI agents working alongside the booking tool you already use. From $197/mo founding rate.",
+    bestFor: "Best when you need coverage fast without a platform migration.",
   },
   {
     name: "Growth",
-    body: "Everything in Starter + NOELL Care, website chat widget, no-show recovery.",
-    bestFor: "Best for 1–3 person teams.",
+    body: "The full recovery system: operations layer, three agents, no-show recovery, reputation workflows, and Predictive Customer Intelligence signals as they roll out.",
+    bestFor: "Recommended for revenue recovery.",
     highlighted: true,
   },
   {
-    name: "Pro",
-    body: "Everything in Growth + advanced analytics, custom agent training, priority support.",
+    name: "Custom Ops",
+    body: "The full system for multi-location practices and operators running reactivation at scale. Dedicated account manager, custom reporting, and priority support.",
     bestFor: "Best for 4+ teams or multi-location.",
   },
 ];
@@ -264,7 +264,7 @@ export default function WhatYouGetPage() {
             data-source-page="what_you_get"
             data-source-section="hero"
           >
-            Book a 15-min walkthrough &rarr;
+            Get Your Free Revenue Signal Report &rarr;
           </Button>
         </div>
       </section>
@@ -381,7 +381,7 @@ export default function WhatYouGetPage() {
               >
                 {card.highlighted && (
                   <p className="text-[10px] uppercase tracking-[0.22em] text-wine font-medium mb-3">
-                    Most teams start here
+                    Recommended for revenue recovery
                   </p>
                 )}
                 <h3 className="font-serif text-2xl font-semibold text-charcoal mb-3">
@@ -405,10 +405,10 @@ export default function WhatYouGetPage() {
               data-source-page="what_you_get"
               data-source-section="pricing"
             >
-              Start with Starter &rarr;
+              Get Your Free Revenue Signal Report &rarr;
             </Button>
-            <Button href="/book" variant="secondary">
-              Talk to us first &rarr;
+            <Button href="/pricing" variant="secondary">
+              See full pricing &rarr;
             </Button>
           </div>
         </div>
@@ -428,10 +428,10 @@ export default function WhatYouGetPage() {
         eyebrow="The first step"
         headlineStart="Stop missing the next booking"
         headlineAccent="while you're with the current one."
-        body="A 15-minute walkthrough. We show you exactly what gets installed, what it costs, and how fast you'd be live."
-        primaryCta={{ label: "Book a 15-min walkthrough", href: "/book" }}
+        body="Your free Revenue Signal Report maps the leaks in your front desk, booking flow, and follow-up system, and shows what fits."
+        primaryCta={{ label: "Get Your Free Revenue Signal Report", href: "/book" }}
         secondaryCta={{ label: "See full pricing", href: "/pricing" }}
-        trustLine="Done-for-you setup · Live in a week · No contracts"
+        trustLine="Done-for-you setup · Live in 14 days · No contracts"
         sourcePage="what_you_get"
       />
     </div>

--- a/src/components/article-layout.tsx
+++ b/src/components/article-layout.tsx
@@ -48,7 +48,7 @@ export function ArticleLayout({
                   href="/book"
                   className="text-wine font-semibold underline underline-offset-4"
                 >
-                  Book a free 30-minute audit
+                  Get your free Revenue Signal Report
                 </Link>
                 . We&apos;ll map the gaps and show exactly what a Noell install
                 would catch.

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -4,19 +4,21 @@ import { Logo } from "./logo";
 export function Footer() {
   const pages = [
     { title: "Home", href: "/" },
+    { title: "Predictive Customer Intelligence", href: "/predictive-customer-intelligence" },
     { title: "Systems", href: "/systems" },
     { title: "Verticals", href: "/verticals" },
     { title: "Pricing", href: "/pricing" },
     { title: "ROI calculator", href: "/roi" },
     { title: "Resources", href: "/resources" },
-    { title: "Book", href: "/book" },
+    { title: "Revenue Signal Report", href: "/book" },
   ];
 
   const products = [
     { title: "Noell Support", href: "/noell-support" },
     { title: "Noell Front Desk", href: "/noell-front-desk" },
     { title: "Noell Care", href: "/noell-care" },
-    { title: "Book an Audit", href: "/book" },
+    { title: "Predictive Customer Intelligence", href: "/predictive-customer-intelligence" },
+    { title: "Revenue Signal Report", href: "/book" },
   ];
 
   const verticals = [

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -34,12 +34,13 @@ interface NavbarProps {
 export const Navbar = () => {
   const navItems = [
     { name: "Home", link: "/" },
+    { name: "PCI", link: "/predictive-customer-intelligence" },
     { name: "Systems", link: "/systems" },
-    { name: "About", link: "/about" },
     { name: "Verticals", link: "/verticals" },
     { name: "Agents", link: "/agents" },
     { name: "What You Get", link: "/what-you-get" },
     { name: "Pricing", link: "/pricing" },
+    { name: "About", link: "/about" },
     { name: "Noell Support", link: "/noell-support", isAccent: true },
     { name: "Book", link: "/book" },
   ];
@@ -241,11 +242,11 @@ const DesktopNav = ({ navItems, visible }: NavbarProps) => {
               onClick={() =>
                 trackAuditCtaClick("navbar", "navbar_primary", {
                   destination: "/book",
-                  cta_label: "Get Your Free Audit",
+                  cta_label: "Free Revenue Signal Report",
                 })
               }
             >
-              Get Your Free Audit
+              Free Revenue Signal Report
             </Button>
           </motion.div>
         )}
@@ -343,11 +344,11 @@ const MobileNav = ({ navItems, visible }: NavbarProps) => {
               onClick={() =>
                 trackAuditCtaClick("navbar", "navbar_mobile", {
                   destination: "/book",
-                  cta_label: "Get Your Free Audit",
+                  cta_label: "Free Revenue Signal Report",
                 })
               }
             >
-              Get Your Free Audit
+              Free Revenue Signal Report
             </Button>
           </motion.div>
         )}

--- a/src/components/noell-agents-card.tsx
+++ b/src/components/noell-agents-card.tsx
@@ -39,6 +39,10 @@ export function NoellAgentsCard() {
             Three AI agents. No platform migration. Works on top of what you
             have.
           </p>
+          <p className="mt-2 text-sm text-charcoal/75 leading-relaxed max-w-2xl">
+            Best when you already like your booking tool and need calls, chat,
+            and client support covered without a platform migration.
+          </p>
 
           <div className="mt-8 grid grid-cols-1 md:grid-cols-[auto_1fr] gap-6 md:gap-10 items-start">
             {/* Price block */}
@@ -95,15 +99,15 @@ export function NoellAgentsCard() {
           </div>
 
           <p className="mt-8 pt-6 border-t border-warm-border text-sm italic text-muted-strong leading-relaxed max-w-3xl">
-            No platform migration, no PMS integration, no managed install, no
-            reactivation campaigns. For that, see{" "}
+            Need PMS integration, reactivation, or Predictive Customer
+            Intelligence? Start with{" "}
             <Link
               href="#noell-system"
               className="text-wine hover:text-wine-dark underline underline-offset-4 decoration-wine/30"
             >
-              The Noell System
+              Growth
             </Link>{" "}
-            below.
+            instead.
           </p>
         </div>
       </div>

--- a/src/components/pricing.tsx
+++ b/src/components/pricing.tsx
@@ -53,7 +53,7 @@ export function PricingCard({
               </h3>
               {tier.isHighlighted && (
                 <span className="text-[10px] font-mono uppercase tracking-widest text-wine">
-                  most popular
+                  recommended
                 </span>
               )}
             </div>
@@ -111,9 +111,16 @@ export function PricingCard({
     >
       <div className="space-y-6 p-5 bg-cream rounded-[28px] shadow-[0px_95px_27px_0px_rgba(28,25,23,0.00),_0px_61px_24px_0px_rgba(28,25,23,0.03),_0px_34px_21px_0px_rgba(28,25,23,0.08),_0px_15px_15px_0px_rgba(28,25,23,0.12),_0px_4px_8px_0px_rgba(28,25,23,0.15)] pb-8 px-5">
         <div className="flex flex-col">
-          <h3 className="text-sm w-fit font-medium text-charcoal rounded-full border border-warm-border bg-white flex justify-center items-center px-4 py-1">
-            {tier.tier}
-          </h3>
+          <div className="flex items-center justify-between gap-2 flex-wrap">
+            <h3 className="text-sm w-fit font-medium text-charcoal rounded-full border border-warm-border bg-white flex justify-center items-center px-4 py-1">
+              {tier.tier}
+            </h3>
+            {tier.isHighlighted && (
+              <span className="inline-flex items-center rounded-full bg-wine text-cream px-3 py-1 text-[10px] font-mono uppercase tracking-[0.18em]">
+                Recommended for revenue recovery
+              </span>
+            )}
+          </div>
           <div className="mt-3 flex items-baseline">
             <span className="font-serif text-4xl font-bold text-charcoal">
               {tier.priceFrom}

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -20,7 +20,7 @@ export const PRICING_TIERS: PricingTier[] = [
     priceFrom: "$197",
     cadence: "/mo",
     tagline:
-      "The operations layer plus SMS-led automations. No AI agents at this tier. Ideal for solo practitioners who want the system running but don't yet need AI handling calls or chat.",
+      "Best when you need the operating layer in place before adding agents. The foundation layer for businesses that are not ready for managed intelligence yet.",
     features: [
       "Operations layer (CRM, booking calendar, forms) under your brand",
       "Missed-call text-back automation",
@@ -30,7 +30,7 @@ export const PRICING_TIERS: PricingTier[] = [
     ],
     ctaLabel: "Start with Essentials",
     ctaHref: "/book",
-    note: "Not included: three AI agents, two-way booking-system integration, no-show recovery, Predictive Customer Intelligence. + $497 one-time setup",
+    note: "Essentials does not include AI agents or PCI. + $497 one-time setup",
   },
   {
     id: "growth",
@@ -38,7 +38,7 @@ export const PRICING_TIERS: PricingTier[] = [
     priceFrom: "$797",
     cadence: "/mo",
     tagline:
-      "The full system. Operations layer plus all three AI agents, installed around your booking system. Built for practices ready to run everything through one layer.",
+      "The full recovery system: operations layer, three agents, no-show recovery, reputation workflows, and Predictive Customer Intelligence signals as they roll out.",
     features: [
       "Everything in Essentials",
       "All three AI agents (Noell Support, Front Desk, Care)",
@@ -50,10 +50,10 @@ export const PRICING_TIERS: PricingTier[] = [
       "Predictive Customer Intelligence signals (rolling in)",
       "Priority support",
     ],
-    ctaLabel: "Get Growth",
+    ctaLabel: "Start with Growth",
     ctaHref: "/book",
     isHighlighted: true,
-    note: "Most popular · + $997 one-time setup",
+    note: "Recommended for revenue recovery · Built for businesses that want to recover missed calls, rebookings, no-shows, and lapsed-client revenue from one managed system. + $997 one-time setup",
   },
   {
     id: "custom_ops",


### PR DESCRIPTION
## Summary

Shifts the site from generic AI front desk positioning to revenue intelligence positioning. The Revenue Signal Report becomes the wedge, PCI becomes the moat, and the agents are presented as the execution layer behind both.

Aligns to the launch checklist at \`ops-by-noell-website-edit-checklist-and-copy.md\`.

### Homepage (\`src/app/page.tsx\`)

- New hero copy: "Your booking software shows what happened. We show who is about to slip away."
- Primary CTA → "Get Your Free Revenue Signal Report"; secondary → "See How It Works" (links to PCI page).
- PCI section moved into the first half of the page (after the Santa proof block + PCI band) so the differentiator does not feel like a later feature.
- Final CTA reframed around the Revenue Signal Report deliverable.
- FAQ updated; new "What is the Revenue Signal Report?" entry.
- Page metadata + OG copy updated.

### PCI page (\`src/app/predictive-customer-intelligence/page.tsx\`)

- Hero rewritten around buyer behavior, not the category label: "Know who is about to ghost before your calendar shows the gap." Adds a Santa proof line.
- New **booking-software-vs-PCI comparison block**.
- New **sample Revenue Signal module** (Marina D., ghost-risk 87/100, $240 expected recovery, queued for Noell Care).
- Mid-page testimonial and end-page CTAs converted to Revenue Signal Report.
- JSON-LD service description aligned with the new copy.
- Two new FAQ entries about the Revenue Signal Report.

### Pricing (\`src/app/pricing/page.tsx\`, \`src/components/pricing.tsx\`, \`src/lib/pricing.ts\`, \`src/components/noell-agents-card.tsx\`)

- Top headline: "Two ways to recover the revenue your front desk is missing."
- Growth tier carries a visible "Recommended for revenue recovery" badge in both full and compact pricing card variants. Tagline + note rewritten around recovery.
- Essentials clarified as the foundation layer (no agents, no PCI).
- Agents card clarifies "Best when you already like your booking tool"; cross-link from agents → Growth and from pricing hero → PCI.

### Booking (\`src/app/book/page.tsx\`)

- Hero reframed: "Get your free Revenue Signal Report."
- New form intro (six quick details).
- "What happens next" → "What happens after you send it" with four explicit steps: review → reply with times → walk through leaks on the call → recommended track if it's a fit.
- Trust line: "We do not chase. We do not add you to a list. If it is not a fit, we will say so."
- Final CTA primary → Revenue Signal Report.

### Case study — Santa E. (\`src/app/case-studies/santa-e/page.tsx\`)

- Adds a "What made the recovery possible" product breakdown after the result, mapping Noell Support, Noell Front Desk, Noell Care, and Predictive Customer Intelligence to what each contributed.

### Navigation + footer (\`src/components/navbar.tsx\`, \`src/components/footer.tsx\`)

- Adds **PCI** to the top nav (kept compact by collapsing About into the same row).
- Footer adds **Revenue Signal Report** under Pages and **Predictive Customer Intelligence** under both Pages and The Noell System.
- Primary nav CTA button label updated to "Free Revenue Signal Report".

### What You Get (\`src/app/what-you-get/page.tsx\`)

- Removes Starter/Growth/Pro naming drift; replaces with Noell Agents / Growth (recommended for revenue recovery) / Custom Ops.
- Hero, pricing, and final CTAs converted to Revenue Signal Report framing.

### Article layout (\`src/components/article-layout.tsx\`)

- Footer CTA on case studies/articles updated to "Get your free Revenue Signal Report".

## QA

- \`npm run build\` — passes (all pages prerendered).
- \`node_modules/.bin/tsc --noEmit\` — no new type errors from changes (pre-existing test-file TS5097 errors unchanged).
- \`npm run lint\` — same 21 problems before and after these edits (pre-existing).
- Spot-checked for prohibited user-facing platform/vendor/reseller/implementation-mechanics language and "five-day" implementation references — none introduced, none present.
- Premium warm neutral / blush editorial brand preserved (no coral, no generic SaaS patterns introduced).

## Test plan

- [ ] Vercel preview renders the homepage hero, sample signal module, and pricing badge correctly on desktop and mobile.
- [ ] Click-through: homepage hero CTA → /book; secondary "See How It Works" → /predictive-customer-intelligence.
- [ ] PCI page comparison table reads cleanly on mobile (single-column stacking).
- [ ] Pricing: Growth tier shows "Recommended for revenue recovery" badge in both full and vertical-page compact views.
- [ ] Book page form still submits correctly (no functional changes to \`BookRequestForm\`).
- [ ] Top nav fits at 1280px without overflow with the new PCI item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)