### PR TITLE
Align Stripe plans with live pricing page + Build Your Own Stack add-ons

### DIFF
--- a/src/app/api/admin/revenue/route.ts
+++ b/src/app/api/admin/revenue/route.ts
@@ -49,11 +49,19 @@ interface OnboardingRow {
 }
 
 const PLAN_LABELS: Record<string, string> = {
-  agents_founding: "Noell Agents — Founding",
-  agents_standard: "Noell Agents",
+  signal: "Signal",
+  system: "System",
+  full_stack: "Full Stack",
+  b2b_inbound: "B2B Inbound",
+  b2b_pipeline: "B2B Pipeline",
+  b2b_full_stack: "B2B Full Stack",
+  // Legacy aliases
+  agents_founding: "Signal",
+  agents_standard: "Signal",
   essentials: "Signal",
   growth: "System",
   custom_ops: "Full Stack",
+  b2b_prospect: "B2B Inbound",
 };
 
 export async function GET(req: Request): Promise<Response> {

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: Request): Promise<Response> {
     return NextResponse.json({ error: "Invalid JSON." }, { status: 400 });
   }
 
-  const planId = body.planId ?? "agents_founding";
+  const planId = body.planId ?? "signal";
   const plan = getPlanById(planId);
 
   if (!plan) {

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -89,7 +89,7 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
 
   const email = session.customer_details?.email ?? session.customer_email ?? "";
   const name = session.customer_details?.name ?? "";
-  const planId = session.metadata?.plan_id ?? "agents_founding";
+  const planId = session.metadata?.plan_id ?? "signal";
 
   if (!stripeCustomerId || !stripeSubscriptionId) {
     console.error("[stripe-webhook] Missing customer or subscription ID in checkout session");

--- a/src/app/client/dashboard/page.tsx
+++ b/src/app/client/dashboard/page.tsx
@@ -58,11 +58,19 @@ interface StatsResponse {
 }
 
 const PLAN_LABELS: Record<string, string> = {
-  agents_founding: "Noell Agents — Launch Pricing",
-  agents_standard: "Noell Agents",
+  signal: "Noell System — Signal",
+  system: "Noell System — System",
+  full_stack: "Noell System — Full Stack",
+  b2b_inbound: "B2B — Inbound",
+  b2b_pipeline: "B2B — Pipeline",
+  b2b_full_stack: "B2B — Full Stack",
+  // Legacy aliases
+  agents_founding: "Noell System — Signal",
+  agents_standard: "Noell System — Signal",
   essentials: "Noell System — Signal",
   growth: "Noell System — System",
   custom_ops: "Noell System — Full Stack",
+  b2b_prospect: "B2B — Inbound",
 };
 
 const SEVERITY_COLORS: Record<string, string> = {

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -4,19 +4,21 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { IconCheck, IconBolt, IconPhoneCall, IconHeartHandshake } from "@tabler/icons-react";
 
 const PLAN_LABELS: Record<string, string> = {
-  // current plan IDs
+  // Service track
   signal: "Noell System: Signal ($397/mo)",
-  system: "Noell System: System ($1,097/mo)",
+  system: "Noell System: System ($897/mo)",
   full_stack: "Noell System: Full Stack ($1,497/mo)",
-  b2b_prospect: "B2B: Inbound ($497/mo launch)",
+  // B2B track
+  b2b_inbound: "B2B: Inbound ($497/mo)",
   b2b_pipeline: "B2B: Pipeline ($1,197/mo)",
   b2b_full_stack: "B2B: Full Stack ($2,497/mo)",
-  // legacy plan IDs kept for in-flight checkouts; safe to remove once Stripe no longer has them
-  agents_signal: "Signal ($397/mo)",
-  agents_standard: "Noell Agents ($497/mo)",
+  // Legacy aliases for in-flight checkouts
+  agents_founding: "Noell System: Signal ($397/mo)",
+  agents_standard: "Noell System: Signal ($397/mo)",
   essentials: "Noell System: Signal ($397/mo)",
   growth: "Noell System: System ($897/mo)",
   custom_ops: "Noell System: Full Stack ($1,497/mo)",
+  b2b_prospect: "B2B: Inbound ($497/mo)",
 };
 
 const BOOKING_TOOLS = [

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -41,61 +41,346 @@ export interface StripePlan {
   name: string;
   description: string;
   priceId: string;        // Stripe Price ID (from env)
-  amountCents: number;    // Display amount
-  interval: "month" | "year";
-  isFoundingRate?: boolean;
+  amountCents: number;    // Display amount (launch price where applicable)
+  standardAmountCents?: number; // Standard price before launch discount
+  interval: "month" | "year" | "one_time";
+  isLaunchPrice?: boolean;
+  category?: "service" | "b2b" | "addon";
   setupFeeAmountCents?: number;
 }
 
-export const STRIPE_PLANS: StripePlan[] = [
+// ─────────────────────────────────────────────────────────────────────────────
+// Service track
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const SERVICE_PLANS: StripePlan[] = [
   {
-    id: "agents_founding",
-    name: "Noell Agents — Founding Rate",
-    description:
-      "Three AI agents: Noell Support, Noell Front Desk, and Noell Care. Founding rate locked from day one.",
-    priceId: process.env.STRIPE_PRICE_AGENTS_FOUNDING ?? "",
-    amountCents: 39700,
-    interval: "month",
-    isFoundingRate: true,
-  },
-  {
-    id: "agents_standard",
-    name: "Noell Agents",
-    description:
-      "Three AI agents: Noell Support, Noell Front Desk, and Noell Care.",
-    priceId: process.env.STRIPE_PRICE_AGENTS_STANDARD ?? "",
-    amountCents: 49700,
-    interval: "month",
-  },
-  {
-    id: "essentials",
+    id: "signal",
     name: "Noell System — Signal",
     description:
-      "One agent: Noell Support handles 24/7 website chat and lead capture with HOT/WARM scoring. Works alongside any existing booking tool.",
-    priceId: process.env.STRIPE_PRICE_ESSENTIALS ?? "",
+      "All three agents: Noell Support (24/7 chat + lead capture), Noell Front Desk (calls, scheduling, reminders), and Noell Care (returning clients). Works alongside any booking tool.",
+    priceId: process.env.STRIPE_PRICE_SIGNAL ?? "",
     amountCents: 39700,
+    standardAmountCents: 49700,
     interval: "month",
+    isLaunchPrice: true,
+    category: "service",
   },
   {
-    id: "growth",
+    id: "system",
     name: "Noell System — System",
     description:
-      "All three agents (Support, Front Desk, Care), deep two-way PMS or booking integration, no-show recovery, review automation, and the full Noell Ops Dashboard.",
-    priceId: process.env.STRIPE_PRICE_GROWTH ?? "",
+      "Everything in Signal, plus deep two-way PMS/booking integration, reactivation campaigns, no-show recovery, Google review automation, and the full Noell Ops Dashboard.",
+    priceId: process.env.STRIPE_PRICE_SYSTEM ?? "",
     amountCents: 89700,
+    standardAmountCents: 109700,
     interval: "month",
+    isLaunchPrice: true,
+    category: "service",
   },
   {
-    id: "custom_ops",
+    id: "full_stack",
     name: "Noell System — Full Stack",
     description:
       "Everything in System, plus a full website build or redesign, the Noell Ops CRM, click-through audit, custom automation workflows, and a dedicated ops partner.",
-    priceId: process.env.STRIPE_PRICE_CUSTOM_OPS ?? "",
+    priceId: process.env.STRIPE_PRICE_FULL_STACK ?? "",
     amountCents: 149700,
     interval: "month",
+    category: "service",
   },
 ];
 
+// ─────────────────────────────────────────────────────────────────────────────
+// B2B track
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const B2B_PLANS: StripePlan[] = [
+  {
+    id: "b2b_inbound",
+    name: "B2B — Inbound",
+    description:
+      "Noell Inbound: AI lead qualification and intake, ICP scoring, routing. B2B Pipeline Dashboard and weekly report.",
+    priceId: process.env.STRIPE_PRICE_B2B_INBOUND ?? "",
+    amountCents: 49700,
+    standardAmountCents: 59700,
+    interval: "month",
+    isLaunchPrice: true,
+    category: "b2b",
+  },
+  {
+    id: "b2b_pipeline",
+    name: "B2B — Pipeline",
+    description:
+      "Everything in Inbound, plus Noell Pipeline (demo scheduling, follow-up, stalled-deal nudges), Noell Account (health touchpoints, renewals, upsell), and the PCI signal layer.",
+    priceId: process.env.STRIPE_PRICE_B2B_PIPELINE ?? "",
+    amountCents: 119700,
+    interval: "month",
+    category: "b2b",
+  },
+  {
+    id: "b2b_full_stack",
+    name: "B2B — Full Stack",
+    description:
+      "Everything in Pipeline, plus Digital Presence Architecture, AI-Optimized GTM Strategy, website build, the full Noell Ops CRM, custom ICP research, and a dedicated pipeline partner.",
+    priceId: process.env.STRIPE_PRICE_B2B_FULL_STACK ?? "",
+    amountCents: 249700,
+    interval: "month",
+    category: "b2b",
+  },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Build Your Own Stack — add-ons
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ADDON_PLANS: StripePlan[] = [
+  // Digital Infrastructure
+  {
+    id: "addon_tech_stack_audit",
+    name: "Tech Stack Audit + Cleanup",
+    description: "Audit disconnected tools and build a single source of truth.",
+    priceId: process.env.STRIPE_PRICE_ADDON_TECH_STACK_AUDIT ?? "",
+    amountCents: 29700,
+    interval: "one_time",
+    category: "addon",
+  },
+  {
+    id: "addon_crm_pipeline_setup",
+    name: "CRM + Pipeline Setup",
+    description: "CRM and pipeline buildout with ongoing management.",
+    priceId: process.env.STRIPE_PRICE_ADDON_CRM_SETUP ?? "",
+    amountCents: 19700,
+    setupFeeAmountCents: 49700,
+    interval: "month",
+    category: "addon",
+  },
+  {
+    id: "addon_workflow_automation",
+    name: "Workflow Automation (3/qtr)",
+    description: "Three custom automation workflows per quarter.",
+    priceId: process.env.STRIPE_PRICE_ADDON_WORKFLOW_AUTOMATION ?? "",
+    amountCents: 29700,
+    interval: "month",
+    category: "addon",
+  },
+  {
+    id: "addon_unified_analytics",
+    name: "Unified Analytics Dashboard",
+    description: "Consolidated analytics across all channels.",
+    priceId: process.env.STRIPE_PRICE_ADDON_UNIFIED_ANALYTICS ?? "",
+    amountCents: 19700,
+    interval: "month",
+    category: "addon",
+  },
+  // Online Presence
+  {
+    id: "addon_seo_audit",
+    name: "Technical SEO Audit",
+    description: "Full technical SEO audit with actionable fixes.",
+    priceId: process.env.STRIPE_PRICE_ADDON_SEO_AUDIT ?? "",
+    amountCents: 49700,
+    interval: "one_time",
+    category: "addon",
+  },
+  {
+    id: "addon_local_seo",
+    name: "Local SEO Management",
+    description: "Ongoing local search optimization and management.",
+    priceId: process.env.STRIPE_PRICE_ADDON_LOCAL_SEO ?? "",
+    amountCents: 29700,
+    interval: "month",
+    category: "addon",
+  },
+  {
+    id: "addon_content_engine",
+    name: "SEO Content Engine (4 posts/mo)",
+    description: "Four SEO-optimized blog posts per month.",
+    priceId: process.env.STRIPE_PRICE_ADDON_CONTENT_ENGINE ?? "",
+    amountCents: 49700,
+    interval: "month",
+    category: "addon",
+  },
+  {
+    id: "addon_site_performance",
+    name: "Website Performance Optimization",
+    description: "Ongoing site speed, Core Web Vitals, and UX tuning.",
+    priceId: process.env.STRIPE_PRICE_ADDON_SITE_PERF ?? "",
+    amountCents: 29700,
+    interval: "month",
+    category: "addon",
+  },
+  // Social Media
+  {
+    id: "addon_content_calendar",
+    name: "Content Calendar + Scheduling",
+    description: "Monthly content calendar with scheduled posting across platforms.",
+    priceId: process.env.STRIPE_PRICE_ADDON_CONTENT_CALENDAR ?? "",
+    amountCents: 29700,
+    interval: "month",
+    category: "addon",
+  },
+  {
+    id: "addon_video_scripts",
+    name: "Short-Form Video Scripts (4/mo)",
+    description: "Four short-form video scripts per month.",
+    priceId: process.env.STRIPE_PRICE_ADDON_VIDEO_SCRIPTS ?? "",
+    amountCents: 19700,
+    interval: "month",
+    category: "addon",
+  },
+  {
+    id: "addon_social_listening",
+    name: "Social Listening + Engagement",
+    description: "Monitor mentions, respond to comments, engage strategically.",
+    priceId: process.env.STRIPE_PRICE_ADDON_SOCIAL_LISTENING ?? "",
+    amountCents: 19700,
+    interval: "month",
+    category: "addon",
+  },
+  {
+    id: "addon_linkedin_outreach",
+    name: "LinkedIn B2B Outreach",
+    description: "Managed LinkedIn outreach campaigns for B2B pipeline.",
+    priceId: process.env.STRIPE_PRICE_ADDON_LINKEDIN ?? "",
+    amountCents: 49700,
+    interval: "month",
+    category: "addon",
+  },
+  // Brand Kit + Visual Identity
+  {
+    id: "addon_brand_audit",
+    name: "Brand Audit",
+    description: "Full brand audit: positioning, visual identity, voice consistency.",
+    priceId: process.env.STRIPE_PRICE_ADDON_BRAND_AUDIT ?? "",
+    amountCents: 29700,
+    interval: "one_time",
+    category: "addon",
+  },
+  {
+    id: "addon_brand_kit",
+    name: "Full Brand Kit Build",
+    description: "Logo, color system, typography, brand guidelines document.",
+    priceId: process.env.STRIPE_PRICE_ADDON_BRAND_KIT ?? "",
+    amountCents: 99700,
+    interval: "one_time",
+    category: "addon",
+  },
+  {
+    id: "addon_voice_guide",
+    name: "Copywriting Voice Guide",
+    description: "Documented brand voice and messaging framework.",
+    priceId: process.env.STRIPE_PRICE_ADDON_VOICE_GUIDE ?? "",
+    amountCents: 49700,
+    interval: "one_time",
+    category: "addon",
+  },
+  {
+    id: "addon_visual_templates",
+    name: "Visual Templates (social, email, decks)",
+    description: "Branded templates for social posts, emails, and presentations.",
+    priceId: process.env.STRIPE_PRICE_ADDON_VISUAL_TEMPLATES ?? "",
+    amountCents: 29700,
+    interval: "one_time",
+    category: "addon",
+  },
+  // Psychology + Conversion
+  {
+    id: "addon_conversion_copy",
+    name: "Conversion Copy Rewrite",
+    description: "Full website copy rewrite optimized for conversion.",
+    priceId: process.env.STRIPE_PRICE_ADDON_CONVERSION_COPY ?? "",
+    amountCents: 99700,
+    interval: "one_time",
+    category: "addon",
+  },
+  {
+    id: "addon_funnel_build",
+    name: "Full Funnel Design + Build",
+    description: "End-to-end sales funnel: landing pages, email sequences, conversion tracking.",
+    priceId: process.env.STRIPE_PRICE_ADDON_FUNNEL_BUILD ?? "",
+    amountCents: 149700,
+    interval: "one_time",
+    category: "addon",
+  },
+  {
+    id: "addon_nurture_sequence",
+    name: "7-Email Nurture Sequence",
+    description: "Seven-email nurture sequence written and deployed.",
+    priceId: process.env.STRIPE_PRICE_ADDON_NURTURE_SEQ ?? "",
+    amountCents: 49700,
+    interval: "one_time",
+    category: "addon",
+  },
+  {
+    id: "addon_offer_workshop",
+    name: "Offer Positioning Workshop (90 min)",
+    description: "Live 90-minute workshop to nail your offer, messaging, and positioning.",
+    priceId: process.env.STRIPE_PRICE_ADDON_OFFER_WORKSHOP ?? "",
+    amountCents: 49700,
+    interval: "one_time",
+    category: "addon",
+  },
+  // Operational Systems
+  {
+    id: "addon_sop_docs",
+    name: "SOP Documentation (5 processes)",
+    description: "Document five core business processes as standard operating procedures.",
+    priceId: process.env.STRIPE_PRICE_ADDON_SOP_DOCS ?? "",
+    amountCents: 49700,
+    interval: "one_time",
+    category: "addon",
+  },
+  {
+    id: "addon_client_onboarding",
+    name: "Client Onboarding System",
+    description: "Automated client onboarding workflow and welcome sequence.",
+    priceId: process.env.STRIPE_PRICE_ADDON_CLIENT_ONBOARDING ?? "",
+    amountCents: 69700,
+    interval: "one_time",
+    category: "addon",
+  },
+  {
+    id: "addon_kpi_dashboard",
+    name: "Automated Reporting + KPI Dashboard",
+    description: "Live KPI dashboard with automated weekly/monthly reporting.",
+    priceId: process.env.STRIPE_PRICE_ADDON_KPI_DASHBOARD ?? "",
+    amountCents: 19700,
+    interval: "month",
+    category: "addon",
+  },
+  {
+    id: "addon_team_playbook",
+    name: "Team Playbook",
+    description: "Comprehensive team playbook covering roles, workflows, and escalation paths.",
+    priceId: process.env.STRIPE_PRICE_ADDON_TEAM_PLAYBOOK ?? "",
+    amountCents: 49700,
+    interval: "one_time",
+    category: "addon",
+  },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Combined catalog
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const STRIPE_PLANS: StripePlan[] = [
+  ...SERVICE_PLANS,
+  ...B2B_PLANS,
+  ...ADDON_PLANS,
+];
+
+// Legacy plan ID aliases — maps old IDs from in-flight Stripe sessions to
+// current plans so existing checkouts and webhooks don't break.
+const LEGACY_ALIASES: Record<string, string> = {
+  agents_founding: "signal",
+  agents_standard: "signal",
+  essentials: "signal",
+  growth: "system",
+  custom_ops: "full_stack",
+  b2b_prospect: "b2b_inbound",
+};
+
 export function getPlanById(planId: string): StripePlan | undefined {
-  return STRIPE_PLANS.find((p) => p.id === planId);
+  const canonical = LEGACY_ALIASES[planId] ?? planId;
+  return STRIPE_PLANS.find((p) => p.id === canonical);
 }


### PR DESCRIPTION
## Summary

- Replaces the stale 5-plan Stripe catalog with the full pricing structure from opsbynoell.com/pricing
- **Service track:** Signal ($397), System ($897), Full Stack ($1,497)
- **B2B track:** Inbound ($497), Pipeline ($1,197), Full Stack ($2,497)
- **Add-ons:** 22 Build Your Own Stack items across 6 categories (Digital Infrastructure, Online Presence, Social Media, Brand Kit, Psychology + Conversion, Operational Systems)
- Legacy plan IDs (`agents_founding`, `agents_standard`, `essentials`, `growth`, `custom_ops`, `b2b_prospect`) preserved as aliases in `getPlanById()` so in-flight Stripe sessions and existing webhook payloads resolve correctly
- All referencing files updated: onboarding labels, client dashboard labels, admin revenue labels, checkout default, webhook default

## Env vars needed in Stripe + Vercel

New `STRIPE_PRICE_*` env vars for each plan (set once Stripe Products/Prices are created):

**Service:** `STRIPE_PRICE_SIGNAL`, `STRIPE_PRICE_SYSTEM`, `STRIPE_PRICE_FULL_STACK`

**B2B:** `STRIPE_PRICE_B2B_INBOUND`, `STRIPE_PRICE_B2B_PIPELINE`, `STRIPE_PRICE_B2B_FULL_STACK`

**Add-ons (set as needed):** `STRIPE_PRICE_ADDON_TECH_STACK_AUDIT`, `STRIPE_PRICE_ADDON_CRM_SETUP`, `STRIPE_PRICE_ADDON_WORKFLOW_AUTOMATION`, `STRIPE_PRICE_ADDON_UNIFIED_ANALYTICS`, `STRIPE_PRICE_ADDON_SEO_AUDIT`, `STRIPE_PRICE_ADDON_LOCAL_SEO`, `STRIPE_PRICE_ADDON_CONTENT_ENGINE`, `STRIPE_PRICE_ADDON_SITE_PERF`, `STRIPE_PRICE_ADDON_CONTENT_CALENDAR`, `STRIPE_PRICE_ADDON_VIDEO_SCRIPTS`, `STRIPE_PRICE_ADDON_SOCIAL_LISTENING`, `STRIPE_PRICE_ADDON_LINKEDIN`, `STRIPE_PRICE_ADDON_BRAND_AUDIT`, `STRIPE_PRICE_ADDON_BRAND_KIT`, `STRIPE_PRICE_ADDON_VOICE_GUIDE`, `STRIPE_PRICE_ADDON_VISUAL_TEMPLATES`, `STRIPE_PRICE_ADDON_CONVERSION_COPY`, `STRIPE_PRICE_ADDON_FUNNEL_BUILD`, `STRIPE_PRICE_ADDON_NURTURE_SEQ`, `STRIPE_PRICE_ADDON_OFFER_WORKSHOP`, `STRIPE_PRICE_ADDON_SOP_DOCS`, `STRIPE_PRICE_ADDON_CLIENT_ONBOARDING`, `STRIPE_PRICE_ADDON_KPI_DASHBOARD`, `STRIPE_PRICE_ADDON_TEAM_PLAYBOOK`

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Existing Stripe webhook payloads with old plan IDs (e.g. `agents_founding`) resolve via legacy aliases
- [ ] `/api/checkout` with `planId: "signal"` creates a valid Stripe session
- [ ] Onboarding page shows correct labels for all plan IDs
- [ ] Client dashboard shows correct labels for all plan IDs
- [ ] Admin revenue view shows correct labels

https://claude.ai/code/session_01WeTcZAQ1cLvNQmNdcVV7ZQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeTcZAQ1cLvNQmNdcVV7ZQ)_