### PR TITLE
hotfix(seo): canonical-host enforcement for production *.vercel.app aliases

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,5 @@
 /**
- * Next.js 16 Proxy — admin gate.
+ * Next.js 16 Proxy — canonical-host hotfix + admin gate.
  *
  * In Next.js 16 the middleware file convention was renamed to
  * `proxy`. The framework looks for `proxy.ts` at the project root or
@@ -8,12 +8,17 @@
  * warning, but we use the current name.
  *
  * Responsibilities:
- *   1. For `/admin/*` pages (excluding login / accept-invite), require
+ *   1. On production, force the canonical host. Requests reaching the
+ *      production deployment via a non-canonical `*.vercel.app` alias
+ *      are 308-redirected to the same path on www.opsbynoell.com for
+ *      safe methods, and tagged `X-Robots-Tag: noindex, nofollow` for
+ *      everything else so search engines stop indexing legacy aliases.
+ *   2. For `/admin/*` pages (excluding login / accept-invite), require
  *      a valid admin session cookie; otherwise bounce to /admin/login.
- *   2. For `/api/admin/*` API routes (excluding public login/invite/
+ *   3. For `/api/admin/*` API routes (excluding public login/invite/
  *      forgot-password flows), require a valid admin session cookie;
  *      otherwise return 401 JSON.
- *   3. On valid sessions, forward the decoded payload to downstream
+ *   4. On valid sessions, forward the decoded payload to downstream
  *      handlers via `x-admin-*` request headers so they do not need
  *      to re-verify the token on every call.
  *
@@ -25,8 +30,45 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyToken, COOKIE_NAME } from "@/lib/admin-auth";
 
+const CANONICAL_HOST = "www.opsbynoell.com";
+
+function isNonCanonicalProdHost(host: string | null): boolean {
+  if (!host) return false;
+  // Strip an optional port suffix; the host header may include `:443`
+  // on some platforms.
+  const bare = host.split(":")[0].toLowerCase();
+  if (bare === CANONICAL_HOST) return false;
+  // Any *.vercel.app alias attached to the production deployment is
+  // legacy and should not be served as the canonical site. Matches the
+  // known `opsbynoell-marketing-review.vercel.app` alias plus any
+  // future production aliases that get added by mistake.
+  return bare.endsWith(".vercel.app");
+}
+
 export async function proxy(req: NextRequest) {
-  const { pathname } = req.nextUrl;
+  const { pathname, search } = req.nextUrl;
+
+  // -------------------------------------------------------------------
+  // Canonical-host enforcement (production only).
+  // -------------------------------------------------------------------
+  if (process.env.VERCEL_ENV === "production") {
+    const host = req.headers.get("host");
+    if (isNonCanonicalProdHost(host)) {
+      // For safe methods, redirect permanently to the canonical host.
+      // For other methods (POST webhooks, etc.) we don't redirect —
+      // a 308 would be followed by clients but could break non-browser
+      // callers that target a vercel.app URL directly. Tag the response
+      // as noindex so any HTML body still served via that path is not
+      // crawled.
+      if (req.method === "GET" || req.method === "HEAD") {
+        const target = new URL(`https://${CANONICAL_HOST}${pathname}${search}`);
+        return NextResponse.redirect(target, 308);
+      }
+      const passthrough = NextResponse.next();
+      passthrough.headers.set("X-Robots-Tag", "noindex, nofollow");
+      return passthrough;
+    }
+  }
 
   // -------------------------------------------------------------------
   // /admin/* — browser pages
@@ -95,5 +137,9 @@ export async function proxy(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/admin/:path*", "/api/admin/:path*"],
+  // Match all routes except Next.js static assets and image optimizer
+  // output, plus the favicon. The proxy itself dispatches based on
+  // path: canonical-host check applies everywhere, the admin gate
+  // only fires for /admin/* and /api/admin/*.
+  matcher: ["/((?!_next/static|_next/image|favicon\\.ico).*)"],
 };


### PR DESCRIPTION
## Summary

Search Console cleanup found the legacy `opsbynoell-marketing-review.vercel.app` Vercel alias still attached to the current production deployment, serving the live site as `index, follow`. CLI/API removal of the alias was denied. This is a small production-safe hotfix in the Next.js 16 proxy so non-canonical hosts stop competing with `www.opsbynoell.com` in search results.

## What changed

- `src/proxy.ts`
  - On `VERCEL_ENV === "production"` only, detect any `*.vercel.app` host (covers the known `opsbynoell-marketing-review.vercel.app` alias and any future production aliases attached by mistake).
  - For `GET`/`HEAD`, **308 permanent redirect** to the same path + query on `https://www.opsbynoell.com`.
  - For other methods (e.g. POST webhooks), pass through with `X-Robots-Tag: noindex, nofollow` so we never break a webhook that happened to be configured against a vercel.app URL while still telling crawlers not to index any HTML body.
  - The canonical host check sits **before** the existing admin gate; admin auth behavior is unchanged.
- Proxy `matcher` widened from `["/admin/:path*", "/api/admin/:path*"]` to a single regex matcher that excludes `_next/static`, `_next/image`, and `favicon.ico`. The function still dispatches by path internally, so admin-only paths get the same treatment as before.

## What is intentionally NOT changed

- Apex `opsbynoell.com` → `www.opsbynoell.com` is left to the existing Vercel domain config (the brief said don't break it if it's already handled).
- Preview / branch deployments still rely on the existing `VERCEL_ENV !== "production"` noindex from PR #60. Preview/review domains keep their meta `noindex` and PR QA is not affected.
- No metadata changes — `www.opsbynoell.com` canonical / OG / sitemap behavior is untouched.
- No user-facing copy or vendor/platform language added.

## Test plan

- [x] `npm run build` passes; the build log shows `ƒ Proxy (Middleware)` registered, all 50+ routes generated, no errors.
- [ ] After merge + Vercel deploy, hit `https://opsbynoell-marketing-review.vercel.app/` and confirm a 308 to `https://www.opsbynoell.com/`. Repeat for a deep path like `/predictive-customer-intelligence` to confirm the path is preserved.
- [ ] Hit `https://www.opsbynoell.com/` and confirm 200 and no redirect (the canonical path is unaffected).
- [ ] In Search Console, request re-indexing of the canonical homepage and submit a removal for the alias URLs once the redirect is live.

## Risk

Low. Production-only behavior; redirect targets the exact same path on the canonical host. Webhooks keyed on a `*.vercel.app` URL would only see a `noindex` header, not a redirect — body still serves normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)