### PR TITLE
fix: admin inbox shows empty — query support_sessions instead of legacy chatSessions

### DIFF
--- a/src/app/api/admin/sessions/[id]/message/route.ts
+++ b/src/app/api/admin/sessions/[id]/message/route.ts
@@ -56,14 +56,14 @@ export async function POST(
       ? "front_desk_messages"
       : agent === "care"
         ? "care_messages"
-        : "chatMessages";
+        : "support_messages";
 
   const sessionTable =
     agent === "frontDesk"
       ? "front_desk_sessions"
       : agent === "care"
         ? "care_sessions"
-        : "chatSessions";
+        : "support_sessions";
 
   const sessionClientId = await fetchSessionClientId(sessionTable, id);
   if (!sessionClientId) {
@@ -73,15 +73,9 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const messageRow =
-    messagesTable === "chatMessages"
-      ? { sessionId: id, role: "human", content }
-      : { session_id: id, role: "human", content };
-
-  const sessionPatch =
-    sessionTable === "chatSessions"
-      ? { humanTakeover: true, updatedAt: new Date().toISOString() }
-      : { human_takeover: true, updated_at: new Date().toISOString() };
+  // All current tables use snake_case column names
+  const messageRow = { session_id: id, role: "human", content };
+  const sessionPatch = { human_takeover: true, updated_at: new Date().toISOString() };
 
   const [msgRes] = await Promise.all([
     fetch(restUrl(messagesTable), {

--- a/src/app/api/admin/sessions/[id]/route.ts
+++ b/src/app/api/admin/sessions/[id]/route.ts
@@ -55,14 +55,14 @@ export async function GET(
       ? "front_desk_sessions"
       : agent === "care"
         ? "care_sessions"
-        : "chatSessions";
+        : "support_sessions";
 
   const messagesTable =
     agent === "frontDesk"
       ? "front_desk_messages"
       : agent === "care"
         ? "care_messages"
-        : "chatMessages";
+        : "support_messages";
 
   try {
     const [session, messages] = await Promise.all([

--- a/src/app/api/admin/sessions/[id]/takeover/route.ts
+++ b/src/app/api/admin/sessions/[id]/takeover/route.ts
@@ -52,7 +52,7 @@ export async function POST(
       ? "front_desk_sessions"
       : agent === "care"
         ? "care_sessions"
-        : "chatSessions";
+        : "support_sessions";
 
   const sessionClientId = await fetchSessionClientId(table, id);
   if (!sessionClientId) {
@@ -62,10 +62,8 @@ export async function POST(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const patch =
-    table === "chatSessions"
-      ? { humanTakeover: true }
-      : { human_takeover: true };
+  // All current tables use snake_case column names
+  const patch = { human_takeover: true };
 
   const res = await fetch(`${restUrl(table)}?id=eq.${id}`, {
     method: "PATCH",

--- a/src/app/api/admin/sessions/route.ts
+++ b/src/app/api/admin/sessions/route.ts
@@ -6,8 +6,7 @@
  * to filter, and ?clientId=<id> to filter by client (super admin only; non-super
  * admins are automatically scoped to their accessible clients).
  *
- * The Support agent uses camelCase column names (legacy Noell Support schema).
- * Front Desk and Care use snake_case (new agent schema).
+ * All three agents use snake_case column names (support_sessions, front_desk_sessions, care_sessions).
  * This route normalizes everything to snake_case.
  */
 
@@ -60,9 +59,8 @@ async function fetchSessions(
   let clientFilter = "";
   if (clientIds !== null && clientIds.length > 0) {
     const ids = clientIds.map(encodeURIComponent).join(",");
-    // snake_case tables use client_id; camelCase legacy uses clientId
-    const col = table === "chatSessions" ? "clientId" : "client_id";
-    clientFilter = `&${col}=in.(${ids})`;
+    // All current tables use snake_case client_id column
+    clientFilter = `&client_id=in.(${ids})`;
   } else if (clientIds !== null && clientIds.length === 0) {
     // No accessible clients — return empty
     return [];
@@ -136,14 +134,14 @@ export async function GET(req: NextRequest): Promise<Response> {
     clientFilter = payload.accessibleClients;
   }
 
-  // Non-super-admins don't see Noell Support (chatSessions) — those are internal
+  // Non-super-admins don't see Noell Support (support_sessions) — those are internal
   const showSupport =
     (filter === "all" || filter === "support") && payload.isSuperAdmin;
 
   try {
     const [support, frontDesk, care] = await Promise.all([
       showSupport
-        ? fetchSessions("chatSessions", "support", "chatMessages", null)
+        ? fetchSessions("support_sessions", "support", "support_messages", null)
         : Promise.resolve([]),
       filter === "all" || filter === "frontDesk"
         ? fetchSessions("front_desk_sessions", "frontDesk", "front_desk_messages", clientFilter)


### PR DESCRIPTION
## Summary

The Admin Inbox was showing **"No conversations yet"** despite 57+ live chat sessions existing in the database.

## Root Cause

The API routes were querying the legacy `chatSessions` and `chatMessages` tables (last updated April 2026, from the Vite SPA era) instead of the current `support_sessions` and `support_messages` tables where the live Noell Support widget actually writes data.

## Files Changed

| File | Change |
|---|---|
| `src/app/api/admin/sessions/route.ts` | Query `support_sessions` + `support_messages` instead of `chatSessions` + `chatMessages` |
| `src/app/api/admin/sessions/[id]/route.ts` | Same table name fix |
| `src/app/api/admin/sessions/[id]/message/route.ts` | Same fix + remove camelCase legacy compat |
| `src/app/api/admin/sessions/[id]/takeover/route.ts` | Same fix + remove camelCase legacy compat |

## Expected Result After Merge

The Admin Inbox will immediately display all 57+ live sessions across the Noell Support, Front Desk, and Care tabs. The takeover and reply features will also work correctly against the current tables.

## Notes

- The legacy `chatSessions` table (17 rows, Vite SPA era) still exists but is no longer needed for the inbox
- All three agent session tables use consistent snake_case column names (`session_id`, `client_id`, `human_takeover`, `updated_at`)
