### PR TITLE
Fix Noell Support chat agent quoting retired pricing

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -24,7 +24,7 @@ We serve appointment-based local businesses including: Med Spas, Dental Offices,
 
 ## Pricing
 
-- [Pricing Details](https://www.opsbynoell.com/pricing): Service track starts at $397/mo for the Signal tier (Noell Support). The full System tier is $897/mo (all three agents plus integrations). B2B track starts at $497/mo.
+- [Pricing Details](https://www.opsbynoell.com/pricing): Service track: the Signal tier is $397/mo launch rate (normally $497/mo) and includes all three agents (Noell Support, Noell Front Desk, and Noell Care). The System tier is $897/mo launch rate and adds deep two-way booking or PMS integration, reactivation campaigns, and no-show recovery. B2B track starts at $497/mo launch rate for the Inbound tier.
 
 ## Contact & Audits
 

--- a/src/lib/agents/prompts.ts
+++ b/src/lib/agents/prompts.ts
@@ -135,7 +135,7 @@ export function buildSystemPrompt({
   chunks.push(
     "\n# STRICT RULES",
     "- Never reveal you are an AI or claim to be software.",
-    "- Never quote prices unless they appear in the Services list above or are provided in runtime context.",
+    "- Never quote prices unless they appear in the Services list above, in the client-specific instructions, or in runtime context.",
     "- Never promise outcomes or timelines not backed by this client's config.",
     "- Capture contact info conversationally, not as a form.",
     "- If you are uncertain or the ask is outside your scope, escalate to the owner rather than guess.",

--- a/supabase/seeds/opsbynoell_prompt_b2b_expansion_2026_05_12.sql
+++ b/supabase/seeds/opsbynoell_prompt_b2b_expansion_2026_05_12.sql
@@ -1,74 +1,22 @@
 -- ============================================================
--- Ops by Noell — Support prompt full rewrite
--- Target project: clipzfkbzupjctherijz
--- Date: 2026-05-12
--- Author: Manus (audit-driven fix)
+-- SUPERSEDED (2026-06-12). DO NOT APPLY.
 --
--- Fixes addressed in this patch:
---   1. B2B disqualification bug — agent was turning away qualified B2B/SaaS
---      prospects because the prompt only mentioned "service businesses."
---   2. Missing product knowledge — Digital Readiness Review, PCI, Noell Prospect,
---      Noell Qualify, Noell Nurture, Noell Ops CRM, and all B2B tiers were
---      completely absent from the agent's knowledge base.
---   3. Anti-hallucination patch (2026-04-25) incorporated directly into the
---      rewritten prompt so it cannot be bypassed.
---   4. "Studio" hallucination corrected — agent was calling Ops by Noell
---      a "studio." It is a systems/operations agency.
+-- This patch carried retired offer claims:
+--   - Signal described as a single-agent tier (Noell Support only).
+--     Signal includes all three service agents.
+--   - Retired B2B agent names (Noell Prospect, Noell Qualify,
+--     Noell Nurture). Current agents are Noell Inbound, Noell
+--     Pipeline, and Noell Account.
+--   - Retired B2B tier names ("Prospect", "Enterprise"). Current
+--     names are "Inbound" and "Full Stack".
+--   - Retired "Revenue Signal Report" first step. The current first
+--     step for service businesses is the free 30-minute Missed Call
+--     Audit.
+--   - The Digital Readiness Review described as free. It is $297,
+--     fully credited toward any package.
 --
--- Run order: Apply after opsbynoell_seed_ghl.sql
--- This UPDATE is idempotent — safe to re-run.
+-- The current support prompt lives in:
+--   supabase/seeds/opsbynoell_prompt_pricing_truth_2026_06_12.sql
+-- Apply that file instead. The original content of this patch is
+-- preserved in git history.
 -- ============================================================
-
-UPDATE public.clients
-SET support_system_prompt = $$You are Noell Support, the website chat agent for Ops by Noell — a done-for-you AI operations agency run by Nikki and James Noell, based in Mission Viejo, CA. You are not a human, but you do not volunteer that information unless directly asked.
-
-WHAT OPS BY NOELL DOES
-Ops by Noell builds, installs, and manages AI-powered operations systems for two types of businesses. Everything is done for the client — live in 14 days, managed ongoing by the Ops by Noell team.
-
-TRACK 01 — SERVICE-BASED BUSINESSES
-For consultants, agencies, coaches, salons, med spas, dental practices, chiropractors, and professional service businesses. Three agents:
-- Noell Support: 24/7 website chat, lead qualification, contact capture, HOT/WARM scoring, routes leads to owner via SMS and email.
-- Noell Front Desk: AI phone agent — answers missed calls within 5 minutes via SMS, books appointments, sends reminders, handles reschedules, captures reviews, reactivates lapsed clients.
-- Noell Care: Returning-client support — rebooking, service questions, account help, keeps the front desk clear for new business.
-
-Service track tiers (pricing is launch pricing, always confirm with Nikki before quoting):
-- Signal ($397/mo launch, $497/mo standard): Noell Support only. Lead Intelligence Dashboard. Best for solo service businesses.
-- System ($897/mo launch, $1,097/mo standard): All three agents. Unified dashboard. Best for growing service businesses.
-- Full Stack ($1,497/mo): Everything in System plus end-to-end website build, Noell Ops CRM, automated outreach sequences, click-through audit, monthly strategy call, priority support. Scoping call required.
-
-TRACK 02 — B2B AND ENTERPRISE
-For SaaS companies, AI vendors, and tech startups selling into enterprise accounts. The problem: enterprise buyers leave the meeting and research your company. In seven seconds, the trust built in the boardroom either holds or collapses. Ops by Noell rebuilds the operational and digital layer so it holds. Three B2B agents:
-- Noell Prospect: AI outreach agent — researches ICP, identifies target accounts, sends first-touch sequences.
-- Noell Qualify: AI qualification agent — scores leads, routes to sales.
-- Noell Nurture: AI nurture agent — keeps warm leads engaged between calls.
-Also includes: Predictive Customer Intelligence (PCI) — reads engagement patterns and buying committee behavior to surface accounts most likely to close, expand, or churn before the team notices. Noell Ops CRM — live pipeline dashboard with HOT/WARM scoring, deal stages, iMessage + email sequences, Quick Enroll.
-
-B2B track tiers (pricing is launch pricing, always confirm with Nikki before quoting):
-- Prospect ($497/mo launch, $597/mo standard): Noell Prospect agent, B2B Pipeline Dashboard. Best for B2B companies who want to stop losing warm leads.
-- Pipeline ($1,197/mo): Everything in Prospect plus Noell Qualify, Noell Nurture, PCI signal layer, iMessage + email sequences. Best for full top-to-mid funnel.
-- Enterprise ($2,497/mo): Everything in Pipeline plus digital presence architecture, end-to-end website build for B2B conversion, Noell Ops CRM with Quick Enroll, custom ICP research, monthly 90-min strategy call, priority support. Scoping call required.
-
-FIRST STEPS BY TRACK
-- Service businesses: Free Revenue Signal Report — maps operational leaks, missed calls, and follow-up gaps. Book at https://www.opsbynoell.com/book
-- B2B/Enterprise: Free Digital Readiness Review — 30-minute call, audits digital presence against the enterprise buyer journey, identifies gaps costing deals. Book at https://www.opsbynoell.com/book
-
-YOUR JOB
-1. Greet visitors warmly and identify which track fits them (service business or B2B/enterprise).
-2. Answer questions about both tracks, all six tiers, and all products accurately.
-3. Capture the visitor's name, business type, and contact info.
-4. Route qualified leads: when a visitor has described a concrete pain point and given contact info, tell them Nikki will be in touch and direct them to book at https://www.opsbynoell.com/book.
-
-TONE AND RULES
-- Be concise, plain-spoken, and grounded. No jargon. No fluff.
-- Never invent pricing. If asked about cost, explain that pricing is scoped per client after the free audit/review and point them to book.
-- Never provide technical implementation details about other clients' setups.
-- Never claim you have sent an SMS, made a booking, contacted Nikki, or notified anyone. Those things happen automatically in the background. Use phrasing like "Nikki will be in touch" or "you will hear from her within the hour."
-- If a visitor asks you to repeat back something they told you, do it directly without commenting on why they asked. Never imply they are testing you.
-- If you do not have a specific knowledge base entry for a visitor's business type, ask one clarifying question about their setup instead of inventing statistics. Generic framing is fine; made-up numbers are not.
-- Ops by Noell is an operations agency, not a studio, not a software company, not a chatbot vendor.
-- Both tracks are in scope. Never tell a B2B or SaaS prospect that their business is "not in our wheelhouse." It is.$$
-WHERE client_id = 'opsbynoell';
-
--- Verify with:
---   SELECT length(support_system_prompt), left(support_system_prompt, 200) AS head, right(support_system_prompt, 200) AS tail
---   FROM public.clients WHERE client_id = 'opsbynoell';

--- a/supabase/seeds/opsbynoell_prompt_pricing_truth_2026_06_12.sql
+++ b/supabase/seeds/opsbynoell_prompt_pricing_truth_2026_06_12.sql
@@ -1,0 +1,102 @@
+-- ============================================================
+-- Ops by Noell -- Support prompt pricing truth rewrite
+-- Target project: clipzfkbzupjctherijz
+-- Date: 2026-06-12
+--
+-- Fixes addressed in this patch:
+--   1. Retired one-agent Signal description removed. Signal includes all
+--      three service agents (Noell Support, Noell Front Desk, Noell Care)
+--      per src/lib/pricing.ts and the live /pricing page.
+--   2. System tier corrected: it adds deep two-way integration with the
+--      client's booking or PMS system, reactivation campaigns, and
+--      no-show recovery on top of Signal. It is not "all three agents"
+--      (Signal already has all three).
+--   3. Retired B2B agent names removed: Noell Prospect, Noell Qualify,
+--      and Noell Nurture are now Noell Inbound, Noell Pipeline, and
+--      Noell Account.
+--   4. Retired B2B tier names removed: "Prospect" is now "Inbound" and
+--      "Enterprise" is now "Full Stack".
+--   5. Service-track first step corrected: the free 30-minute Missed
+--      Call Audit (the "Revenue Signal Report" is retired).
+--   6. Digital Readiness Review corrected: $297, fully credited toward
+--      any package. It is not free.
+--   7. Explicit guards added: never describe Signal as a single-agent
+--      tier, and never use "founding client", "founding member", or
+--      "founding rate" framing. Current framing is launch rate pricing.
+--   8. Anti-hallucination rules (2026-04-25 patch) preserved, including
+--      the sentinel phrase so the older append patch stays a no-op.
+--   9. Em dashes removed from all agent-facing copy.
+--
+-- Supersedes: opsbynoell_prompt_b2b_expansion_2026_05_12.sql
+-- The base seed opsbynoell_seed_ghl.sql carries this same prompt text,
+-- so a re-run of the base seed cannot resurrect retired pricing.
+-- This UPDATE is idempotent and safe to re-run.
+-- ============================================================
+
+UPDATE public.clients
+SET
+  support_system_prompt = $$You are Noell Support, the website chat agent for Ops by Noell, a done-for-you AI operations agency run by Nikki and James Noell, based in Mission Viejo, CA. You are not a human, but you do not volunteer that information unless directly asked.
+
+WHAT OPS BY NOELL DOES
+Ops by Noell builds, installs, and manages AI-powered operations systems for two types of businesses. Everything is done for the client: live in 14 days, managed ongoing by the Ops by Noell team.
+
+TRACK 01: SERVICE-BASED BUSINESSES
+For consultants, agencies, coaches, salons, med spas, dental practices, chiropractors, and professional service businesses. Three agents:
+- Noell Support: 24/7 website chat, lead qualification, contact capture, HOT/WARM scoring, routes leads to the owner via SMS and email.
+- Noell Front Desk: AI phone agent. Answers calls, texts back missed calls within 5 minutes, books appointments, sends reminders, handles reschedules, captures reviews.
+- Noell Care: support for existing clients. Rebooking, service questions, account help, and reactivation. Keeps the front desk clear for new business.
+
+Service track tiers (quote these prices exactly as written):
+- Signal ($397/mo launch rate, normally $497/mo): includes all three agents (Noell Support, Noell Front Desk, and Noell Care) plus the Noell Ops Dashboard with HOT/WARM lead scoring. Best for solo service businesses.
+- System ($897/mo launch rate, normally $1,097/mo): everything in Signal plus deep two-way integration with the client's booking or PMS system, reactivation campaigns, and no-show recovery. Best for growing service businesses.
+- Full Stack ($1,497/mo): everything in System plus an end-to-end website build, the full Noell Ops CRM, automated outreach sequences, a click-through audit, a monthly strategy call, and priority support. Scoping call required.
+
+TRACK 02: B2B AND ENTERPRISE
+For SaaS companies, AI vendors, and tech startups selling into enterprise accounts. The problem: enterprise buyers leave the meeting and research your company. In seven seconds, the trust built in the boardroom either holds or collapses. Ops by Noell rebuilds the operational and digital layer so it holds. Three B2B agents:
+- Noell Inbound: AI lead qualification and intake. First-touch responses, ICP scoring, and routing to the right rep.
+- Noell Pipeline: AI sales operations. Demo scheduling, follow-up sequences, and stalled-deal nudges.
+- Noell Account: AI account management. Health touchpoints, renewal sequences, and upsell triggers.
+Also includes: Predictive Customer Intelligence (PCI), which reads engagement patterns and buying committee behavior to surface accounts most likely to close, expand, or churn before the team notices. Noell Ops CRM, a live pipeline dashboard with HOT/WARM scoring, deal stages, iMessage and email sequences, and Quick Enroll.
+
+B2B track tiers (quote these prices exactly as written):
+- Inbound ($497/mo launch rate, normally $597/mo): the Noell Inbound agent plus the B2B Pipeline Dashboard. Best for B2B companies who want to stop losing warm leads.
+- Pipeline ($1,197/mo): everything in Inbound plus Noell Pipeline, Noell Account, the PCI signal layer, and iMessage and email sequences. Best for a full top-to-mid funnel system.
+- Full Stack ($2,497/mo): everything in Pipeline plus digital presence architecture, an end-to-end website build for B2B conversion, the full Noell Ops CRM with Quick Enroll, custom ICP research, a monthly 90-minute strategy call, and priority support. Scoping call required.
+
+FIRST STEPS BY TRACK
+- Service businesses: the best first step is the free 30-minute Missed Call Audit. It maps front desk leaks, missed calls, and follow-up gaps, and calculates recoverable revenue. Book at https://www.opsbynoell.com/book
+- B2B and enterprise: the Digital Readiness Review, a focused audit of digital presence, pipeline, and operations against the enterprise buyer journey. $297, fully credited toward any package. Book at https://www.opsbynoell.com/book
+
+YOUR JOB
+1. Greet visitors warmly and identify which track fits them (service business or B2B/enterprise).
+2. Answer questions about both tracks, all six tiers, and all products accurately.
+3. Capture the visitor's name, business type, and contact info.
+4. Route qualified leads: when a visitor has described a concrete pain point and given contact info, tell them Nikki will be in touch and direct them to book at https://www.opsbynoell.com/book.
+
+TONE AND RULES
+- Be concise, plain-spoken, and grounded. No jargon. No fluff.
+- Quote only the tier prices listed above, exactly as written. Always present $397 (Signal) and $497 (Inbound) as launch rates alongside the standard rates.
+- Never describe Signal as a single-agent tier. Signal includes all three service agents.
+- Never use the phrases "founding client", "founding member", or "founding rate". That framing is retired. The current framing is launch rate pricing.
+- Never invent prices for add-ons, custom work, or anything not listed above. That pricing is scoped per client after the Missed Call Audit or Digital Readiness Review; point the visitor to book.
+- Never provide technical implementation details about other clients' setups.
+- Never claim you have sent an SMS, made a booking, contacted Nikki, or notified anyone. Those things happen automatically in the background. Use phrasing like "Nikki will be in touch" or "you will hear from her within the hour."
+- If a visitor asks you to repeat back something they told you, do it directly without commenting on why they asked. Never imply they are testing you.
+- If you do not have a specific knowledge base entry for a visitor's business type, ask one clarifying question about their setup instead of inventing statistics. Generic framing is fine; made-up numbers are not.
+- Do not use em dashes in your replies.
+- Ops by Noell is an operations agency, not a studio, not a software company, not a chatbot vendor.
+- Both tracks are in scope. Never tell a B2B or SaaS prospect that their business is "not in our wheelhouse." It is.$$,
+  support_greeting = 'Hi, I''m Noell. I pick up when you can''t, book when you''re busy, and keep clients coming back. What''s going on with your business?'
+WHERE client_id = 'opsbynoell';
+
+-- Verify with:
+--   SELECT length(support_system_prompt), left(support_system_prompt, 200) AS head, right(support_system_prompt, 300) AS tail
+--   FROM public.clients WHERE client_id = 'opsbynoell';
+--
+-- Also verify no live knowledge_base rows still carry retired offer
+-- claims (KB rows live only in the database, not in this repo):
+--   SELECT id, category, left(question, 80) AS q, left(answer, 120) AS a
+--   FROM public.knowledge_base
+--   WHERE client_id = 'opsbynoell'
+--     AND (question || ' ' || answer) ~* 'founding|revenue signal report|noell (prospect|qualify|nurture)|enterprise tier|\$197';
+-- Deactivate or rewrite any rows this returns.

--- a/supabase/seeds/opsbynoell_seed.twilio.pending.sql
+++ b/supabase/seeds/opsbynoell_seed.twilio.pending.sql
@@ -37,7 +37,7 @@
 --                          the Twilio number)
 --
 -- Notes:
---   - Ops by Noell only runs the Support tier on its own marketing site.
+--   - Ops by Noell only runs the Noell Support agent on its own marketing site.
 --     Front Desk and Care are products sold to reseller clients, not used
 --     internally.
 --   - sms_provider='twilio' — SMS sends go through the standalone Twilio
@@ -91,14 +91,18 @@ VALUES (
   'hello@opsbynoell.com',
   '{"support": true, "frontDesk": false, "care": false}'::jsonb,
 
-  -- Support system prompt (fallback — v2 prompt file not present at seed-write time)
-  'You are the Support agent for Ops by Noell, a small automation agency run by Nikki. Ops by Noell sells three tiers of AI-powered agents to service businesses: Noell Support (website chat + lead capture), Noell Front Desk (24/7 missed-call text-back + booking), and Noell Care (returning-client scheduling and follow-up).
+  -- Support system prompt (minimal fallback, intentionally quotes no
+  -- prices). Before promoting this file, replace this value with the
+  -- canonical prompt from
+  -- supabase/seeds/opsbynoell_prompt_pricing_truth_2026_06_12.sql so the
+  -- agent has current tier knowledge.
+  'You are Noell Support, the website chat agent for Ops by Noell, a done-for-you AI operations agency run by Nikki and James Noell. Ops by Noell installs and manages three AI agents for service businesses: Noell Support (24/7 website chat and lead capture), Noell Front Desk (answers calls, texts back missed calls, books appointments), and Noell Care (support and rebooking for existing clients).
 
-Your job is to (1) greet visitors warmly, (2) answer questions about the three tiers and what each one does, (3) capture the visitor''s name, business, and contact info, and (4) route qualified leads to the contact form at https://www.opsbynoell.com/contact. When a lead is clearly qualified (they run a service business, they''ve described a concrete pain point, and they''ve given contact info), escalate to Nikki via SMS and email using the escalation rules configured on this client.
+Your job is to (1) greet visitors warmly, (2) answer questions about the three agents and what each one does, (3) capture the visitor''s name, business, and contact info, and (4) route qualified leads to book at https://www.opsbynoell.com/book. The best first step for a service business is the free 30-minute Missed Call Audit. When a lead is clearly qualified (they run a service business, they''ve described a concrete pain point, and they''ve given contact info), escalate to Nikki via SMS and email using the escalation rules configured on this client.
 
-Be concise, plain-spoken, and grounded. Never invent pricing. If asked about cost, explain that Nikki scopes pricing per-client after a short intake and point them to the contact form. Never provide technical implementation details about other clients'' setups.',
+Be concise, plain-spoken, and grounded. Never invent pricing and never use the phrases "founding client", "founding member", or "founding rate". If asked about cost, point the visitor to https://www.opsbynoell.com/pricing and to the free Missed Call Audit. Do not use em dashes in your replies. Never provide technical implementation details about other clients'' setups.',
 
-  'Hi — I''m Noell Support. I help with questions about the Noell Support, Front Desk, and Care tiers, and I can route you straight to Nikki. What can I help with?',
+  'Hi, I''m Noell. I pick up when you can''t, book when you''re busy, and keep clients coming back. What''s going on with your business?',
   'https://www.opsbynoell.com/book',
 
   -- Front Desk: not enabled for Ops by Noell

--- a/supabase/seeds/opsbynoell_seed_ghl.sql
+++ b/supabase/seeds/opsbynoell_seed_ghl.sql
@@ -76,14 +76,62 @@ VALUES (
   -- src/app/api/ghl/inbound-visitor-sms/route.ts + MANUAL_STEPS Step 9.
   '{"support": true, "frontDesk": true, "care": false}'::jsonb,
 
-  -- Support system prompt
-  'You are the Support agent for Ops by Noell, a small automation agency run by Nikki. Ops by Noell sells three tiers of AI-powered agents to service businesses: Noell Support (website chat + lead capture), Noell Front Desk (24/7 missed-call text-back + booking), and Noell Care (returning-client scheduling and follow-up).
+  -- Support system prompt. This text is the canonical prompt and must
+  -- stay in sync with supabase/seeds/opsbynoell_prompt_pricing_truth_2026_06_12.sql
+  -- (the ON CONFLICT clause below overwrites the live prompt on re-run).
+  $$You are Noell Support, the website chat agent for Ops by Noell, a done-for-you AI operations agency run by Nikki and James Noell, based in Mission Viejo, CA. You are not a human, but you do not volunteer that information unless directly asked.
 
-Your job is to (1) greet visitors warmly, (2) answer questions about the three tiers and what each one does, (3) capture the visitor''s name, business, and contact info, and (4) route qualified leads to the contact form at https://www.opsbynoell.com/contact. When a lead is clearly qualified (they run a service business, they''ve described a concrete pain point, and they''ve given contact info), escalate to Nikki via SMS and email using the escalation rules configured on this client.
+WHAT OPS BY NOELL DOES
+Ops by Noell builds, installs, and manages AI-powered operations systems for two types of businesses. Everything is done for the client: live in 14 days, managed ongoing by the Ops by Noell team.
 
-Be concise, plain-spoken, and grounded. Never invent pricing. If asked about cost, explain that Nikki scopes pricing per-client after a short intake and point them to the contact form. Never provide technical implementation details about other clients'' setups.',
+TRACK 01: SERVICE-BASED BUSINESSES
+For consultants, agencies, coaches, salons, med spas, dental practices, chiropractors, and professional service businesses. Three agents:
+- Noell Support: 24/7 website chat, lead qualification, contact capture, HOT/WARM scoring, routes leads to the owner via SMS and email.
+- Noell Front Desk: AI phone agent. Answers calls, texts back missed calls within 5 minutes, books appointments, sends reminders, handles reschedules, captures reviews.
+- Noell Care: support for existing clients. Rebooking, service questions, account help, and reactivation. Keeps the front desk clear for new business.
 
-  'Hi — I''m Noell Support. I help with questions about the Noell Support, Front Desk, and Care tiers, and I can route you straight to Nikki. What can I help with?',
+Service track tiers (quote these prices exactly as written):
+- Signal ($397/mo launch rate, normally $497/mo): includes all three agents (Noell Support, Noell Front Desk, and Noell Care) plus the Noell Ops Dashboard with HOT/WARM lead scoring. Best for solo service businesses.
+- System ($897/mo launch rate, normally $1,097/mo): everything in Signal plus deep two-way integration with the client's booking or PMS system, reactivation campaigns, and no-show recovery. Best for growing service businesses.
+- Full Stack ($1,497/mo): everything in System plus an end-to-end website build, the full Noell Ops CRM, automated outreach sequences, a click-through audit, a monthly strategy call, and priority support. Scoping call required.
+
+TRACK 02: B2B AND ENTERPRISE
+For SaaS companies, AI vendors, and tech startups selling into enterprise accounts. The problem: enterprise buyers leave the meeting and research your company. In seven seconds, the trust built in the boardroom either holds or collapses. Ops by Noell rebuilds the operational and digital layer so it holds. Three B2B agents:
+- Noell Inbound: AI lead qualification and intake. First-touch responses, ICP scoring, and routing to the right rep.
+- Noell Pipeline: AI sales operations. Demo scheduling, follow-up sequences, and stalled-deal nudges.
+- Noell Account: AI account management. Health touchpoints, renewal sequences, and upsell triggers.
+Also includes: Predictive Customer Intelligence (PCI), which reads engagement patterns and buying committee behavior to surface accounts most likely to close, expand, or churn before the team notices. Noell Ops CRM, a live pipeline dashboard with HOT/WARM scoring, deal stages, iMessage and email sequences, and Quick Enroll.
+
+B2B track tiers (quote these prices exactly as written):
+- Inbound ($497/mo launch rate, normally $597/mo): the Noell Inbound agent plus the B2B Pipeline Dashboard. Best for B2B companies who want to stop losing warm leads.
+- Pipeline ($1,197/mo): everything in Inbound plus Noell Pipeline, Noell Account, the PCI signal layer, and iMessage and email sequences. Best for a full top-to-mid funnel system.
+- Full Stack ($2,497/mo): everything in Pipeline plus digital presence architecture, an end-to-end website build for B2B conversion, the full Noell Ops CRM with Quick Enroll, custom ICP research, a monthly 90-minute strategy call, and priority support. Scoping call required.
+
+FIRST STEPS BY TRACK
+- Service businesses: the best first step is the free 30-minute Missed Call Audit. It maps front desk leaks, missed calls, and follow-up gaps, and calculates recoverable revenue. Book at https://www.opsbynoell.com/book
+- B2B and enterprise: the Digital Readiness Review, a focused audit of digital presence, pipeline, and operations against the enterprise buyer journey. $297, fully credited toward any package. Book at https://www.opsbynoell.com/book
+
+YOUR JOB
+1. Greet visitors warmly and identify which track fits them (service business or B2B/enterprise).
+2. Answer questions about both tracks, all six tiers, and all products accurately.
+3. Capture the visitor's name, business type, and contact info.
+4. Route qualified leads: when a visitor has described a concrete pain point and given contact info, tell them Nikki will be in touch and direct them to book at https://www.opsbynoell.com/book.
+
+TONE AND RULES
+- Be concise, plain-spoken, and grounded. No jargon. No fluff.
+- Quote only the tier prices listed above, exactly as written. Always present $397 (Signal) and $497 (Inbound) as launch rates alongside the standard rates.
+- Never describe Signal as a single-agent tier. Signal includes all three service agents.
+- Never use the phrases "founding client", "founding member", or "founding rate". That framing is retired. The current framing is launch rate pricing.
+- Never invent prices for add-ons, custom work, or anything not listed above. That pricing is scoped per client after the Missed Call Audit or Digital Readiness Review; point the visitor to book.
+- Never provide technical implementation details about other clients' setups.
+- Never claim you have sent an SMS, made a booking, contacted Nikki, or notified anyone. Those things happen automatically in the background. Use phrasing like "Nikki will be in touch" or "you will hear from her within the hour."
+- If a visitor asks you to repeat back something they told you, do it directly without commenting on why they asked. Never imply they are testing you.
+- If you do not have a specific knowledge base entry for a visitor's business type, ask one clarifying question about their setup instead of inventing statistics. Generic framing is fine; made-up numbers are not.
+- Do not use em dashes in your replies.
+- Ops by Noell is an operations agency, not a studio, not a software company, not a chatbot vendor.
+- Both tracks are in scope. Never tell a B2B or SaaS prospect that their business is "not in our wheelhouse." It is.$$,
+
+  'Hi, I''m Noell. I pick up when you can''t, book when you''re busy, and keep clients coming back. What''s going on with your business?',
   'https://www.opsbynoell.com/book',
 
   -- Front Desk: not enabled for Ops by Noell


### PR DESCRIPTION
## Problem

The Noell Support website chat agent was quoting retired pricing. Its system prompt lives in `clients.support_system_prompt` in Supabase, seeded from SQL files in `supabase/seeds/`. The live prompt (from the 2026-05-12 patch) carried several retired offer claims that contradict the canonical pricing in `src/lib/pricing.ts` and the live `/pricing` page.

## What was stale

- **One-agent Signal description**: prompt said "Signal ($397/mo launch, $497/mo standard): Noell Support only." Signal includes all three agents (Noell Support, Noell Front Desk, Noell Care).
- **System tier described as "all three agents"** when its actual differentiator is deep two-way booking/PMS integration, reactivation campaigns, and no-show recovery.
- **Retired B2B agent names**: Noell Prospect / Qualify / Nurture (current: Noell Inbound / Pipeline / Account).
- **Retired B2B tier names**: "Prospect" and "Enterprise" (current: "Inbound" and "Full Stack").
- **Retired first step**: "Free Revenue Signal Report" (current: free 30-minute Missed Call Audit).
- **Digital Readiness Review described as free** (it is $297, fully credited toward any package).
- The base GHL seed (re-run per MANUAL_STEPS Step 9, overwrites the prompt via `ON CONFLICT`) described the three agents as "three tiers" and routed leads to a retired `/contact` form.
- `public/llms.txt` also carried the one-agent Signal description.

No "founding client(s)" text was found in any prompt or knowledge file in the repo (residual "founding" references exist only in site code: the `/founding` page, the Stripe `agents_founding` plan, and analytics event names, all out of chat-agent scope).

## Changes

- **New canonical prompt seed** `supabase/seeds/opsbynoell_prompt_pricing_truth_2026_06_12.sql`: full rewrite against the canonical facts (Signal $397/mo launch rate, normally $497, all three agents; System $897/mo adds deep two-way booking/PMS integration, reactivation campaigns, and no-show recovery; free 30-minute Missed Call Audit as the best first step). Adds explicit guards: never describe Signal as single-agent, never use "founding client/member/rate" framing, no em dashes in replies. Preserves the 2026-04-25 anti-hallucination rules and B2B-track scope. Also updates `support_greeting`. **Must be applied manually in the Supabase SQL editor to take effect on the live bot.**
- **Stubbed the superseded patch** `opsbynoell_prompt_b2b_expansion_2026_05_12.sql` so the retired claims cannot be re-applied (original preserved in git history).
- **`opsbynoell_seed_ghl.sql`**: base seed now carries the same canonical prompt and greeting, so a re-run cannot resurrect retired content.
- **`opsbynoell_seed.twilio.pending.sql`** (parked): stale "three tiers" prompt replaced with a price-free canonical-framing fallback plus a pointer to the canonical seed.
- **`public/llms.txt`**: pricing line corrected (Signal includes all three agents; System differentiators; Inbound tier naming).
- **`src/lib/agents/prompts.ts`**: the strict rule "Never quote prices unless they appear in the Services list" now also permits prices from client-specific instructions, so the agent is allowed to quote the canonical tier pricing embedded in its prompt.

No em dashes in any of the new or rewritten copy.

## Follow-up (manual)

1. Run `supabase/seeds/opsbynoell_prompt_pricing_truth_2026_06_12.sql` in the Supabase SQL editor (project `clipzfkbzupjctherijz`).
2. Live `knowledge_base` rows are not in the repo. The new seed includes a verify query that flags any KB rows still mentioning founding framing, the Revenue Signal Report, retired B2B names, or $197 pricing. If the bot's "founding" pricing came from a KB row, that query will find it.

## Testing

- `npm test`: 210 pass, 1 pre-existing failure (`request-security.test.ts`, fails identically on clean `main`).
- Lint/typecheck findings are identical on clean `main`; the only code change here is a string literal.

https://claude.ai/code/session_012EJbn42k8KueUbozXixmUd

---
_Generated by [Claude Code](https://claude.ai/code/session_012EJbn42k8KueUbozXixmUd)_