### PR TITLE
Fix LP logo 404, /book title duplication, sticky bar copy, and sweep body-copy em dashes

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -121,7 +121,7 @@ export default function AboutPage() {
               &ldquo;In fourteen days, four missed calls turned into booked appointments and $960 in recovered revenue.&rdquo;
             </blockquote>
             <p className="text-sm text-cream/60 mb-8">
-              Santa E. &mdash; Healing Hands by Santa, Laguna Niguel CA
+              Santa E., Healing Hands by Santa, Laguna Niguel CA
             </p>
             <div className="grid grid-cols-3 gap-4 border-t border-white/10 pt-6">
               <div className="text-center">

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -11,9 +11,10 @@ import { breadcrumbSchema, faqPageSchema } from "@/lib/schema";
 
 export const metadata = pageMetadata({
   path: "/book",
-  title: "Free Missed Call Audit — Most Businesses Find $3K+ in Missing Revenue",
+  title: "Book Your Free Missed Call Audit | Ops by Noell",
+  absoluteTitle: true,
   description:
-    "Tell us where your front desk is leaking. We'll review it personally and reply within one business day with two or three times for a focused walkthrough.",
+    "Pick a time for your free 30-minute Missed Call Audit. We walk your missed call rate, follow-up gaps, and booking flow, and show you what the leaks are worth.",
 });
 
 const bookFaqs: FaqItem[] = [

--- a/src/app/for-service-businesses/page.tsx
+++ b/src/app/for-service-businesses/page.tsx
@@ -136,7 +136,7 @@ const objections = [
   {
     question: "I already have a booking system.",
     answer:
-      "We work around the tools you already use. No migration. No rip-and-replace. The system layers on top of your existing scheduling, CRM, or practice management software. Jane App, Mindbody, GHL, Vagaro, Square — we have seen them all.",
+      "We work around the tools you already use. No migration. No rip-and-replace. The system layers on top of your existing scheduling, CRM, or practice management software. Jane App, Mindbody, GHL, Vagaro, Square. We have seen them all.",
   },
   {
     question: "I am not a tech person.",
@@ -161,7 +161,7 @@ const serviceFaqs: FaqItem[] = [
     id: "sb_existing_tools",
     question: "Do I need to replace my current booking or CRM tools?",
     answer:
-      "No. We build around the tools you already use. The Ops by Noell system layers on top of your existing scheduling, CRM, or practice management software. No migration, no rip-and-replace. It is done-for-you operations — we handle the setup, the integrations, and the ongoing management.",
+      "No. We build around the tools you already use. The Ops by Noell system layers on top of your existing scheduling, CRM, or practice management software. No migration, no rip-and-replace. It is done-for-you operations: we handle the setup, the integrations, and the ongoing management.",
   },
   {
     id: "sb_timeline",

--- a/src/app/how-it-works/page.tsx
+++ b/src/app/how-it-works/page.tsx
@@ -430,7 +430,7 @@ export default function HowItWorksPage() {
                 The audit is free. The findings are yours to keep.
               </p>
               <p className="text-sm text-cream/65 leading-relaxed">
-                No pitch. No deck. You leave with a clear map of what is leaking and what the fix looks like — whether you work with us or not.
+                No pitch. No deck. You leave with a clear map of what is leaking and what the fix looks like, whether you work with us or not.
               </p>
             </div>
             <div className="flex-shrink-0 flex flex-col items-center gap-3">

--- a/src/app/lp/booking-automation/page.tsx
+++ b/src/app/lp/booking-automation/page.tsx
@@ -9,6 +9,7 @@ export const metadata = pageMetadata({
   ogTitle: "Automate Client Booking — Stop Losing Jobs to No-Shows",
   ogDescription:
     "Most service businesses lose 5–8 jobs per month to no-shows and missed booking requests. This free guide shows you exactly how to automate your calendar and recover that revenue.",
+  noindex: true,
 });
 
 export default function BookingAutomationPage() {

--- a/src/app/lp/missed-call-audit/page.tsx
+++ b/src/app/lp/missed-call-audit/page.tsx
@@ -9,6 +9,7 @@ export const metadata = pageMetadata({
   ogTitle: "Free Missed Call Audit — Find out what your front desk is costing you.",
   ogDescription:
     "Most service businesses lose 3-5 clients a week to missed calls and slow follow-up. This audit shows you exactly where the leaks are and what to do about them.",
+  noindex: true,
 });
 
 export default function MissedCallAuditPage() {

--- a/src/app/lp/service-businesses/page.tsx
+++ b/src/app/lp/service-businesses/page.tsx
@@ -87,13 +87,10 @@ export default function LpServiceBusinessesPage() {
         <Link href="/" className="flex items-center gap-2">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src="/images/logo-obn-cream.png"
+            src="/images/logo-ops-by-noell-cream-text.png"
             alt="Ops by Noell"
             className="h-7 w-auto"
           />
-          <span className="font-serif text-lg font-semibold text-cream">
-            Ops by Noell
-          </span>
         </Link>
         <a
           href="#form"
@@ -154,7 +151,7 @@ export default function LpServiceBusinessesPage() {
 
       {/* ─── STICKY MOBILE CTA ───────────────────────────────────────────────── */}
       <div className="fixed bottom-0 left-0 right-0 z-50 bg-[#1F1219]/95 backdrop-blur-sm border-t border-wine/20 px-6 py-4 flex items-center justify-between md:hidden">
-        <p className="text-sm text-cream/80 font-medium">Free revenue audit</p>
+        <p className="text-sm text-cream/80 font-medium">Free Missed Call Audit</p>
         <a
           href="#form"
           className="bg-wine hover:bg-wine-dark text-cream font-semibold px-5 py-2.5 rounded-full text-sm transition-colors"

--- a/src/app/lp/service-businesses/page.tsx
+++ b/src/app/lp/service-businesses/page.tsx
@@ -19,6 +19,7 @@ export const metadata = pageMetadata({
   ogTitle: "Every missed call is a client you lost. Let's fix that.",
   ogDescription:
     "Ops by Noell is the AI receptionist and done-for-you operations system for service businesses. Catch every call, follow up instantly, keep your calendar full.",
+  noindex: true,
 });
 
 const painPoints = [

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -122,7 +122,7 @@ export default function Home() {
               ))}
             </div>
             <p className="text-sm text-cream/70">
-              Santa E. &mdash; Healing Hands by Santa, Laguna Niguel CA
+              Santa E., Healing Hands by Santa, Laguna Niguel CA
             </p>
             <Link
               href="/case-studies/santa-e"

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -135,8 +135,6 @@ const entries: Entry[] = [
   { path: "/legal/terms", changeFrequency: "yearly", priority: 0.3, lastmod: TODAY },
   { path: "/legal/cookies", changeFrequency: "yearly", priority: 0.3, lastmod: TODAY },
   { path: "/sms-policy", changeFrequency: "yearly", priority: 0.3, lastmod: TODAY },
-  { path: "/lp/missed-call-audit", changeFrequency: "monthly", priority: 0.85, lastmod: TODAY },
-  { path: "/lp/service-businesses", changeFrequency: "monthly", priority: 0.85, lastmod: TODAY },
 ];
 
 export default function sitemap(): MetadataRoute.Sitemap {

--- a/src/components/book-request-form.tsx
+++ b/src/components/book-request-form.tsx
@@ -40,7 +40,7 @@ const LEAK_OPTIONS = [
   "Manual follow-up taking too much of my time",
   "Booking confirmations and reminders are inconsistent",
   "Slow or no response to web form inquiries",
-  "Review generation — I'm not getting enough 5-star reviews",
+  "Review generation: I'm not getting enough 5-star reviews",
   "Something else",
 ];
 

--- a/src/components/booking-automation-page.tsx
+++ b/src/components/booking-automation-page.tsx
@@ -10,7 +10,7 @@ type FormState = "idle" | "submitting" | "done" | "error";
 const benefitItems = [
   "How to stop losing booked jobs to no-shows and last-minute cancellations",
   "The 3 booking gaps that cost service businesses 5–8 jobs per month",
-  "How AI handles your calendar 24/7 — even when you're on a job",
+  "How AI handles your calendar 24/7, even when you're on a job",
   "The exact automation stack we use to get clients live in 14 days",
 ];
 
@@ -129,7 +129,7 @@ export function BookingAutomationPageClient() {
           className="text-center text-base md:text-lg leading-relaxed mb-10 max-w-xl mx-auto"
           style={{ color: "rgba(245,234,224,0.65)" }}
         >
-          A practical guide to automating your client booking system — so your
+          A practical guide to automating your client booking system, so your
           calendar fills itself, even when you&apos;re on a job. Free. No credit
           card. Instant download.
         </p>
@@ -228,7 +228,7 @@ export function BookingAutomationPageClient() {
                   className="text-sm mb-6"
                   style={{ color: "rgba(245,234,224,0.55)" }}
                 >
-                  Enter your name and email — we&apos;ll send it right over.
+                  Enter your name and email. We&apos;ll send it right over.
                 </p>
                 <form onSubmit={handleSubmit} className="space-y-4">
                   <div>
@@ -346,7 +346,7 @@ export function BookingAutomationPageClient() {
                     className="text-sm mb-4"
                     style={{ color: "rgba(245,234,224,0.55)" }}
                   >
-                    Want us to set up your booking automation — for free?
+                    Want us to set up your booking automation, for free?
                   </p>
                   <Link
                     href="/book"

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -62,7 +62,7 @@ export function Footer() {
                 ))}
               </div>
               <div>
-                <p className="text-xs font-semibold text-cream leading-none">5.0 &mdash; Rated by clients</p>
+                <p className="text-xs font-semibold text-cream leading-none">5.0, rated by clients</p>
                 <p className="text-[10px] text-cream/50 mt-0.5">Service businesses nationwide</p>
               </div>
             </div>

--- a/src/components/missed-call-audit-page.tsx
+++ b/src/components/missed-call-audit-page.tsx
@@ -227,7 +227,7 @@ export function MissedCallAuditPageClient() {
                   className="text-sm mb-6"
                   style={{ color: "rgba(245,234,224,0.55)" }}
                 >
-                  Enter your name and email — we&apos;ll send it right over.
+                  Enter your name and email. We&apos;ll send it right over.
                 </p>
                 <form onSubmit={handleSubmit} className="space-y-4">
                   <div>
@@ -359,7 +359,7 @@ export function MissedCallAuditPageClient() {
                     className="text-sm mb-4"
                     style={{ color: "rgba(245,234,224,0.55)" }}
                   >
-                    Want us to run the audit for you — for free?
+                    Want us to run the audit for you, for free?
                   </p>
                   <Link
                     href="/book"

--- a/src/components/pricing.tsx
+++ b/src/components/pricing.tsx
@@ -322,10 +322,10 @@ export default function Pricing() {
       <div className="max-w-3xl mx-auto mb-12 rounded-[20px] border border-wine/30 bg-wine/10 p-5 text-center">
         <div className="flex items-center justify-center gap-2 mb-2">
           <span className="w-2 h-2 rounded-full bg-wine animate-pulse" />
-          <p className="text-xs font-mono uppercase tracking-[0.2em] text-wine">Launch Pricing — Live Now</p>
+          <p className="text-xs font-mono uppercase tracking-[0.2em] text-wine">Launch Pricing: Live Now</p>
         </div>
         <p className="text-sm text-cream/80 leading-relaxed">
-          The price you see is what you pay today. The <span className="line-through text-cream/40">strikethrough</span> is the standard rate this tier moves to. Your rate is locked from the day you sign up — no surprises.
+          The price you see is what you pay today. The <span className="line-through text-cream/40">strikethrough</span> is the standard rate this tier moves to. Your rate is locked from the day you sign up. No surprises.
         </p>
       </div>
 

--- a/src/components/upgrade-page-client.tsx
+++ b/src/components/upgrade-page-client.tsx
@@ -77,7 +77,7 @@ function AudioDemo() {
     <div className="w-full max-w-xl mx-auto mt-6">
       <div className="rounded-[22px] bg-[#271520] border border-white/10 p-5 shadow-[0px_4px_8px_0px_rgba(28,25,23,0.08)]">
         <p className="text-[10px] uppercase tracking-[0.2em] text-cream/60 mb-3 text-center">
-          Hear Nova · Noell Front Desk AI · Live demo call
+          Noell Front Desk AI · Live demo call
         </p>
         <audio
           controls
@@ -89,7 +89,7 @@ function AudioDemo() {
           Your browser does not support audio playback.
         </audio>
         <p className="text-[10px] text-cream/40 text-center mt-2">
-          AI-generated demo · Nova (Noell Front Desk AI) + caller · Not a real client call
+          AI-generated demo · Noell Front Desk AI + caller · Not a real client call
         </p>
       </div>
     </div>

--- a/src/content/pricing.ts
+++ b/src/content/pricing.ts
@@ -5,4 +5,4 @@ export const PRICING_FAQ_EYEBROW = "Before you book";
 export const PRICING_FAQ_HEADLINE_START = "Pricing questions,";
 export const PRICING_FAQ_HEADLINE_ACCENT = "answered.";
 export const PRICING_FAQ_BODY =
-  "No sales theater. These are the real questions we get before someone books an audit. If yours isn't here, chat with Noell Support — she has the answers too.";
+  "No sales theater. These are the real questions we get before someone books an audit. If yours isn't here, chat with Noell Support. She has the answers too.";


### PR DESCRIPTION
## Summary

Six small fixes, no functional changes beyond copy/metadata/assets:

### 1. Broken logo on /lp/service-businesses
The header referenced `/images/logo-obn-cream.png`, which does not exist in `public/images/` (404). It was the only reference to that path in the codebase (the preload the browser issued derived from this `<img>` src). Now points at the same lockup the site-wide `Logo` component uses: `/images/logo-ops-by-noell-cream-text.png`. The adjacent "Ops by Noell" text span was removed because the lockup image contains the wordmark — keeping both would render the name twice.

### 2. /book title duplication
`/book` duplicated `/lp/missed-call-audit`'s title ("Free Missed Call Audit — Most Businesses Find $3K+ in Missing Revenue"). Now:
- **Title:** `Book Your Free Missed Call Audit | Ops by Noell` (using `absoluteTitle: true` so the root layout's `%s | Ops by Noell` template doesn't double the brand)
- **Description:** "Pick a time for your free 30-minute Missed Call Audit. We walk your missed call rate, follow-up gaps, and booking flow, and show you what the leaks are worth."

### 3. Sticky bar copy on /lp/service-businesses
"Free revenue audit" → "Free Missed Call Audit".

### 4. Em dash sweep (body copy only)
16 rendered instances replaced with periods, commas, or colons, whichever read naturally — including `&mdash;` HTML entities (homepage/about testimonial attributions, footer rating line). Files: `pricing.tsx`, `content/pricing.ts`, `about`, homepage, `for-service-businesses` (FAQ answers), `how-it-works`, `footer.tsx`, `book-request-form.tsx`, `booking-automation-page.tsx`, `missed-call-audit-page.tsx`.

Explicitly left untouched: title-tag separators and ogTitles, JSON-LD schema names, code comments, and en dash numeric ranges ("2–4 weeks").

### 5. Nova persona name removed from /upgrade demo captions
"Hear Nova · Noell Front Desk AI · Live demo call" → "Noell Front Desk AI · Live demo call"; the disclaimer line now reads "AI-generated demo · Noell Front Desk AI + caller · Not a real client call". Audio files untouched. A case-sensitive whole-word sweep found no other user-facing "Nova" references (remaining hits are a code comment in `content/nova.ts` and internal docs).

### 6. Ad landing pages noindexed
`/lp/service-businesses` and `/lp/missed-call-audit` now ship `noindex, nofollow` robots metadata and are removed from the sitemap allowlist. The pages stay live and publicly accessible as paid-traffic destinations. (robots.txt intentionally untouched: a Disallow would prevent crawlers from seeing the noindex.)

## Verification
- `next build` compiles all routes
- ESLint on every changed file: the remaining findings (unescaped-entity errors, unused-import warnings) reproduce identically on clean `main` — pre-existing, none introduced here

https://claude.ai/code/session_01QcWn3cmosAYN15iy1KswGf