### PR TITLE
hotfix(metadata): align /pricing and /what-you-get titles with launch positioning

### DIFF
--- a/src/app/predictive-customer-intelligence/page.tsx
+++ b/src/app/predictive-customer-intelligence/page.tsx
@@ -262,7 +262,10 @@ function CaseSummaryPanel() {
           Pattern caught
         </p>
         <p className="text-sm font-medium text-charcoal">Marina D.</p>
-        <p className="font-serif text-3xl font-semibold text-wine mt-2">
+        <p
+          className="font-serif text-3xl font-semibold text-wine mt-2"
+          aria-label="ghost-risk score: 87 out of 100"
+        >
           87 / 100
         </p>
         <p className="text-[11px] text-charcoal/70 mt-1">ghost-risk score</p>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -19,9 +19,9 @@ import {
 
 export const metadata = pageMetadata({
   path: "/pricing",
-  title: "Pricing — AI Front Desk for Service Businesses",
+  title: "Pricing — Revenue Recovery Systems for Service Businesses",
   description:
-    "Two tracks. Noell Agents at $197/mo founding rate, or the full Noell System — Essentials $197, Growth $797, Custom Ops $1,497/mo.",
+    "Pricing for the intelligence layer that recovers revenue your booking software misses. Noell Agents at $197/mo founding rate, or the full Noell System — Essentials $197, Growth $797, Custom Ops $1,497/mo.",
 });
 
 const pricingFaqs: FaqItem[] = [

--- a/src/app/what-you-get/page.tsx
+++ b/src/app/what-you-get/page.tsx
@@ -22,12 +22,12 @@ const PATH = "/what-you-get";
 
 export const metadata = pageMetadata({
   path: PATH,
-  title: "What's Included — Done-for-You AI Front Desk",
+  title: "What's Included — The Ops by Noell Revenue Recovery System",
   description:
-    "A business line that never misses a call, three AI agents in the background, the dashboard that runs your front office, and done-for-you setup.",
-  ogTitle: "Stay focused on the client in front of you. We'll handle the phone.",
+    "Everything inside the revenue recovery system: a business line that never misses a call, three agents working in the background, the dashboard that runs your front office, and done-for-you setup.",
+  ogTitle: "Stay focused on the client in front of you. We'll handle the rest.",
   ogDescription:
-    "An AI front desk that answers your calls, books appointments, and texts customers — without losing the next booking.",
+    "The intelligence layer and agents that recover the revenue your booking software is about to lose — answering calls, booking appointments, and re-engaging clients before they ghost.",
 });
 
 type GetItem = {


### PR DESCRIPTION
## Summary

Tiny, launch-safe metadata hotfix for the two pages that still over-indexed on the generic "AI Front Desk" framing after the relaunch around Predictive Customer Intelligence and the Revenue Signal Report.

- **`/pricing`** title/description: emphasizes pricing for revenue-recovery systems instead of "AI Front Desk for Service Businesses".
- **`/what-you-get`** title/description/OG: reframes around the Ops by Noell revenue recovery system rather than "Done-for-You AI Front Desk".
- **PCI page accessibility nit**: the prominent `87 / 100` ghost-risk score in the case summary panel now has `aria-label="ghost-risk score: 87 out of 100"` so assistive tech announces "out of" instead of "slash". Visible design unchanged.

No other content, copy, or component changes. No vendor / platform / reseller / implementation-mechanics language introduced.

## Testing

- [x] `npm run build` — clean (Next.js production build succeeds, no errors, no new warnings)
- [ ] Spot-check rendered `<title>` for `/pricing` and `/what-you-get` after deploy
- [ ] Verify PCI score reads as "87 out of 100" in a screen reader (VoiceOver / NVDA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)