### PR TITLE
fix: admin inbox - remove invalid camelCase order columns causing 400 errors

### DIFF
--- a/src/app/api/admin/sessions/route.ts
+++ b/src/app/api/admin/sessions/route.ts
@@ -67,7 +67,7 @@ async function fetchSessions(
   }
 
   const sessRes = await fetch(
-    `${restUrl(table)}?select=*&order=updated_at.desc,updatedAt.desc&limit=200${clientFilter}`,
+    `${restUrl(table)}?select=*&order=updated_at.desc&limit=200${clientFilter}`,
     { headers: supabaseHeaders(), cache: "no-store" }
   );
   if (!sessRes.ok) return [];
@@ -76,7 +76,7 @@ async function fetchSessions(
 
   // Fetch latest message per session
   const msgRes = await fetch(
-    `${restUrl(messagesTable)}?select=session_id,sessionId,content,role,created_at,createdAt&order=created_at.desc,createdAt.desc&limit=400`,
+    `${restUrl(messagesTable)}?select=session_id,content,role,created_at&order=created_at.desc&limit=400`,
     { headers: supabaseHeaders(), cache: "no-store" }
   );
   const allMessages = msgRes.ok


### PR DESCRIPTION
## Root Cause

The `fetchSessions` function in `/api/admin/sessions/route.ts` was using:
```
order=updated_at.desc,updatedAt.desc
```

This causes Supabase PostgREST to return **HTTP 400 Bad Request** because `updatedAt` (camelCase) does not exist as a column in the snake_case session tables (`support_sessions`, `front_desk_sessions`, `care_sessions`).

The route silently returns `[]` on `!sessRes.ok`, so the admin inbox showed "No conversations yet" despite **57+ live sessions** in the database.

## Fix

Removed the invalid `updatedAt.desc` fallback from both the sessions query and the messages query. All current session tables use snake_case columns exclusively.

## Testing

Verified via direct Supabase REST API calls:
- `order=updated_at.desc,updatedAt.desc` → HTTP 400 ❌
- `order=updated_at.desc` → HTTP 200, returns 57 sessions ✅