### PR TITLE
feat: update homepage to serve as audience-routing hub

### DIFF
--- a/src/app/case-studies/page.tsx
+++ b/src/app/case-studies/page.tsx
@@ -1,0 +1,132 @@
+import Link from "next/link";
+import { IconArrowRight, IconChartBar } from "@tabler/icons-react";
+import CTA from "@/components/cta";
+import { JsonLd } from "@/components/json-ld";
+import { pageMetadata } from "@/lib/seo";
+import { breadcrumbSchema, servicePageSchema } from "@/lib/schema";
+
+export const metadata = pageMetadata({
+  path: "/case-studies",
+  title: "Case Studies — Real Results from Ops by Noell Clients",
+  description:
+    "Real numbers from real service businesses. See how Ops by Noell clients have recovered missed revenue, rebooked lost clients, and filled their calendars with done-for-you AI operations.",
+});
+
+const caseStudies = [
+  {
+    href: "/case-studies/santa-e",
+    name: "Santa E. — Massage Therapist",
+    result: "$960 recovered in 14 days",
+    description:
+      "A solo massage therapist in Orange County recovered four missed calls and rebooked them within 14 days of installing a done-for-you AI front desk.",
+    vertical: "Massage Therapy",
+    timeline: "14 days",
+  },
+];
+
+export default function CaseStudiesPage() {
+  return (
+    <div>
+      <JsonLd
+        data={servicePageSchema({
+          name: "Ops by Noell Case Studies",
+          description:
+            "Real results from service businesses using Ops by Noell done-for-you AI operations.",
+          path: "/case-studies",
+        })}
+        id="case-studies-service"
+      />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: "Home", path: "/" },
+          { name: "Case Studies", path: "/case-studies" },
+        ])}
+        id="case-studies-breadcrumb"
+      />
+
+      {/* ─── HERO ─────────────────────────────────────────────────────────── */}
+      <section className="w-full bg-cream pt-32 pb-20 px-4">
+        <div className="max-w-3xl mx-auto text-center">
+          <p className="text-xs uppercase tracking-[0.2em] text-wine/70 font-medium mb-4">
+            Case Studies
+          </p>
+          <h1 className="font-serif text-4xl md:text-5xl text-charcoal leading-tight mb-6">
+            Real numbers from{" "}
+            <em className="italic bg-gradient-to-r from-wine to-wine/70 bg-clip-text text-transparent">
+              real businesses.
+            </em>
+          </h1>
+          <p className="text-charcoal/70 text-lg leading-relaxed max-w-2xl mx-auto">
+            Every case study below is a real client, a real result, and a real
+            timeline. No composites. No projections. Just what happened after
+            Ops by Noell was installed.
+          </p>
+        </div>
+      </section>
+
+      {/* ─── CASE STUDY CARDS ─────────────────────────────────────────────── */}
+      <section className="w-full bg-cream pb-24 px-4">
+        <div className="max-w-3xl mx-auto grid gap-4">
+          {caseStudies.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="group flex items-start justify-between gap-4 p-6 rounded-2xl border border-warm-border bg-white/60 hover:bg-white hover:shadow-[0_4px_20px_-4px_rgba(92,45,62,0.12)] transition-all"
+            >
+              <div className="flex items-start gap-4">
+                <div className="mt-0.5 flex-shrink-0 w-9 h-9 rounded-xl bg-blush flex items-center justify-center">
+                  <IconChartBar size={18} className="text-wine" />
+                </div>
+                <div>
+                  <div className="flex items-center gap-2 mb-1 flex-wrap">
+                    <p className="font-serif text-lg text-charcoal group-hover:text-wine transition-colors leading-snug">
+                      {item.name}
+                    </p>
+                    <span className="text-xs uppercase tracking-widest text-wine/60 font-medium border border-wine/20 rounded-full px-2 py-0.5">
+                      {item.vertical}
+                    </span>
+                  </div>
+                  <p className="text-sm font-medium text-wine mb-1">
+                    {item.result}
+                  </p>
+                  <p className="text-sm text-charcoal/60 leading-relaxed">
+                    {item.description}
+                  </p>
+                  <p className="text-xs text-charcoal/40 mt-2">
+                    Timeline: {item.timeline}
+                  </p>
+                </div>
+              </div>
+              <IconArrowRight
+                size={18}
+                className="flex-shrink-0 mt-1 text-charcoal/30 group-hover:text-wine transition-colors"
+              />
+            </Link>
+          ))}
+        </div>
+
+        {/* More coming soon note */}
+        <div className="max-w-3xl mx-auto mt-8">
+          <div className="rounded-2xl border border-warm-border bg-blush/30 p-6 text-center">
+            <p className="text-sm text-charcoal/60">
+              More case studies are being documented as clients complete their
+              first 30 days. Check back soon.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ─── CTA ──────────────────────────────────────────────────────────── */}
+      <CTA
+        eyebrow="The first step"
+        headlineStart="Find the revenue your booking software is"
+        headlineAccent="missing."
+        body="In your free Revenue Signal Report, we map the leaks in your front desk, booking flow, and follow-up system. You will know what is being missed, what it may be worth, and which Ops by Noell track fits."
+        trustLine="No pitch. No pressure. If it is not a fit, we will say so."
+        primaryCta={{ label: "Get Your Free Revenue Signal Report", href: "/book" }}
+        secondaryCta={{ label: "Read the Santa E. Case Study", href: "/case-studies/santa-e" }}
+        sourcePage="case_studies"
+      />
+    </div>
+  );
+}

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,0 +1,141 @@
+import Link from "next/link";
+import {
+  IconArrowRight,
+  IconScale,
+} from "@tabler/icons-react";
+import CTA from "@/components/cta";
+import { JsonLd } from "@/components/json-ld";
+import { pageMetadata } from "@/lib/seo";
+import { breadcrumbSchema, servicePageSchema } from "@/lib/schema";
+
+export const metadata = pageMetadata({
+  path: "/compare",
+  title: "Compare Ops by Noell — vs. My AI Front Desk, Podium, DIY AI, and More",
+  description:
+    "Side-by-side comparisons of Ops by Noell against the most common alternatives for service businesses. See how setup model, voice fit, retention, and ongoing management stack up.",
+});
+
+const comparisons = [
+  {
+    href: "/compare/my-ai-front-desk",
+    name: "Ops by Noell vs. My AI Front Desk",
+    description:
+      "Done-for-you managed operations versus a self-serve AI receptionist platform. Setup model, voice fit, and what happens after go-live.",
+  },
+  {
+    href: "/compare/podium",
+    name: "Ops by Noell vs. Podium",
+    description:
+      "Full-stack AI operations versus a messaging and review platform. What each one actually covers for a service business.",
+  },
+  {
+    href: "/compare/diy-ai-receptionist",
+    name: "Ops by Noell vs. DIY AI Receptionist",
+    description:
+      "Managed installation versus building and maintaining your own AI front desk. Time cost, voice quality, and ongoing tuning.",
+  },
+  {
+    href: "/compare/human-answering-services",
+    name: "Ops by Noell vs. Human Answering Services",
+    description:
+      "AI-powered operations versus a live answering service. Speed, consistency, cost, and what happens at 11 PM on a Sunday.",
+  },
+  {
+    href: "/compare/local-business-messaging-platforms",
+    name: "Ops by Noell vs. Local Business Messaging Platforms",
+    description:
+      "Done-for-you AI operations versus a self-managed messaging tool. Coverage, retention, and what requires your attention.",
+  },
+  {
+    href: "/compare/ai-front-desk-alternatives",
+    name: "AI Front Desk Alternatives — Full Comparison",
+    description:
+      "A complete look at the AI front desk landscape for service businesses. What to look for, what to avoid, and how Ops by Noell fits.",
+  },
+];
+
+export default function ComparePage() {
+  return (
+    <div>
+      <JsonLd
+        data={servicePageSchema({
+          name: "Compare Ops by Noell",
+          description:
+            "Side-by-side comparisons of Ops by Noell against the most common alternatives for service businesses.",
+          path: "/compare",
+        })}
+        id="compare-service"
+      />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: "Home", path: "/" },
+          { name: "Compare", path: "/compare" },
+        ])}
+        id="compare-breadcrumb"
+      />
+
+      {/* ─── HERO ─────────────────────────────────────────────────────────── */}
+      <section className="w-full bg-cream pt-32 pb-20 px-4">
+        <div className="max-w-3xl mx-auto text-center">
+          <p className="text-xs uppercase tracking-[0.2em] text-wine/70 font-medium mb-4">
+            Comparisons
+          </p>
+          <h1 className="font-serif text-4xl md:text-5xl text-charcoal leading-tight mb-6">
+            How Ops by Noell compares to{" "}
+            <em className="italic bg-gradient-to-r from-wine to-wine/70 bg-clip-text text-transparent">
+              the alternatives.
+            </em>
+          </h1>
+          <p className="text-charcoal/70 text-lg leading-relaxed max-w-2xl mx-auto">
+            Every comparison below is written for service business owners who are
+            evaluating their options honestly. No hype. Just what each tool
+            actually covers, what it leaves out, and where Ops by Noell fits.
+          </p>
+        </div>
+      </section>
+
+      {/* ─── COMPARISON CARDS ─────────────────────────────────────────────── */}
+      <section className="w-full bg-cream pb-24 px-4">
+        <div className="max-w-3xl mx-auto grid gap-4">
+          {comparisons.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="group flex items-start justify-between gap-4 p-6 rounded-2xl border border-warm-border bg-white/60 hover:bg-white hover:shadow-[0_4px_20px_-4px_rgba(92,45,62,0.12)] transition-all"
+            >
+              <div className="flex items-start gap-4">
+                <div className="mt-0.5 flex-shrink-0 w-9 h-9 rounded-xl bg-blush flex items-center justify-center">
+                  <IconScale size={18} className="text-wine" />
+                </div>
+                <div>
+                  <p className="font-serif text-lg text-charcoal group-hover:text-wine transition-colors leading-snug mb-1">
+                    {item.name}
+                  </p>
+                  <p className="text-sm text-charcoal/60 leading-relaxed">
+                    {item.description}
+                  </p>
+                </div>
+              </div>
+              <IconArrowRight
+                size={18}
+                className="flex-shrink-0 mt-1 text-charcoal/30 group-hover:text-wine transition-colors"
+              />
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* ─── CTA ──────────────────────────────────────────────────────────── */}
+      <CTA
+        eyebrow="The first step"
+        headlineStart="Find the revenue your booking software is"
+        headlineAccent="missing."
+        body="In your free Revenue Signal Report, we map the leaks in your front desk, booking flow, and follow-up system. You will know what is being missed, what it may be worth, and which Ops by Noell track fits."
+        trustLine="No pitch. No pressure. If it is not a fit, we will say so."
+        primaryCta={{ label: "Get Your Free Revenue Signal Report", href: "/book" }}
+        secondaryCta={{ label: "See Pricing", href: "/pricing" }}
+        sourcePage="compare_index"
+      />
+    </div>
+  );
+}

--- a/src/app/for-b2b/page.tsx
+++ b/src/app/for-b2b/page.tsx
@@ -1,0 +1,424 @@
+import Link from "next/link";
+import {
+  IconBuildingSkyscraper,
+  IconChartBar,
+  IconShieldCheck,
+  IconCheck,
+} from "@tabler/icons-react";
+import { Hero } from "@/components/hero";
+import { FAQ, type FaqItem } from "@/components/faq";
+import CTA from "@/components/cta";
+import { Button } from "@/components/button";
+import { JsonLd } from "@/components/json-ld";
+import { pageMetadata } from "@/lib/seo";
+import { breadcrumbSchema, faqPageSchema, servicePageSchema } from "@/lib/schema";
+import { cn } from "@/lib/utils";
+
+export const metadata = pageMetadata({
+  path: "/for-b2b",
+  title: "AI-Optimized Digital Operations for B2B and Enterprise",
+  description:
+    "You win in boardrooms. Ops by Noell makes sure you do not lose on the internet. Predictive customer intelligence, AI-optimized GTM strategy, and digital presence architecture for B2B companies selling into enterprise accounts.",
+  ogTitle: "You win in boardrooms. We make sure you do not lose on the internet.",
+  ogDescription:
+    "Predictive customer intelligence, AI-optimized GTM, and enterprise-grade digital presence for B2B companies. The gap between your pitch and your website is costing you deals.",
+});
+
+type TrustSignal = {
+  icon: React.ReactNode;
+  tag: string;
+  title: string;
+  body: string;
+};
+
+const trustSignals: TrustSignal[] = [
+  {
+    icon: <IconBuildingSkyscraper size={20} />,
+    tag: "The seven-second window",
+    title: "The procurement team left the meeting and visited your site.",
+    body: "Your pitch landed. The champion is sold. Then the buying committee does their own research. They visit your site. In seven seconds, the trust you built in the boardroom either holds or collapses. Most B2B sites fail this test.",
+  },
+  {
+    icon: <IconChartBar size={20} />,
+    tag: "Consumer-grade copy",
+    title: "Your website reads like a startup. Your buyers are enterprise.",
+    body: "Enterprise buyers are not reading your homepage for inspiration. They are looking for proof of operational maturity, security posture, and implementation credibility. If your copy sounds like a product hunt launch, you are losing deals you never knew you were in.",
+  },
+  {
+    icon: <IconShieldCheck size={20} />,
+    tag: "Missing proof layer",
+    title: "You have case studies. They are buried on page four.",
+    body: "The proof exists. The results are real. But the architecture of your site does not surface it at the moment the buyer needs it. The trust signal arrives too late, or not at all. That is a structural problem, not a content problem.",
+  },
+];
+
+type SystemCard = {
+  eyebrow: string;
+  title: string;
+  description: string;
+  bullets: string[];
+};
+
+const systems: SystemCard[] = [
+  {
+    eyebrow: "Predictive Customer Intelligence",
+    title: "Know who is about to move before they do.",
+    description:
+      "PCI reads every signal in your pipeline, from engagement patterns to buying committee behavior, and surfaces the accounts most likely to close, expand, or churn before your team notices the shift. Not a dashboard. An operational layer that tells your team what to do next.",
+    bullets: [
+      "Account-level signal monitoring",
+      "Buying committee engagement tracking",
+      "Churn and expansion prediction",
+      "Actionable next-step surfacing",
+    ],
+  },
+  {
+    eyebrow: "AI-Optimized GTM Strategy",
+    title: "A go-to-market motion built for how enterprise buyers actually buy.",
+    description:
+      "Enterprise buying is not linear. It involves multiple stakeholders, long timelines, and trust signals that most GTM strategies ignore. We build the operational layer that maps your motion to how procurement actually works, not how you wish it did.",
+    bullets: [
+      "Buying committee mapping and sequencing",
+      "Trust signal architecture by stage",
+      "Content and proof layer alignment",
+      "Outbound and inbound motion design",
+    ],
+  },
+  {
+    eyebrow: "Digital Presence Architecture",
+    title: "A site that holds up when procurement does their research.",
+    description:
+      "We rebuild the structural layer of your digital presence so that every page, every proof point, and every trust signal is positioned for the enterprise buyer who is evaluating you without your sales team in the room. Built to survive the seven-second test.",
+    bullets: [
+      "Enterprise-grade site architecture",
+      "Proof layer positioning and sequencing",
+      "Security and compliance trust signals",
+      "Buyer-stage content mapping",
+    ],
+  },
+];
+
+const processSteps = [
+  {
+    number: "01",
+    title: "Digital Readiness Review",
+    description:
+      "A 30-minute working session. We audit your current digital presence against the enterprise buyer journey, identify the specific gaps that are costing you deals, and tell you exactly what we found. No pitch. No deck.",
+  },
+  {
+    number: "02",
+    title: "Strategic Brief",
+    description:
+      "We deliver a written brief that maps every finding to a deal outcome. You know what is broken, what it is costing you in pipeline, and what the fix looks like before any work begins.",
+  },
+  {
+    number: "03",
+    title: "System Build",
+    description:
+      "We build the infrastructure. Site architecture, proof layer, PCI integration, and GTM motion designed around your buyer and your growth stage. Built by our team, not templated.",
+  },
+  {
+    number: "04",
+    title: "Ongoing Operations",
+    description:
+      "We run it. Signal monitoring, content updates, GTM iteration, and account management handled by our team. The system keeps working while your team closes deals.",
+  },
+];
+
+const b2bFaqs: FaqItem[] = [
+  {
+    id: "b2b_who_is_this_for",
+    question: "What types of B2B companies do you work with?",
+    answer:
+      "We work with SaaS companies, AI vendors, tech startups, and B2B platforms that are selling into enterprise accounts. If you have a strong product and a strong pitch but your digital presence is not keeping up with your sales motion, we are a fit.",
+  },
+  {
+    id: "b2b_pci",
+    question: "What is Predictive Customer Intelligence?",
+    answer:
+      "PCI is the signal layer we build on top of your existing data. It reads engagement patterns, buying committee behavior, and account signals to surface who is most likely to close, expand, or churn before your team notices the shift. It is not a dashboard you check. It is an operational layer that tells your team what to do next.",
+  },
+  {
+    id: "b2b_timeline",
+    question: "How long does it take to see results?",
+    answer:
+      "The Digital Readiness Review is 30 minutes and produces immediate findings. The Strategic Brief is delivered within five business days. System build timelines vary by scope, but most initial implementations are live within 30 days of signing.",
+  },
+  {
+    id: "b2b_existing_stack",
+    question: "Do you work with our existing CRM and marketing stack?",
+    answer:
+      "Yes. We build around the tools you already use. PCI layers on top of your CRM. The GTM motion is designed around your existing sales process. We do not require you to replace anything to get started.",
+  },
+  {
+    id: "b2b_proof",
+    question: "Do you have B2B case studies?",
+    answer:
+      "Our current flagship B2B implementation is running inside a live enterprise sales operation. We use it as a live proof of concept in every sales conversation. We will show you exactly how it works on the Digital Readiness Review call.",
+  },
+  {
+    id: "b2b_pricing",
+    question: "How is this priced?",
+    answer:
+      "B2B and enterprise engagements are scoped individually. We discuss fit, scope, and pricing on the Digital Readiness Review call. There is no standard package because enterprise buyers have different needs. We will tell you exactly what we would build and what it costs before you commit to anything.",
+  },
+];
+
+export default function ForB2BPage() {
+  return (
+    <div>
+      <JsonLd
+        data={servicePageSchema({
+          name: "Ops by Noell for B2B and Enterprise",
+          description:
+            "Predictive customer intelligence, AI-optimized GTM strategy, and digital presence architecture for B2B companies selling into enterprise accounts.",
+          path: "/for-b2b",
+        })}
+        id="b2b-service"
+      />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: "Home", path: "/" },
+          { name: "For B2B and Enterprise", path: "/for-b2b" },
+        ])}
+        id="b2b-breadcrumb"
+      />
+      <JsonLd
+        data={faqPageSchema(b2bFaqs)}
+        id="b2b-faq"
+      />
+
+      {/* ─── 1. HERO ──────────────────────────────────────────────────────── */}
+      <Hero
+        headlineLine1Start="You win in boardrooms."
+        headlineLine1Accent=""
+        headlineLine2Start="We make sure you do not lose"
+        headlineLine2Accent="on the internet."
+        headlineLine2Smaller={false}
+        body="Enterprise buyers leave the meeting and do their own research. In seven seconds, the trust you built in the boardroom either holds or collapses. Ops by Noell builds the operational layer that makes sure it holds."
+        footnote="Predictive Customer Intelligence. AI-Optimized GTM. Digital Presence Architecture."
+        primaryCta={{ label: "Book a Digital Readiness Review", href: "/book" }}
+        secondaryCta={{ label: "See How PCI Works", href: "/predictive-customer-intelligence" }}
+        showProofBar={false}
+        variant="wine"
+      />
+
+      {/* ─── 2. THE BOARDROOM DISCONNECT ──────────────────────────────────── */}
+      <section className="w-full px-4 py-16 md:py-24">
+        <div className="max-w-6xl mx-auto">
+          <div className="text-center mb-14">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-wine font-medium mb-4">
+              The boardroom disconnect
+            </p>
+            <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight max-w-3xl mx-auto">
+              The pitch is excellent.{" "}
+              <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+                The website is not.
+              </span>
+            </h2>
+            <p className="mt-6 text-base md:text-lg text-charcoal/75 max-w-2xl mx-auto leading-relaxed">
+              Enterprise buying committees do not make decisions in the room. They do their own research. Here is where the trust collapses.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {trustSignals.map((signal, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "relative rounded-[22px] bg-white p-7 border border-warm-border",
+                  "shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
+                )}
+              >
+                <div className="flex items-center gap-2 mb-4">
+                  <span className="text-wine">{signal.icon}</span>
+                  <p className="text-[10px] uppercase tracking-[0.2em] text-wine/85 font-medium">
+                    {signal.tag}
+                  </p>
+                </div>
+                <h3 className="font-serif text-lg md:text-xl font-semibold text-charcoal leading-snug mb-3">
+                  {signal.title}
+                </h3>
+                <p className="text-sm text-charcoal/75 leading-relaxed">
+                  {signal.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ─── 3. PCI BAND ──────────────────────────────────────────────────── */}
+      <section className="w-full bg-cream-dark py-16 md:py-20">
+        <div className="mx-auto max-w-3xl px-4 text-center">
+          <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+            Predictive Customer Intelligence
+          </p>
+          <h2 className="font-serif text-3xl md:text-4xl font-semibold text-wine leading-tight">
+            Your pipeline tells you what happened. We tell you what is about to.
+          </h2>
+          <p className="mt-6 text-base md:text-lg text-charcoal/85 leading-relaxed">
+            Every signal in your pipeline, from engagement patterns to buying committee behavior, is data your CRM is not reading. Ops by Noell reads it every day and surfaces the accounts most likely to close, expand, or churn before your team notices the shift. Not a dashboard you check. An operational layer that tells your team what to do next.
+          </p>
+          <p className="mt-8 font-serif italic text-lg md:text-xl text-charcoal">
+            We do not just tell you who is interested. We tell you who is about to go quiet.
+          </p>
+          <div className="mt-10">
+            <Button href="/predictive-customer-intelligence" variant="primary">
+              See How PCI Works
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* ─── 4. THE THREE SYSTEMS ─────────────────────────────────────────── */}
+      <section className="w-full px-4 py-16 md:py-24">
+        <div className="max-w-6xl mx-auto">
+          <div className="text-center mb-14">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-wine font-medium mb-4">
+              What we build
+            </p>
+            <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight max-w-3xl mx-auto">
+              Three systems.{" "}
+              <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+                One enterprise-grade operation.
+              </span>
+            </h2>
+            <p className="mt-6 text-base md:text-lg text-charcoal/75 max-w-2xl mx-auto leading-relaxed">
+              Every B2B engagement is built around three interconnected systems that cover the full enterprise buyer journey, from first signal to closed deal.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {systems.map((system, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "relative flex flex-col rounded-[22px] bg-white p-7 md:p-8 border border-warm-border",
+                  "shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
+                )}
+              >
+                <p className="text-[10px] uppercase tracking-[0.2em] text-wine/85 font-medium mb-2">
+                  {system.eyebrow}
+                </p>
+                <h3 className="font-serif text-xl md:text-2xl font-semibold text-charcoal mb-3 leading-snug">
+                  {system.title}
+                </h3>
+                <p className="text-sm md:text-base text-charcoal/75 leading-relaxed mb-6">
+                  {system.description}
+                </p>
+                <ul className="space-y-2 flex-1">
+                  {system.bullets.map((bullet, j) => (
+                    <li key={j} className="flex items-start gap-2.5">
+                      <IconCheck size={14} className="text-wine shrink-0 mt-0.5" />
+                      <span className="text-sm text-charcoal/80">{bullet}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ─── 5. LIVE PROOF ────────────────────────────────────────────────── */}
+      <section className="w-full px-4 py-14 md:py-16 bg-cream-dark">
+        <div className="mx-auto max-w-2xl">
+          <div className="rounded-[22px] border border-warm-border bg-white p-7 md:p-10 shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+              Live implementation · Premier Tech Sales Inc.
+            </p>
+            <p className="font-serif text-xl md:text-2xl text-charcoal leading-snug mb-5">
+              Our current flagship B2B implementation is running inside a live enterprise sales operation today. We use it as a proof of concept in every sales conversation because it is the most honest demonstration we can offer.
+            </p>
+            <div className="grid grid-cols-3 gap-4 mb-6">
+              <div className="text-center">
+                <p className="font-serif text-3xl md:text-4xl font-semibold text-wine">Live</p>
+                <p className="text-[11px] text-charcoal/70 mt-1 uppercase tracking-wide">production<br />system</p>
+              </div>
+              <div className="text-center">
+                <p className="font-serif text-3xl md:text-4xl font-semibold text-wine">3</p>
+                <p className="text-[11px] text-charcoal/70 mt-1 uppercase tracking-wide">integrated<br />systems</p>
+              </div>
+              <div className="text-center">
+                <p className="font-serif text-3xl md:text-4xl font-semibold text-wine">B2B</p>
+                <p className="text-[11px] text-charcoal/70 mt-1 uppercase tracking-wide">enterprise<br />verified</p>
+              </div>
+            </div>
+            <div className="border-l-2 border-wine/40 pl-4">
+              <p className="text-sm md:text-base text-charcoal/80 italic leading-relaxed">
+                "The site must speak their language. Predictive customer intelligence, AI-optimized GTM, and enterprise-grade operational systems. That is the brief. That is what we built."
+              </p>
+              <footer className="mt-3 text-[11px] uppercase tracking-[0.2em] text-charcoal/80">
+                Nikki Noell · Ops by Noell
+              </footer>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ─── 6. HOW IT STARTS ─────────────────────────────────────────────── */}
+      <section className="w-full px-4 py-16 md:py-24">
+        <div className="max-w-4xl mx-auto">
+          <div className="text-center mb-14">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-wine font-medium mb-4">
+              The process
+            </p>
+            <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+              We do not send proposals.{" "}
+              <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+                We run working sessions.
+              </span>
+            </h2>
+            <p className="mt-6 text-base md:text-lg text-charcoal/75 max-w-xl mx-auto leading-relaxed">
+              Every B2B engagement starts with a Digital Readiness Review. No pitch. No deck. A direct conversation about what is broken and what it is costing you in pipeline.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {processSteps.map((step, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "relative rounded-[22px] bg-white p-7 border border-warm-border",
+                  "shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
+                )}
+              >
+                <p className="font-mono text-[10px] uppercase tracking-[0.25em] text-wine/60 mb-3">
+                  {step.number}
+                </p>
+                <h3 className="font-serif text-xl font-semibold text-charcoal mb-3">
+                  {step.title}
+                </h3>
+                <p className="text-sm md:text-base text-charcoal/75 leading-relaxed">
+                  {step.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ─── 7. FAQ ───────────────────────────────────────────────────────── */}
+      <FAQ
+        faqs={b2bFaqs}
+        eyebrow="Questions"
+        headlineStart="Straight"
+        headlineAccent="answers."
+        body="Real questions from B2B founders and revenue leaders before they book a Digital Readiness Review."
+      />
+
+      {/* ─── 8. CTA ───────────────────────────────────────────────────────── */}
+      <CTA
+        eyebrow="The first step"
+        headlineStart="Let us talk about"
+        headlineAccent="your pipeline."
+        body="In your free Digital Readiness Review, we audit your current digital presence against the enterprise buyer journey, identify the specific gaps costing you deals, and tell you exactly what we found."
+        trustLine="No pitch. No pressure. If it is not a fit, we will say so."
+        primaryCta={{ label: "Book a Digital Readiness Review", href: "/book" }}
+        secondaryCta={{ label: "See How PCI Works", href: "/predictive-customer-intelligence" }}
+        sourcePage="for_b2b"
+      />
+    </div>
+  );
+}

--- a/src/app/for-service-businesses/page.tsx
+++ b/src/app/for-service-businesses/page.tsx
@@ -1,0 +1,403 @@
+import Link from "next/link";
+import {
+  IconCalendarEvent,
+  IconPhoneCall,
+  IconHeartHandshake,
+  IconBolt,
+  IconCheck,
+  IconArrowRight,
+} from "@tabler/icons-react";
+import { Hero } from "@/components/hero";
+import { FAQ, type FaqItem } from "@/components/faq";
+import CTA from "@/components/cta";
+import { JsonLd } from "@/components/json-ld";
+import { pageMetadata } from "@/lib/seo";
+import { breadcrumbSchema, faqPageSchema, servicePageSchema } from "@/lib/schema";
+import { cn } from "@/lib/utils";
+
+export const metadata = pageMetadata({
+  path: "/for-service-businesses",
+  title: "AI Operations for Service-Based Businesses",
+  description:
+    "You deliver exceptional work. Ops by Noell makes sure your digital presence and front desk reflect it. Done-for-you AI operations for consultants, agencies, coaches, and professional service businesses.",
+  ogTitle: "Your work is excellent. Your front desk should say so.",
+  ogDescription:
+    "Done-for-you AI operations for service businesses. Catch every missed call, follow up instantly, and stop losing clients to competitors who just look more polished.",
+});
+
+type SignalCard = {
+  icon: React.ReactNode;
+  tag: string;
+  title: string;
+  body: string;
+};
+
+const signals: SignalCard[] = [
+  {
+    icon: <IconPhoneCall size={20} />,
+    tag: "Missed call",
+    title: "The call went to voicemail. They booked someone else.",
+    body: "A prospect called during a client session. No one answered. No text went out. By the time you saw the missed call, they had already moved on. That is not a lead problem. That is a front desk problem.",
+  },
+  {
+    icon: <IconCalendarEvent size={20} />,
+    tag: "No follow-up",
+    title: "They filled out the form. You never heard from them again.",
+    body: "The inquiry came in on a Saturday. You were with family. By Monday it felt awkward to follow up. They assumed you were not interested. You lost a client you never knew you had.",
+  },
+  {
+    icon: <IconHeartHandshake size={20} />,
+    tag: "Quiet client",
+    title: "A great client stopped booking. You never knew why.",
+    body: "They loved the work. Life got busy. No one reached out. No reminder. No check-in. They found someone else, not because they wanted to, but because no one made it easy to come back.",
+  },
+];
+
+type SystemCard = {
+  eyebrow: string;
+  title: string;
+  description: string;
+  bullets: string[];
+  href: string;
+};
+
+const systems: SystemCard[] = [
+  {
+    eyebrow: "Noell Support",
+    title: "24/7 website chat and lead intake",
+    description:
+      "Every inquiry that lands on your site gets a real response, around the clock. Noell Support qualifies the lead, captures contact information, and routes them to booking or your team. No more Saturday morning inbox surprises.",
+    bullets: [
+      "24/7 website chat coverage",
+      "Lead qualification and contact capture",
+      "Routing to booking or your team",
+      "Trained on your services, pricing, and voice",
+    ],
+    href: "/noell-support",
+  },
+  {
+    eyebrow: "Noell Front Desk",
+    title: "Calls, scheduling, and follow-up",
+    description:
+      "Your phone gets answered. Every time. Noell Front Desk handles inbound calls, books appointments, sends confirmations, and follows up on no-shows. Built around the scheduling tool you already use.",
+    bullets: [
+      "Inbound call answering and booking",
+      "Appointment confirmations and reminders",
+      "Missed-call recovery via SMS",
+      "Works with your existing booking system",
+    ],
+    href: "/noell-front-desk",
+  },
+  {
+    eyebrow: "Noell Care",
+    title: "Existing client retention and rebooking",
+    description:
+      "The clients already in your book are your most valuable asset. Noell Care handles rebooking requests, service questions, and proactive outreach to clients who have gone quiet. Retention on autopilot.",
+    bullets: [
+      "Rebooking requests and scheduling",
+      "Proactive outreach to lapsed clients",
+      "Service and account questions",
+      "Review capture after visits",
+    ],
+    href: "/noell-care",
+  },
+];
+
+const processSteps = [
+  {
+    number: "01",
+    title: "Revenue Signal Report",
+    description:
+      "We start with a free 30-minute working session. We audit your current front desk, identify where leads and revenue are slipping out, and tell you exactly what we found. No pitch. No deck.",
+  },
+  {
+    number: "02",
+    title: "Strategic Brief",
+    description:
+      "We deliver a written brief that maps every finding to a business outcome. You know what is broken, what it is costing you, and what the fix looks like before any work begins.",
+  },
+  {
+    number: "03",
+    title: "System Build",
+    description:
+      "We build and install the system around the tools you already use. Copy written in your voice, integrations wired, agents trained. You approve before anything goes live.",
+  },
+  {
+    number: "04",
+    title: "Ongoing Operations",
+    description:
+      "We run it. Monthly reporting, ongoing tuning, and account management handled by our team. You stay focused on the client in front of you.",
+  },
+];
+
+const serviceFaqs: FaqItem[] = [
+  {
+    id: "sb_who_is_this_for",
+    question: "What types of service businesses do you work with?",
+    answer:
+      "We work with consultants, agencies, coaches, freelancers, and professional service businesses where client relationships are the core of the business. If you deliver exceptional work but your front desk, follow-up, or digital presence is not keeping up, we are a fit.",
+  },
+  {
+    id: "sb_existing_tools",
+    question: "Do I need to replace my current booking or CRM tools?",
+    answer:
+      "No. We build around the tools you already use. The Ops by Noell system layers on top of your existing scheduling, CRM, or practice management software. No migration, no rip-and-replace.",
+  },
+  {
+    id: "sb_timeline",
+    question: "How long until the system is live?",
+    answer:
+      "Most installs are live within 14 days of signing. We handle the setup, copy, integrations, and agent training. You approve before anything goes live.",
+  },
+  {
+    id: "sb_pricing",
+    question: "What does it cost?",
+    answer:
+      "Pricing starts at $197/mo for Noell Agents (self-serve, three AI agents). The full done-for-you Noell System starts at $197/mo and scales based on the scope of your operation. We discuss fit and pricing on the free Revenue Signal Report call.",
+  },
+  {
+    id: "sb_contract",
+    question: "Is there a contract?",
+    answer:
+      "Month-to-month. No long-term contracts. Cancel anytime with 30 days notice. Your rate is locked at the price you signed up at for as long as you stay on that tier.",
+  },
+];
+
+export default function ForServiceBusinessesPage() {
+  return (
+    <div>
+      <JsonLd
+        data={servicePageSchema({
+          name: "Ops by Noell for Service-Based Businesses",
+          description:
+            "Done-for-you AI operations for service businesses. Catch every missed call, follow up instantly, and stop losing clients to competitors who just look more polished.",
+          path: "/for-service-businesses",
+        })}
+        id="sb-service"
+      />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: "Home", path: "/" },
+          { name: "For Service Businesses", path: "/for-service-businesses" },
+        ])}
+        id="sb-breadcrumb"
+      />
+      <JsonLd
+        data={faqPageSchema(serviceFaqs)}
+        id="sb-faq"
+      />
+
+      {/* ─── 1. HERO ──────────────────────────────────────────────────────── */}
+      <Hero
+        headlineLine1Start="Your work is excellent."
+        headlineLine1Accent=""
+        headlineLine2Start="Your front desk should"
+        headlineLine2Accent="say so."
+        headlineLine2Smaller={false}
+        body="You built a service business on the quality of your work. Ops by Noell makes sure your front desk, follow-up, and digital presence reflect that quality, so you stop losing clients to competitors who just look more polished."
+        footnote="Done for you. Built around the tools you already use. Live in 14 days."
+        primaryCta={{ label: "Get Your Free Revenue Signal Report", href: "/book" }}
+        secondaryCta={{ label: "See How It Works", href: "/systems" }}
+        showProofBar={false}
+      />
+
+      {/* ─── 2. THE REAL PROBLEM ──────────────────────────────────────────── */}
+      <section className="w-full px-4 py-16 md:py-24">
+        <div className="max-w-6xl mx-auto">
+          <div className="text-center mb-14">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-wine font-medium mb-4">
+              The quiet revenue leak
+            </p>
+            <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight max-w-3xl mx-auto">
+              You are not losing clients because your work is bad.{" "}
+              <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+                You are losing them between sessions.
+              </span>
+            </h2>
+            <p className="mt-6 text-base md:text-lg text-charcoal/75 max-w-2xl mx-auto leading-relaxed">
+              The gap between delivering excellent work and running a business that captures and retains every client is an operations problem. Here is what it looks like in practice.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {signals.map((signal, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "relative rounded-[22px] bg-white p-7 border border-warm-border",
+                  "shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
+                )}
+              >
+                <div className="flex items-center gap-2 mb-4">
+                  <span className="text-wine">{signal.icon}</span>
+                  <p className="text-[10px] uppercase tracking-[0.2em] text-wine/85 font-medium">
+                    {signal.tag}
+                  </p>
+                </div>
+                <h3 className="font-serif text-lg md:text-xl font-semibold text-charcoal leading-snug mb-3">
+                  {signal.title}
+                </h3>
+                <p className="text-sm text-charcoal/75 leading-relaxed">
+                  {signal.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ─── 3. PROOF BAND ────────────────────────────────────────────────── */}
+      <section className="w-full px-4 py-14 md:py-16 bg-cream-dark">
+        <div className="mx-auto max-w-2xl rounded-[22px] border border-warm-border bg-white p-7 md:p-10 shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]">
+          <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+            Case study · Healing Hands by Santa · Laguna Niguel, CA
+          </p>
+          <p className="font-serif text-xl md:text-2xl text-charcoal leading-snug mb-5">
+            Santa, a licensed massage therapist with 25 years of experience, was losing clients every time she was with a client. Her phone went quiet. No follow-up went out. Clients booked elsewhere.
+          </p>
+          <div className="grid grid-cols-3 gap-4 mb-6">
+            <div className="text-center">
+              <p className="font-serif text-3xl md:text-4xl font-semibold text-wine">4</p>
+              <p className="text-[11px] text-charcoal/70 mt-1 uppercase tracking-wide">missed calls<br />recovered</p>
+            </div>
+            <div className="text-center">
+              <p className="font-serif text-3xl md:text-4xl font-semibold text-wine">$960</p>
+              <p className="text-[11px] text-charcoal/70 mt-1 uppercase tracking-wide">recovered<br />in 14 days</p>
+            </div>
+            <div className="text-center">
+              <p className="font-serif text-3xl md:text-4xl font-semibold text-wine">75%</p>
+              <p className="text-[11px] text-charcoal/70 mt-1 uppercase tracking-wide">fewer<br />no-shows</p>
+            </div>
+          </div>
+          <blockquote className="border-l-2 border-wine/40 pl-4">
+            <p className="text-sm md:text-base text-charcoal/80 italic leading-relaxed">
+              "I used to dread Mondays because there would always be gaps I didn't expect. Now I open my calendar and it's just full. The reminders go out and people show up. I don't think about it anymore."
+            </p>
+            <footer className="mt-3 text-[11px] uppercase tracking-[0.2em] text-charcoal/80">
+              Santa E. · Licensed Massage Therapist · Laguna Niguel CA
+            </footer>
+          </blockquote>
+        </div>
+      </section>
+
+      {/* ─── 4. THE THREE SYSTEMS ─────────────────────────────────────────── */}
+      <section className="w-full px-4 py-16 md:py-24">
+        <div className="max-w-6xl mx-auto">
+          <div className="text-center mb-14">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-wine font-medium mb-4">
+              What we build
+            </p>
+            <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight max-w-3xl mx-auto">
+              Three agents.{" "}
+              <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+                One complete front desk.
+              </span>
+            </h2>
+            <p className="mt-6 text-base md:text-lg text-charcoal/75 max-w-2xl mx-auto leading-relaxed">
+              Every Ops by Noell engagement is built around three AI agents that cover the full client lifecycle, from first contact to retention. Installed and managed by our team.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {systems.map((system, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "relative flex flex-col rounded-[22px] bg-white p-7 md:p-8 border border-warm-border",
+                  "shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
+                )}
+              >
+                <p className="text-[10px] uppercase tracking-[0.2em] text-wine/85 font-medium mb-2">
+                  {system.eyebrow}
+                </p>
+                <h3 className="font-serif text-xl md:text-2xl font-semibold text-charcoal mb-3 leading-snug">
+                  {system.title}
+                </h3>
+                <p className="text-sm md:text-base text-charcoal/75 leading-relaxed mb-6">
+                  {system.description}
+                </p>
+                <ul className="space-y-2 mb-7 flex-1">
+                  {system.bullets.map((bullet, j) => (
+                    <li key={j} className="flex items-start gap-2.5">
+                      <IconCheck size={14} className="text-wine shrink-0 mt-0.5" />
+                      <span className="text-sm text-charcoal/80">{bullet}</span>
+                    </li>
+                  ))}
+                </ul>
+                <Link
+                  href={system.href}
+                  className="inline-flex items-center gap-1.5 text-sm font-medium text-wine hover:text-wine-dark transition-colors"
+                >
+                  Learn more <IconArrowRight size={14} />
+                </Link>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ─── 5. HOW IT STARTS ─────────────────────────────────────────────── */}
+      <section className="w-full px-4 py-16 md:py-24 bg-cream-dark">
+        <div className="max-w-4xl mx-auto">
+          <div className="text-center mb-14">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-wine font-medium mb-4">
+              The process
+            </p>
+            <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+              We do not send proposals.{" "}
+              <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+                We run working sessions.
+              </span>
+            </h2>
+            <p className="mt-6 text-base md:text-lg text-charcoal/75 max-w-xl mx-auto leading-relaxed">
+              Every engagement starts with a free Revenue Signal Report. No pitch. No deck. Just a direct conversation about what is broken and what it is costing you.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {processSteps.map((step, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "relative rounded-[22px] bg-white p-7 border border-warm-border",
+                  "shadow-[0px_34px_21px_0px_rgba(28,25,23,0.04),0px_15px_15px_0px_rgba(28,25,23,0.06),0px_4px_8px_0px_rgba(28,25,23,0.05)]"
+                )}
+              >
+                <p className="font-mono text-[10px] uppercase tracking-[0.25em] text-wine/60 mb-3">
+                  {step.number}
+                </p>
+                <h3 className="font-serif text-xl font-semibold text-charcoal mb-3">
+                  {step.title}
+                </h3>
+                <p className="text-sm md:text-base text-charcoal/75 leading-relaxed">
+                  {step.description}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ─── 6. FAQ ───────────────────────────────────────────────────────── */}
+      <FAQ
+        faqs={serviceFaqs}
+        eyebrow="Questions"
+        headlineStart="Straight"
+        headlineAccent="answers."
+        body="Real questions from service business owners before they request a Revenue Signal Report."
+      />
+
+      {/* ─── 7. CTA ───────────────────────────────────────────────────────── */}
+      <CTA
+        eyebrow="The first step"
+        headlineStart="Find the revenue your front desk is"
+        headlineAccent="missing."
+        body="In your free Revenue Signal Report, we map the leaks in your front desk, booking flow, and follow-up system. You will know what is being missed, what it may be worth, and which Ops by Noell track fits."
+        trustLine="No pitch. No pressure. If it is not a fit, we will say so."
+        primaryCta={{ label: "Get Your Free Revenue Signal Report", href: "/book" }}
+        secondaryCta={{ label: "See Pricing", href: "/pricing" }}
+        sourcePage="for_service_businesses"
+      />
+    </div>
+  );
+}

--- a/src/app/noell-care/page.tsx
+++ b/src/app/noell-care/page.tsx
@@ -151,7 +151,7 @@ export default function NoellCarePage() {
         primaryCta={{ label: "Get Your Free Audit", href: "/book" }}
         secondaryCta={{ label: "See the capabilities", href: "#capabilities" }}
         mockScreen={careScreen}
-        sourcePage="noell-care"
+        sourcePage="noell_care"
       />
 
       <section id="capabilities" className="py-20 md:py-28 px-4">

--- a/src/app/noell-front-desk/page.tsx
+++ b/src/app/noell-front-desk/page.tsx
@@ -198,7 +198,7 @@ export default function NoellFrontDeskPage() {
             </Link>
           </>
         }
-        sourcePage="front-desk"
+        sourcePage="noell_front_desk"
       />
 
       {/* 7 capabilities */}

--- a/src/app/noell-support/page.tsx
+++ b/src/app/noell-support/page.tsx
@@ -199,7 +199,7 @@ export default function NoellSupportPage() {
             </Link>
           </>
         }
-        sourcePage="noell-support"
+        sourcePage="noell_support"
       />
 
       {/* Stats */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Hero } from "@/components/hero";
 import CTA from "@/components/cta";
 import { ROICalculator } from "@/components/roi-calculator";
@@ -18,15 +19,14 @@ import {
 export const metadata = pageMetadata({
   path: "/",
   absoluteTitle: true,
-  title: "Predictive Customer Intelligence for Service Businesses — Ops by Noell",
+  title: "AI Operations for Service Businesses and B2B — Ops by Noell",
   description:
-    "We find the clients, leads, and rebookings your booking software is about to lose, then deploy the agents that recover them. Get your free Revenue Signal Report.",
-  ogTitle: "Ops by Noell — Predictive Customer Intelligence for Service Businesses",
+    "Ops by Noell builds and runs AI-powered operational systems for service-based businesses and B2B companies. Done for you. Live in 14 days.",
+  ogTitle: "Ops by Noell — AI Operations for Service Businesses and B2B",
   ogDescription:
-    "$960 recovered in 14 days. The intelligence layer that catches revenue your booking software misses. Free Revenue Signal Report.",
+    "Whether you run a service business or sell into enterprise, Ops by Noell builds the operational layer that keeps revenue from slipping out. Free audit to start.",
 });
 
-// Three questions that kill the three most common objections before the CTA.
 const homepageFaqs: FaqItem[] = [
   {
     id: "is-this-a-sales-pitch",
@@ -44,7 +44,7 @@ const homepageFaqs: FaqItem[] = [
     id: "who-is-this-for",
     question: "Who is this for?",
     answer:
-      "Dental practices, med spas, salons, massage therapists, estheticians, and HVAC companies. Solo operators and small teams whose front desk has gone quiet while the owner is with a client.",
+      "Service businesses including dental practices, med spas, salons, massage therapists, and HVAC companies, as well as B2B companies including SaaS, AI vendors, and tech startups selling into enterprise accounts.",
   },
 ];
 
@@ -53,9 +53,9 @@ export default function Home() {
     <div>
       <JsonLd
         data={servicePageSchema({
-          name: "The Ops by Noell AI front desk",
+          name: "Ops by Noell AI Operations",
           description:
-            "The done-for-you AI front desk for local service businesses. Built, installed, and managed around the booking system you already use, so missed calls, consults, reminders, reviews, and reactivation keep moving.",
+            "Done-for-you AI operational systems for service businesses and B2B companies. Built, installed, and managed by our team.",
           path: "/",
         })}
         id="home-service"
@@ -70,34 +70,125 @@ export default function Home() {
       />
 
       {/* ─── 1. HOOK ─────────────────────────────────────────────────────────
-          One headline. One body line. One CTA. The visitor decides in 5 sec.
+          Brand-level headline. Speaks to both audiences.
       ─────────────────────────────────────────────────────────────────────── */}
       <Hero
-        headlineLine1Start="Your booking software shows what happened."
+        headlineLine1Start="The operations layer your business"
         headlineLine1Accent=""
-        headlineLine2Start="We show who is about to"
-        headlineLine2Accent="slip away."
+        headlineLine2Start="is"
+        headlineLine2Accent="missing."
         headlineLine2Smaller={false}
-        body="Ops by Noell finds the clients, leads, and rebookings your front desk is about to lose, then deploys AI agents that recover the revenue before it leaves your book."
-        footnote="Done for you. Built around the booking and practice management tools you already use. Live in 14 days."
+        body="Ops by Noell builds and runs AI-powered operational systems that catch missed revenue, recover lost clients, and make sure your digital presence holds up when it matters most."
+        footnote="Done for you. Built around the tools you already use. Live in 14 days."
         primaryCta={{ label: "Get Your Free Revenue Signal Report", href: "/book" }}
         secondaryCta={{ label: "See How It Works", href: "/systems" }}
         showProofBar={false}
       />
 
-      {/* ─── 2. PROOF ────────────────────────────────────────────────────────
+      {/* ─── 2. AUDIENCE SPLIT ───────────────────────────────────────────────
+          The moment the visitor self-identifies. Two tracks. Clean routing.
+      ─────────────────────────────────────────────────────────────────────── */}
+      <section className="w-full py-16 md:py-24 px-4">
+        <div className="max-w-5xl mx-auto">
+          <div className="text-center mb-12">
+            <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
+              Who we work with
+            </p>
+            <h2 className="font-serif text-3xl md:text-5xl font-semibold text-charcoal leading-tight">
+              Two types of business.{" "}
+              <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+                One operational standard.
+              </span>
+            </h2>
+            <p className="mt-5 text-charcoal/70 max-w-2xl mx-auto leading-relaxed text-base md:text-lg">
+              Tell us which describes you and we will show you exactly what we build.
+            </p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2 items-stretch">
+            {/* Track 1: Service Businesses */}
+            <Link
+              href="/for-service-businesses"
+              className="group relative flex flex-col rounded-[22px] bg-white p-8 md:p-10 border border-warm-border hover:border-wine/40 transition-all duration-300 shadow-[0px_4px_8px_0px_rgba(28,25,23,0.05),0px_15px_15px_0px_rgba(28,25,23,0.04)] hover:shadow-[0px_8px_24px_0px_rgba(106,44,62,0.12)]"
+            >
+              <p className="text-[11px] uppercase tracking-[0.2em] text-wine/85 mb-3">
+                Track 01
+              </p>
+              <h3 className="font-serif text-2xl md:text-3xl font-semibold text-charcoal mb-4 leading-snug">
+                Service-Based Businesses
+              </h3>
+              <p className="text-charcoal/75 leading-relaxed mb-6 flex-1">
+                Consultants, agencies, coaches, salons, med spas, dental practices, and professional services. You deliver excellent work. We make sure your front desk, follow-up, and client retention reflect that.
+              </p>
+              <ul className="space-y-2.5 mb-8">
+                {[
+                  "Missed-call recovery and front desk automation",
+                  "Client retention and rebooking systems",
+                  "24/7 lead intake and qualification",
+                ].map((item) => (
+                  <li key={item} className="flex items-start gap-2.5 text-sm text-charcoal/80">
+                    <span className="flex-shrink-0 mt-0.5 w-4 h-4 rounded-full bg-wine/10 text-wine flex items-center justify-center text-[10px] font-bold">
+                      ✓
+                    </span>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-auto flex items-center gap-2 text-wine font-medium text-sm group-hover:gap-3 transition-all">
+                See how it works for service businesses
+                <span className="text-base">→</span>
+              </div>
+            </Link>
+
+            {/* Track 2: B2B and Enterprise */}
+            <Link
+              href="/for-b2b"
+              className="group relative flex flex-col rounded-[22px] bg-wine p-8 md:p-10 border border-wine hover:border-wine-dark transition-all duration-300 shadow-[0px_4px_8px_0px_rgba(106,44,62,0.18),0px_15px_15px_0px_rgba(106,44,62,0.12)] hover:shadow-[0px_8px_24px_0px_rgba(106,44,62,0.28)]"
+            >
+              <p className="text-[11px] uppercase tracking-[0.2em] text-cream/60 mb-3">
+                Track 02
+              </p>
+              <h3 className="font-serif text-2xl md:text-3xl font-semibold text-cream mb-4 leading-snug">
+                B2B and Enterprise
+              </h3>
+              <p className="text-cream/80 leading-relaxed mb-6 flex-1">
+                SaaS companies, AI vendors, and tech startups selling into enterprise accounts. You win in boardrooms. We make sure you do not lose on the internet when procurement does their research.
+              </p>
+              <ul className="space-y-2.5 mb-8">
+                {[
+                  "Predictive Customer Intelligence for pipeline signals",
+                  "AI-optimized GTM strategy for enterprise buyers",
+                  "Digital presence architecture that survives the seven-second test",
+                ].map((item) => (
+                  <li key={item} className="flex items-start gap-2.5 text-sm text-cream/85">
+                    <span className="flex-shrink-0 mt-0.5 w-4 h-4 rounded-full bg-cream/20 text-cream flex items-center justify-center text-[10px] font-bold">
+                      ✓
+                    </span>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-auto flex items-center gap-2 text-cream font-medium text-sm group-hover:gap-3 transition-all">
+                See how it works for B2B companies
+                <span className="text-base">→</span>
+              </div>
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ─── 3. PROOF ────────────────────────────────────────────────────────
           Kill skepticism immediately. Real result, real number, real timeline.
       ─────────────────────────────────────────────────────────────────────── */}
       <SantaProofBlock />
 
-      {/* ─── 3. TRUST ────────────────────────────────────────────────────────
+      {/* ─── 4. TRUST ────────────────────────────────────────────────────────
           "A real person built this." Photo + one paragraph. Short.
       ─────────────────────────────────────────────────────────────────────── */}
       <FounderQuote />
 
-      {/* ─── 4. PAIN MADE PERSONAL ───────────────────────────────────────────
+      {/* ─── 5. PAIN MADE PERSONAL ───────────────────────────────────────────
           The ROI calculator. Visitor stops skimming and starts calculating.
-          Moved up — this is the conversion engine, not a footer feature.
       ─────────────────────────────────────────────────────────────────────── */}
       <section id="roi-calculator" className="w-full py-16 px-4">
         <div className="max-w-3xl mx-auto">
@@ -105,32 +196,30 @@ export default function Home() {
         </div>
       </section>
 
-      {/* ─── 5. HOW IT WORKS ─────────────────────────────────────────────────
+      {/* ─── 6. HOW IT WORKS ─────────────────────────────────────────────────
           PCI differentiator band (tight, editorial) + three agents.
-          Together these answer: "okay but what actually happens?"
       ─────────────────────────────────────────────────────────────────────── */}
       <PciBand />
       <Systems />
 
-      {/* ─── 6. REMOVES THE LAST OBJECTION ───────────────────────────────────
-          "Works with the tools I already use." One row. No switching required.
+      {/* ─── 7. REMOVES THE LAST OBJECTION ───────────────────────────────────
+          "Works with the tools I already use."
       ─────────────────────────────────────────────────────────────────────── */}
       <IntegrationBand />
 
-      {/* ─── 7. ONE ACTION + THREE OBJECTION KILLERS ─────────────────────────
-          Three FAQs max. Then the button. End clean.
+      {/* ─── 8. FAQ + CTA ────────────────────────────────────────────────────
+          Three objection killers. Then the button. End clean.
       ─────────────────────────────────────────────────────────────────────── */}
       <FAQ
         faqs={homepageFaqs}
         eyebrow="Questions"
         headlineStart="Straight"
         headlineAccent="answers."
-        body="Real questions from service business owners before they request a Revenue Signal Report."
+        body="Real questions from service business owners and B2B founders before they book their first working session."
       />
-
       <CTA
         eyebrow="The first step"
-        headlineStart="Find the revenue your booking software is"
+        headlineStart="Find out what your operations are"
         headlineAccent="missing."
         body="In your free Revenue Signal Report, we map the leaks in your front desk, booking flow, and follow-up system. You will know what is being missed, what it may be worth, and which Ops by Noell track fits."
         trustLine="No pitch. No pressure. If it is not a fit, we will say so."

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -106,8 +106,13 @@ const entries: Entry[] = [
     lastmod: LAUNCH_FIXES,
   },
 
+  { path: "/case-studies", changeFrequency: "monthly", priority: 0.75, lastmod: TODAY },
   { path: "/case-studies/santa-e", changeFrequency: "monthly", priority: 0.7, lastmod: "2026-04-18" },
 
+  { path: "/for-service-businesses", changeFrequency: "weekly", priority: 0.9, lastmod: TODAY },
+  { path: "/for-b2b", changeFrequency: "weekly", priority: 0.9, lastmod: TODAY },
+
+  { path: "/compare", changeFrequency: "monthly", priority: 0.7, lastmod: TODAY },
   { path: "/compare/my-ai-front-desk", changeFrequency: "monthly", priority: 0.65, lastmod: "2026-04-18" },
   { path: "/compare/podium", changeFrequency: "monthly", priority: 0.65, lastmod: "2026-04-18" },
   { path: "/compare/diy-ai-receptionist", changeFrequency: "monthly", priority: 0.65, lastmod: "2026-04-18" },
@@ -120,8 +125,6 @@ const entries: Entry[] = [
   { path: "/legal/cookies", changeFrequency: "yearly", priority: 0.3, lastmod: "2026-05-02" },
   { path: "/sms-policy", changeFrequency: "yearly", priority: 0.3, lastmod: "2026-05-02" },
 ];
-
-void TODAY;
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return entries.map((e) => ({

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -23,6 +23,12 @@ const SYSTEMS_LINKS = [
   { name: "Pricing", href: "/pricing", description: "Three tiers, plain pricing" },
 ];
 
+// ─── Who We Help links ───────────────────────────────────────────────────────
+const WHO_WE_HELP_LINKS = [
+  { name: "Service Businesses", href: "/for-service-businesses", description: "Consultants, agencies, coaches, and professional services" },
+  { name: "B2B and Enterprise", href: "/for-b2b", description: "SaaS, AI vendors, and tech companies selling to enterprise" },
+];
+
 // ─── Verticals dropdown links ──────────────────────────────────────────────
 const VERTICAL_LINKS = [
   { name: "Dental Offices", href: "/verticals/dental" },
@@ -33,7 +39,7 @@ const VERTICAL_LINKS = [
   { name: "HVAC", href: "/verticals/hvac" },
 ];
 
-type DropdownKey = "systems" | "verticals" | null;
+type DropdownKey = "systems" | "verticals" | "who-we-help" | null;
 
 interface NavbarProps {
   visible: boolean;
@@ -218,6 +224,62 @@ const DesktopNav = ({ visible }: NavbarProps) => {
           </AnimatePresence>
         </div>
 
+        {/* Who We Help dropdown */}
+        <div
+          className="relative"
+          onMouseEnter={() => setOpenDropdown("who-we-help")}
+        >
+          <button
+            type="button"
+            onClick={() =>
+              setOpenDropdown(openDropdown === "who-we-help" ? null : "who-we-help")
+            }
+            className={cn(
+              "flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium transition-colors",
+              openDropdown === "who-we-help"
+                ? "text-wine bg-blush/60"
+                : "text-charcoal/80 hover:text-charcoal hover:bg-cream-dark/60"
+            )}
+          >
+            Who We Help
+            <IconChevronDown
+              size={13}
+              className={cn(
+                "transition-transform duration-200",
+                openDropdown === "who-we-help" ? "rotate-180" : "rotate-0"
+              )}
+            />
+          </button>
+          <AnimatePresence>
+            {openDropdown === "who-we-help" && (
+              <motion.div
+                initial={{ opacity: 0, y: 8, scale: 0.97 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: 8, scale: 0.97 }}
+                transition={{ duration: 0.18, ease: "easeOut" }}
+                onMouseLeave={() => setOpenDropdown(null)}
+                className="absolute top-full left-1/2 -translate-x-1/2 mt-3 w-72 rounded-2xl border border-warm-border bg-cream/98 backdrop-blur-xl shadow-[0_20px_40px_-10px_rgba(28,25,23,0.12)] p-2 z-50"
+              >
+                {WHO_WE_HELP_LINKS.map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    onClick={() => setOpenDropdown(null)}
+                    className="flex flex-col px-3.5 py-2.5 rounded-xl hover:bg-blush/50 transition-colors group"
+                  >
+                    <span className="text-sm font-medium text-charcoal group-hover:text-wine transition-colors">
+                      {link.name}
+                    </span>
+                    <span className="text-[11px] text-charcoal/55 mt-0.5">
+                      {link.description}
+                    </span>
+                  </Link>
+                ))}
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+
         {/* Pricing */}
         <Link
           href="/pricing"
@@ -270,7 +332,7 @@ const MobileNav = ({ visible }: NavbarProps) => {
   const [open, setOpen] = useState(false);
   const [openSection, setOpenSection] = useState<DropdownKey>(null);
 
-  const toggleSection = (key: "systems" | "verticals") => {
+  const toggleSection = (key: "systems" | "verticals" | "who-we-help") => {
     setOpenSection((prev) => (prev === key ? null : key));
   };
 
@@ -431,6 +493,51 @@ const MobileNav = ({ visible }: NavbarProps) => {
                     >
                       All verticals &rarr;
                     </Link>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+
+            {/* Who We Help accordion */}
+            <div className="w-full">
+              <button
+                type="button"
+                onClick={() => toggleSection("who-we-help")}
+                className="w-full flex items-center justify-between px-3 py-2.5 rounded-xl text-charcoal/90 hover:bg-blush/40 transition-colors text-sm font-medium"
+              >
+                Who We Help
+                <IconChevronDown
+                  size={14}
+                  className={cn(
+                    "transition-transform duration-200",
+                    openSection === "who-we-help" ? "rotate-180" : "rotate-0"
+                  )}
+                />
+              </button>
+              <AnimatePresence>
+                {openSection === "who-we-help" && (
+                  <motion.div
+                    initial={{ opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: "auto" }}
+                    exit={{ opacity: 0, height: 0 }}
+                    transition={{ duration: 0.18 }}
+                    className="overflow-hidden pl-3"
+                  >
+                    {WHO_WE_HELP_LINKS.map((link) => (
+                      <Link
+                        key={link.href}
+                        href={link.href}
+                        onClick={() => setOpen(false)}
+                        className="flex flex-col px-3 py-2 rounded-xl hover:bg-blush/40 transition-colors"
+                      >
+                        <span className="text-sm text-charcoal/85">
+                          {link.name}
+                        </span>
+                        <span className="text-[11px] text-charcoal/50">
+                          {link.description}
+                        </span>
+                      </Link>
+                    ))}
                   </motion.div>
                 )}
               </AnimatePresence>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -61,7 +61,9 @@ export type SourcePage =
   | "global_chat"
   | "predictive-customer-intelligence"
   | "revenue_calculator"
-  | "what_you_get";
+  | "what_you_get"
+  | "for_service_businesses"
+  | "for_b2b";
 
 /**
  * Semantic section where the click happened. Keep values kebab_case and


### PR DESCRIPTION
## What this does

Updates the homepage (`/`) to serve as a true hub for both service-based businesses and B2B/enterprise audiences.

### Changes
- **Hero headline** updated to brand-level messaging that speaks to both audiences
- **New audience-split section** added immediately after the hero — two clickable cards routing visitors to `/for-service-businesses` (cream/white card) and `/for-b2b` (wine dark card)
- **Metadata** updated to reflect dual-audience positioning
- **FAQ** "who is this for" answer updated to include both audience types
- **CTA copy** updated to be audience-agnostic

### What is preserved
All existing sections remain intact: Santa proof block, founder quote, ROI calculator, PCI band, systems, integration band, FAQ, and CTA.

### Design
The two audience cards use the exact production design system — same card shadows, border tokens, Playfair Display headings, and wine/cream palette.