### PR TITLE
Refocus homepage on service businesses: new hero, single CTA, persistent CTAs, $2,560/30-day proof

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -15,7 +15,7 @@
 
 ## Key Case Studies & Data
 
-- [Santa E. Case Study](https://www.opsbynoell.com/case-studies/santa-e): A solo licensed massage therapist recovered 4 missed calls and $960 in revenue in 14 days, while reducing no-shows by 75%.
+- [Santa E. Case Study](https://www.opsbynoell.com/case-studies/santa-e): A solo licensed massage therapist recovered 4 missed calls and $2,560 in revenue in 30 days, while reducing no-shows by 75%.
 - [Missed Call Data](https://www.opsbynoell.com/resources/missed-call-recovery-for-service-businesses): 70% of missed calls never leave a voicemail. The response window before a lead goes cold is 5 minutes. 78% of clients book with whoever responds first.
 
 ## Target Industries

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -118,15 +118,15 @@ export default function AboutPage() {
               Client result
             </p>
             <blockquote className="font-serif italic text-xl md:text-2xl text-cream leading-snug mb-6">
-              &ldquo;In fourteen days, four missed calls turned into booked appointments and $960 in recovered revenue.&rdquo;
+              &ldquo;In thirty days, four missed calls turned into booked appointments and $2,560 in recovered revenue.&rdquo;
             </blockquote>
             <p className="text-sm text-cream/60 mb-8">
               Santa E., Healing Hands by Santa, Laguna Niguel CA
             </p>
             <div className="grid grid-cols-3 gap-4 border-t border-white/10 pt-6">
               <div className="text-center">
-                <p className="font-serif text-3xl md:text-4xl font-semibold text-cream">$960</p>
-                <p className="text-[11px] uppercase tracking-widest text-cream/50 mt-1">Recovered in 14 days</p>
+                <p className="font-serif text-3xl md:text-4xl font-semibold text-cream">$2,560</p>
+                <p className="text-[11px] uppercase tracking-widest text-cream/50 mt-1">Recovered in 30 days</p>
               </div>
               <div className="text-center">
                 <p className="font-serif text-3xl md:text-4xl font-semibold text-cream">75%</p>

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -180,13 +180,13 @@ export default function BookPage() {
             Currently running
           </p>
           <p className="font-serif text-lg md:text-xl text-cream leading-snug">
-            Healing Hands by Santa, a solo licensed massage practice in Laguna Niguel, was losing clients every time she was with a client. Her phone went quiet. No follow-up went out. Clients booked elsewhere. In fourteen days, four missed calls turned into booked appointments and{" "}
-            <span className="text-wine font-semibold">$960 in recovered revenue.</span> No new software. No configuration. We built it, installed it, and ran it.
+            Healing Hands by Santa, a solo licensed massage practice in Laguna Niguel, was losing clients every time she was with a client. Her phone went quiet. No follow-up went out. Clients booked elsewhere. In thirty days, four missed calls turned into booked appointments and{" "}
+            <span className="text-wine font-semibold">$2,560 in recovered revenue.</span> No new software. No configuration. We built it, installed it, and ran it.
           </p>
           <div className="mt-5 grid grid-cols-3 gap-4 border-t border-white/10 pt-5">
             {[
               { stat: "4", label: "missed calls recovered" },
-              { stat: "$960", label: "revenue in 14 days" },
+              { stat: "$2,560", label: "revenue in 30 days" },
               { stat: "75%", label: "fewer no-shows" },
             ].map((item) => (
               <div key={item.stat} className="text-center">

--- a/src/app/book/thanks/page.tsx
+++ b/src/app/book/thanks/page.tsx
@@ -106,10 +106,10 @@ export default function BookThanksPage() {
             Healing Hands by Santa, a solo licensed massage practice in Laguna
             Niguel, was losing clients every time she was with a client. Her
             phone went quiet. No follow-up went out. Clients booked elsewhere.
-            In fourteen days, four missed calls turned into booked appointments
+            In thirty days, four missed calls turned into booked appointments
             and{" "}
             <span className="text-wine font-semibold">
-              $960 in recovered revenue.
+              $2,560 in recovered revenue.
             </span>{" "}
             No new software. No configuration. We built it, installed it, and
             ran it.
@@ -117,7 +117,7 @@ export default function BookThanksPage() {
           <div className="mt-5 grid grid-cols-3 gap-4 border-t border-white/10 pt-5">
             {[
               { stat: "4", label: "missed calls recovered" },
-              { stat: "$960", label: "revenue in 14 days" },
+              { stat: "$2,560", label: "revenue in 30 days" },
               { stat: "75%", label: "fewer no-shows" },
             ].map((item) => (
               <div key={item.stat} className="text-center">

--- a/src/app/case-studies/page.tsx
+++ b/src/app/case-studies/page.tsx
@@ -16,11 +16,11 @@ const caseStudies = [
   {
     href: "/case-studies/santa-e",
     name: "Santa E.: Massage Therapist",
-    result: "$960 recovered in 14 days",
+    result: "$2,560 recovered in 30 days",
     description:
-      "A solo massage therapist in Orange County recovered four missed calls and rebooked them within 14 days of installing a done-for-you AI front desk.",
+      "A solo massage therapist in Orange County recovered missed calls and rebooked them within 30 days of installing a done-for-you AI front desk.",
     vertical: "Massage Therapy",
-    timeline: "14 days",
+    timeline: "30 days",
   },
 ];
 

--- a/src/app/case-studies/santa-e/page.tsx
+++ b/src/app/case-studies/santa-e/page.tsx
@@ -8,14 +8,14 @@ import {
 } from "@/lib/schema";
 
 const PATH = "/case-studies/santa-e";
-const TITLE = "Santa E., massage therapist: $960 recovered in 14 days";
+const TITLE = "Santa E., massage therapist: $2,560 recovered in 30 days";
 const DESCRIPTION =
-  "How one solo massage therapist in Orange County recovered four missed calls and rebooked them within 14 days of installing a done-for-you AI front desk.";
+  "How one solo massage therapist in Orange County recovered $2,560 in 30 days by catching missed calls and rebooking them, after installing a done-for-you AI front desk.";
 const PUBLISHED = "2026-04-18";
 
 export const metadata = pageMetadata({
   path: PATH,
-  title: "Santa E. case study, $960 recovered in 14 days",
+  title: "Santa E. case study, $2,560 recovered in 30 days",
   description: DESCRIPTION,
   type: "article",
   publishedTime: PUBLISHED,
@@ -50,9 +50,9 @@ export default function CaseStudy() {
       />
       <ArticleLayout
         eyebrow="Case study · 4 min"
-        title="Santa E., massage therapist: $960 recovered in 14 days"
-        lead="A solo practitioner. Four missed calls the old way would have eaten. All four rebooked within 14 days of install."
-        meta="Orange County, CA · Solo massage practice · 14-day result"
+        title="Santa E., massage therapist: $2,560 recovered in 30 days"
+        lead="A solo practitioner. Missed calls the old way would have eaten, caught and rebooked. $1,060 back in the first 14 days, $2,560 by day 30."
+        meta="Orange County, CA · Solo massage practice · 30-day result"
       >
         <p>
           Santa, owner of Healing Hands by Santa, has run a solo licensed
@@ -107,16 +107,24 @@ export default function CaseStudy() {
           a client who has since rebooked twice.
         </p>
 
-        <h2>The fourteen-day result</h2>
+        <h2>The first fourteen days</h2>
         <ul>
           <li>Four new-client missed calls caught by the text-back layer.</li>
           <li>All four rebooked inside the same week.</li>
-          <li>$960 in recovered revenue, net.</li>
+          <li>$1,060 in recovered revenue, net, in the first two weeks.</li>
           <li>
             Zero additional work for Santa. No dashboard, no configuration, no
             &ldquo;training the AI.&rdquo;
           </li>
         </ul>
+
+        <h2>The thirty-day result</h2>
+        <p>
+          The text-back layer kept catching missed calls through the rest of
+          the month. By day 30, the system had recovered{" "}
+          <strong>$2,560 in booked revenue</strong>, net, for a practice that
+          had been letting that intent die on voicemail.
+        </p>
 
         <h2>What made the recovery possible</h2>
         <p>

--- a/src/app/compare/human-answering-services/page.tsx
+++ b/src/app/compare/human-answering-services/page.tsx
@@ -89,7 +89,7 @@ export default function Compare() {
         }
         internalLinks={[
           { label: "Noell Front Desk: operations layer", href: "/noell-front-desk" },
-          { label: "Santa E. case study: $960 recovered in 14 days", href: "/case-studies/santa-e" },
+          { label: "Santa E. case study: $2,560 recovered in 30 days", href: "/case-studies/santa-e" },
           { label: "Read: AI front desk vs. human receptionist", href: "/resources/ai-front-desk-vs-human-receptionist" },
         ]}
       />

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -113,7 +113,7 @@ export default function ComparePage() {
         {/* Proof strip */}
         <div className="max-w-2xl mx-auto mt-12 grid grid-cols-3 gap-4 rounded-2xl border border-white/10 bg-[#271520]/60 px-6 py-6">
           {[
-            { stat: "$960", label: "recovered in 14 days" },
+            { stat: "$2,560", label: "recovered in 30 days" },
             { stat: "75%", label: "fewer no-shows" },
             { stat: "14 days", label: "to live, fully managed" },
           ].map((item) => (

--- a/src/app/for-service-businesses/page.tsx
+++ b/src/app/for-service-businesses/page.tsx
@@ -321,8 +321,8 @@ export default function ForServiceBusinessesPage() {
               <p className="text-[11px] text-cream/70 mt-1 uppercase tracking-wide">missed calls<br />recovered</p>
             </div>
             <div className="text-center">
-              <p className="font-serif text-3xl md:text-4xl font-semibold text-wine">$960</p>
-              <p className="text-[11px] text-cream/70 mt-1 uppercase tracking-wide">recovered<br />in 14 days</p>
+              <p className="font-serif text-3xl md:text-4xl font-semibold text-wine">$2,560</p>
+              <p className="text-[11px] text-cream/70 mt-1 uppercase tracking-wide">recovered<br />in 30 days</p>
             </div>
             <div className="text-center">
               <p className="font-serif text-3xl md:text-4xl font-semibold text-wine">75%</p>
@@ -615,7 +615,7 @@ export default function ForServiceBusinessesPage() {
                 Find out what your front desk is costing you.
               </p>
               <p className="text-sm text-cream/65 leading-relaxed max-w-xl mx-auto">
-                Santa recovered $960 in 14 days without changing how she works. Pick a time below and we will audit your front desk on the call.
+                Santa recovered $2,560 in 30 days without changing how she works. Pick a time below and we will audit your front desk on the call.
               </p>
             </div>
             <BookingCalendarEmbed

--- a/src/app/how-it-works/page.tsx
+++ b/src/app/how-it-works/page.tsx
@@ -395,7 +395,7 @@ export default function HowItWorksPage() {
             <div className="mt-8 flex flex-wrap justify-center gap-8">
               {[
                 { value: "4", label: "Missed calls recovered" },
-                { value: "$960", label: "Recovered in 14 days" },
+                { value: "$2,560", label: "Recovered in 30 days" },
                 { value: "75%", label: "Fewer no-shows" },
               ].map((stat) => (
                 <div key={stat.label} className="text-center">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Hero } from "@/components/hero";
 import { BookingCalendarEmbed } from "@/components/booking-calendar-embed";
+import { StickyMobileBookCta } from "@/components/book-sticky-mobile-cta";
 import { Systems } from "@/components/systems";
 import { FAQ, type FaqItem } from "@/components/faq";
 import { JsonLd } from "@/components/json-ld";
@@ -28,13 +29,13 @@ const homepageFaqs: FaqItem[] = [
     id: "is-this-a-sales-pitch",
     question: "Is this a sales pitch?",
     answer:
-      "No. The Missed Call Audit and the Digital Readiness Review are both working deliverables. You leave with a clear map of what is leaking, what it is worth, and whether Ops by Noell is the right fit. If it is not, we will say so.",
+      "No. The Missed Call Audit is a working deliverable. You leave with a clear map of what is leaking, what it is worth, and whether Ops by Noell is the right fit. If it is not, we will say so.",
   },
   {
     id: "who-is-this-for",
     question: "Who is this for?",
     answer:
-      "Two types of business. Service businesses including dental practices, med spas, salons, coaches, agencies, and professional service firms where every missed call or slow follow-up costs a client. And B2B and SaaS companies including AI vendors and tech startups where the gap between your pitch and your website is costing you deals.",
+      "Local appointment-based service businesses: dental practices, med spas, salons, massage and wellness practices, and other professional service firms where every missed call or slow follow-up costs a booked appointment.",
   },
   {
     id: "what-does-done-for-you-mean",
@@ -46,7 +47,7 @@ const homepageFaqs: FaqItem[] = [
     id: "how-long-to-go-live",
     question: "How long until the system is live?",
     answer:
-      "Most service business installs are live within 14 days. B2B engagements vary based on scope but start with a Digital Readiness Review that delivers findings within the first session.",
+      "Most service business installs are live within 14 days. Your free Missed Call Audit delivers findings within the first session, before anything is built.",
   },
 ];
 
@@ -57,7 +58,7 @@ export default function Home() {
         data={servicePageSchema({
           name: "Ops by Noell AI Operations",
           description:
-            "Done-for-you AI operational systems for service businesses and B2B companies. Built, installed, and managed by our team.",
+            "Done-for-you AI front desk and operations systems for local appointment-based service businesses. Built, installed, and managed by our team.",
           path: "/",
         })}
         id="home-service"
@@ -72,20 +73,23 @@ export default function Home() {
       />
 
       {/* ─── 1. HOOK ─────────────────────────────────────────────────────────
-          Brand-level headline. Speaks to both audiences.
+          Service-business headline. Single audience, single primary CTA.
       ─────────────────────────────────────────────────────────────────────── */}
       <Hero
-        eyebrow="For service-based businesses"
-        headlineLine1Start="While you are with a client,"
+        eyebrow="For local practices and solo operators who can't catch every call"
+        headlineLine1Start="While you're with a client,"
         headlineLine1Accent=""
-        headlineLine2Start="someone else is answering"
-        headlineLine2Accent="your phone."
+        headlineLine2Start="who's"
+        headlineLine2Accent="picking up?"
         headlineLine2Smaller={false}
-        body="Every missed call is a client who called the next business on Google. Ops by Noell builds and runs your AI front desk so nothing slips through. Done for you. Live in 14 days. No software to learn."
-        footnote=""
+        body="We build and run an AI front desk that answers and follows up on every call, day or night, so a Laguna Niguel practice recovered $2,560 in 30 days. Done for you. Live in 14 days."
+        footnote="Who's answering the phone? Who's following up on every missed call? Who's there after you close?"
         primaryCta={{ label: "Get Your Free Missed Call Audit", href: "/book" }}
-        secondaryCta={{ label: "See How It Works", href: "/systems" }}
-        showProofBar={false}
+        secondaryCta={null}
+        showProofBar={true}
+        priceSignal={
+          <>Free. No pitch. If we can&apos;t find recoverable revenue, we&apos;ll tell you.</>
+        }
       />
 
       {/* ─── 2. PROOF ────────────────────────────────────────────────────────
@@ -101,10 +105,10 @@ export default function Home() {
           </p>
           <p className="font-serif text-lg md:text-xl text-cream leading-snug">
             Keeping the front desk moving for Healing Hands by Santa, a solo
-            licensed therapeutic massage practice in Laguna Niguel. In fourteen
-            days, four missed calls turned into booked appointments and{" "}
+            licensed therapeutic massage practice in Laguna Niguel. In 30 days,
+            missed calls turned into booked appointments and{" "}
             <span className="text-wine font-semibold">
-              $960 in recovered revenue.
+              $2,560 in recovered revenue.
             </span>
           </p>
           <div className="mt-5 flex flex-col sm:flex-row sm:items-center gap-4">
@@ -237,104 +241,6 @@ export default function Home() {
         </div>
       </section>
 
-      {/* ─── 4. AUDIENCE SPLIT ───────────────────────────────────────────────
-          The moment the visitor self-identifies. Two tracks. Clean routing.
-          Now positioned after the "aha moment" from the calculator.
-      ─────────────────────────────────────────────────────────────────────── */}
-      <section className="w-full py-16 md:py-24 px-4 border-t border-white/5">
-        <div className="max-w-5xl mx-auto">
-          <div className="text-center mb-12">
-            <p className="text-[11px] uppercase tracking-[0.25em] text-wine mb-4">
-              Who we work with
-            </p>
-            <h2 className="font-serif text-3xl md:text-5xl font-semibold text-cream leading-tight">
-              Two types of business.{" "}
-              <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
-                One team that runs it for you.
-              </span>
-            </h2>
-          </div>
-
-          <div className="grid gap-6 md:grid-cols-2 items-stretch">
-            {/* Track 1: Service Businesses */}
-            <Link
-              href="/for-service-businesses"
-              className="group relative flex flex-col rounded-[22px] bg-[#271520] p-8 md:p-10 border border-white/10 hover:border-wine/40 transition-all duration-300 shadow-[0px_4px_8px_0px_rgba(28,25,23,0.05),0px_15px_15px_0px_rgba(28,25,23,0.04)] hover:shadow-[0px_8px_24px_0px_rgba(106,44,62,0.12)]"
-            >
-              <p className="text-[11px] uppercase tracking-[0.2em] text-wine/85 mb-3">
-                Track 01
-              </p>
-              <h3 className="font-serif text-2xl md:text-3xl font-semibold text-cream mb-4 leading-snug">
-                Service-Based Businesses
-              </h3>
-              <p className="text-cream/75 leading-relaxed mb-6 flex-1">
-                You built a great business. But every missed call, slow follow-up, and lapsed client is revenue leaving quietly. Your competitors are not better than you. They just pick up the phone.
-              </p>
-              <ul className="space-y-2.5 mb-8">
-                {[
-                  "Every missed call recovered within 5 minutes via SMS",
-                  "Lapsed clients reactivated before they book elsewhere",
-                  "No software to learn. We build it, run it, and manage it.",
-                ].map((item) => (
-                  <li
-                    key={item}
-                    className="flex items-start gap-2.5 text-sm text-cream/80"
-                  >
-                    <span className="flex-shrink-0 mt-0.5 w-4 h-4 rounded-full bg-wine/10 text-wine flex items-center justify-center text-[10px] font-bold">
-                      ✓
-                    </span>
-                    {item}
-                  </li>
-                ))}
-              </ul>
-              <div className="mt-auto flex items-center gap-2 text-wine font-medium text-sm group-hover:gap-3 transition-all">
-                See how it works for service businesses
-                <span className="text-base">→</span>
-              </div>
-            </Link>
-
-            {/* Track 2: B2B & SaaS */}
-            <Link
-              href="/for-b2b"
-              className="group relative flex flex-col rounded-[22px] bg-[#271520] p-8 md:p-10 border border-wine/40 hover:border-wine transition-all duration-300 shadow-[0px_4px_8px_0px_rgba(106,44,62,0.12),0px_15px_15px_0px_rgba(106,44,62,0.08)] hover:shadow-[0px_8px_24px_0px_rgba(106,44,62,0.22)]"
-            >
-              <p className="text-[11px] uppercase tracking-[0.2em] text-wine/85 mb-3">
-                Track 02
-              </p>
-              <h3 className="font-serif text-2xl md:text-3xl font-semibold text-cream mb-4 leading-snug">
-                B2B & SaaS
-              </h3>
-              <p className="text-cream/80 leading-relaxed mb-6 flex-1">
-                B2B and SaaS companies, AI vendors, and tech startups. Your
-                pitch lands in the boardroom. Then procurement visits your
-                website. In seven seconds, the deal either holds or collapses.
-              </p>
-              <ul className="space-y-2.5 mb-8">
-                {[
-                  "Predictive Customer Intelligence surfaces accounts before they move",
-                  "Digital presence rebuilt to survive the procurement research window",
-                  "Live B2B pipeline dashboard tracks every deal and ICP score",
-                ].map((item) => (
-                  <li
-                    key={item}
-                    className="flex items-start gap-2.5 text-sm text-cream/85"
-                  >
-                    <span className="flex-shrink-0 mt-0.5 w-4 h-4 rounded-full bg-wine/10 text-wine flex items-center justify-center text-[10px] font-bold">
-                      ✓
-                    </span>
-                    {item}
-                  </li>
-                ))}
-              </ul>
-              <div className="mt-auto flex items-center gap-2 text-wine font-medium text-sm group-hover:gap-3 transition-all">
-                See how it works for B2B companies
-                <span className="text-base">→</span>
-              </div>
-            </Link>
-          </div>
-        </div>
-      </section>
-
       {/* ─── 5. THE SYSTEM ───────────────────────────────────────────────────
           Three agents. PCI band collapsed — one tight "how it works" section.
           FounderQuote removed — Santa testimonial above already handles trust.
@@ -369,7 +275,7 @@ export default function Home() {
               </span>
             </h2>
             <p className="text-base text-cream/70 max-w-xl mx-auto leading-relaxed">
-              We map the leaks in your front desk, follow-up, and operations. You will know what is being missed, what it is worth, and which track fits. No pitch. No pressure.
+              We map the leaks in your front desk, follow-up, and operations. You will know what is being missed, what it is worth, and what the fix looks like. No pitch. No pressure.
             </p>
           </div>
           <div className="rounded-[22px] border border-wine/30 bg-[#271520] p-6 md:p-8">
@@ -380,6 +286,13 @@ export default function Home() {
           </div>
         </div>
       </section>
+
+      {/* Persistent mobile CTA — appears once the visitor scrolls past the hero */}
+      <StickyMobileBookCta
+        href="/book"
+        sourcePage="home"
+        sourceSection="sticky_mobile"
+      />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -87,6 +87,7 @@ export default function Home() {
         primaryCta={{ label: "Get Your Free Missed Call Audit", href: "/book" }}
         secondaryCta={null}
         showProofBar={true}
+        clipHalo={true}
         priceSignal={
           <>Free. No pitch. If we can&apos;t find recoverable revenue, we&apos;ll tell you.</>
         }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -87,7 +87,7 @@ export default function Home() {
         primaryCta={{ label: "Get Your Free Missed Call Audit", href: "/book" }}
         secondaryCta={null}
         showProofBar={true}
-        clipHalo={true}
+        softHalo={true}
         priceSignal={
           <>Free. No pitch. If we can&apos;t find recoverable revenue, we&apos;ll tell you.</>
         }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -83,7 +83,7 @@ export default function Home() {
         headlineLine2Accent="picking up?"
         headlineLine2Smaller={false}
         body="We build and run an AI front desk that answers and follows up on every call, day or night, so a Laguna Niguel practice recovered $2,560 in 30 days. Done for you. Live in 14 days."
-        footnote="Who's answering the phone? Who's following up on every missed call? Who's there after you close?"
+        footnote=""
         primaryCta={{ label: "Get Your Free Missed Call Audit", href: "/book" }}
         secondaryCta={null}
         showProofBar={true}
@@ -246,6 +246,17 @@ export default function Home() {
           Three agents. PCI band collapsed — one tight "how it works" section.
           FounderQuote removed — Santa testimonial above already handles trust.
       ─────────────────────────────────────────────────────────────────────── */}
+      {/* Agitation lead-in (relocated from the hero) — sits directly above
+          the "Three jobs, handled" block as its question header. */}
+      <section className="px-4 pt-20 md:pt-28 text-center -mb-10 md:-mb-16 border-t border-white/5">
+        <p className="max-w-3xl mx-auto font-serif text-2xl md:text-3xl font-semibold text-cream leading-snug">
+          Who&apos;s answering the phone? Who&apos;s following up on every missed
+          call?{" "}
+          <span className="italic bg-gradient-to-b from-wine-light to-wine bg-clip-text text-transparent">
+            Who&apos;s there after you close?
+          </span>
+        </p>
+      </section>
       <Systems />
 
       {/* ─── 6. FAQ + CTA ────────────────────────────────────────────────────

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -250,15 +250,15 @@ export default function PricingPage() {
             <p className="font-serif text-base md:text-lg text-cream leading-snug">
               Healing Hands by Santa, a solo licensed massage practice in Laguna Niguel, was losing
               clients every time she was with a client. Her phone went quiet. No follow-up went out.
-              Clients booked elsewhere. In fourteen days, four missed calls turned into booked
+              Clients booked elsewhere. In thirty days, four missed calls turned into booked
               appointments and{" "}
-              <span className="text-wine font-semibold">$960 in recovered revenue.</span> No new
+              <span className="text-wine font-semibold">$2,560 in recovered revenue.</span> No new
               software. No configuration. We built it, installed it, and ran it.
             </p>
             <div className="mt-5 grid grid-cols-3 gap-4 border-t border-white/10 pt-5">
               {[
                 { stat: "4", label: "Missed calls recovered" },
-                { stat: "$960", label: "Revenue in 14 days" },
+                { stat: "$2,560", label: "Revenue in 30 days" },
                 { stat: "75%", label: "Fewer no-shows" },
               ].map((item) => (
                 <div key={item.stat} className="text-center">

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -106,7 +106,7 @@ const resources: Resource[] = [
   {
     kind: "Case study",
     status: "live",
-    title: "Santa E., massage therapist, $960 recovered in 14 days",
+    title: "Santa E., massage therapist, $2,560 recovered in 30 days",
     excerpt:
       "How one solo massage therapist in Orange County recovered four missed calls and booked them inside two weeks of install.",
     href: "/case-studies/santa-e",

--- a/src/app/resources/revenue-calculator/page.tsx
+++ b/src/app/resources/revenue-calculator/page.tsx
@@ -16,7 +16,7 @@ export const metadata = pageMetadata({
     "Industry-specific revenue calculator for dental, med spa, and chiropractic practices. Monthly leads, booking rate, no-show rate, and the Santa proof math.",
   ogTitle: "Industry Revenue Calculator, Ops by Noell",
   ogDescription:
-    "Enter your monthly leads, booking rate, and no-show rate. We show you what the Noell System would recover, based on Santa's actual 75% no-show reduction and $960 recovered in 14 days.",
+    "Enter your monthly leads, booking rate, and no-show rate. We show you what the Noell System would recover, based on Santa's actual 75% no-show reduction and $2,560 recovered in 30 days.",
 });
 
 export default function RevenueCalculatorPage() {
@@ -72,9 +72,9 @@ export default function RevenueCalculatorPage() {
           </div>
           <div className="hidden md:block w-px bg-warm-border self-stretch" />
           <div className="text-center">
-            <p className="font-serif text-2xl md:text-3xl font-semibold text-wine">$960</p>
+            <p className="font-serif text-2xl md:text-3xl font-semibold text-wine">$2,560</p>
             <p className="text-[10px] uppercase tracking-[0.2em] text-cream/70 mt-1">
-              recovered in 14 days
+              recovered in 30 days
             </p>
           </div>
           <div className="hidden md:block w-px bg-warm-border self-stretch" />

--- a/src/app/thank-you/page.tsx
+++ b/src/app/thank-you/page.tsx
@@ -90,10 +90,10 @@ export default function ThankYouPage() {
             Healing Hands by Santa, a solo licensed massage practice in Laguna
             Niguel, was losing clients every time she was with a client. Her
             phone went quiet. No follow-up went out. Clients booked elsewhere.
-            In fourteen days, four missed calls turned into booked appointments
+            In thirty days, four missed calls turned into booked appointments
             and{" "}
             <span className="text-wine font-semibold">
-              $960 in recovered revenue.
+              $2,560 in recovered revenue.
             </span>{" "}
             No new software. No configuration. We built it, installed it, and
             ran it.
@@ -101,7 +101,7 @@ export default function ThankYouPage() {
           <div className="mt-5 grid grid-cols-3 gap-4 border-t border-white/10 pt-5">
             {[
               { stat: "4", label: "missed calls recovered" },
-              { stat: "$960", label: "revenue in 14 days" },
+              { stat: "$2,560", label: "revenue in 30 days" },
               { stat: "75%", label: "fewer no-shows" },
             ].map((item) => (
               <div key={item.stat} className="text-center">

--- a/src/app/verticals/massage/page.tsx
+++ b/src/app/verticals/massage/page.tsx
@@ -33,9 +33,9 @@ export const metadata = pageMetadata({
 
 const massageStats = [
   {
-    value: "$960",
+    value: "$2,560",
     label: "Recovered",
-    detail: "in 14 days from missed calls, real install",
+    detail: "in 30 days from missed calls, real install",
   },
   {
     value: "<1",
@@ -145,7 +145,7 @@ const massageFaqs = [
   {
     question: "How long is install and how much do I have to set up?",
     answer:
-      "Most massage installs are live in fourteen days. You do not configure anything. We write the copy with you, plug in your booking tool, and handle the routing. Your part is roughly a sixty-minute voice-match call during install and a short weekly report after that.",
+      "Most massage installs are live in 14 days. You do not configure anything. We write the copy with you, plug in your booking tool, and handle the routing. Your part is roughly a sixty-minute voice-match call during install and a short weekly report after that.",
   },
 ];
 
@@ -184,9 +184,9 @@ const massageScreen = (
 
     <div className="bg-wine rounded-2xl p-3 mx-1 mt-2 shadow-sm">
       <p className="text-[10px] uppercase tracking-widest text-cream/70 font-medium">
-        Recovered, 14 days
+        Recovered, 30 days
       </p>
-      <p className="font-serif text-3xl font-bold text-cream mt-0.5">$960</p>
+      <p className="font-serif text-3xl font-bold text-cream mt-0.5">$2,560</p>
       <p className="text-[11px] text-cream/60">
         from 4 missed calls, all booked
       </p>
@@ -297,7 +297,7 @@ export default function MassageVerticalPage() {
         role="licensed massage therapist"
         business="Laguna Niguel"
         metrics={[
-          { label: "Recovered", value: "$960" },
+          { label: "Recovered", value: "$2,560" },
           { label: "Days live", value: "14" },
           { label: "Rebooks", value: "4" },
         ]}

--- a/src/components/book-sticky-mobile-cta.tsx
+++ b/src/components/book-sticky-mobile-cta.tsx
@@ -1,18 +1,56 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  trackAuditCtaClick,
+  type SourcePage,
+  type SourceSection,
+} from "@/lib/analytics";
+
+interface StickyMobileBookCtaProps {
+  /**
+   * When provided, the bar becomes a link to this href (e.g. "/book") and
+   * appears after the visitor scrolls past the hero. When omitted, the bar
+   * keeps its original behavior: it watches the BookRequestForm and
+   * smooth-scrolls back to it (used on /book).
+   */
+  href?: string;
+  label?: string;
+  sourcePage?: SourcePage;
+  sourceSection?: SourceSection;
+}
 
 /**
  * StickyMobileBookCta
- * Renders a fixed bottom bar on mobile (<768px) that scrolls into view
- * only when the primary BookRequestForm has scrolled out of the viewport.
- * Clicking it smooth-scrolls back to the form.
+ * Fixed bottom bar on mobile (<768px) that gives the visitor a persistent
+ * path to booking.
+ *
+ * - href mode (e.g. homepage): renders a Link to href, shown once the
+ *   visitor scrolls past the hero (~600px), and fires the audit CTA event.
+ * - form mode (default, /book): shown only when the BookRequestForm has
+ *   scrolled out of view; clicking smooth-scrolls back to the form.
  */
-export function StickyMobileBookCta() {
+export function StickyMobileBookCta({
+  href,
+  label = "Get Your Free Missed Call Audit",
+  sourcePage = "home",
+  sourceSection = "sticky_mobile",
+}: StickyMobileBookCtaProps = {}) {
   const [visible, setVisible] = useState(false);
 
+  // href mode: reveal after scrolling past the hero.
   useEffect(() => {
-    // Watch the form card — show sticky bar when form is out of view
+    if (!href) return;
+    const onScroll = () => setVisible(window.scrollY > 600);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [href]);
+
+  // form mode: reveal when the BookRequestForm scrolls out of view.
+  useEffect(() => {
+    if (href) return;
     const form = document.querySelector('[aria-label="Request a working call"]');
     if (!form) return;
 
@@ -24,34 +62,50 @@ export function StickyMobileBookCta() {
     );
     observer.observe(form);
     return () => observer.disconnect();
-  }, []);
+  }, [href]);
 
-  const handleClick = () => {
+  const handleFormScroll = () => {
     const form = document.querySelector('[aria-label="Request a working call"]');
     if (form) {
       form.scrollIntoView({ behavior: "smooth", block: "start" });
     }
   };
 
+  const wrapperClass = [
+    "md:hidden",
+    "fixed bottom-0 left-0 right-0 z-50",
+    "px-4 py-3",
+    "bg-[#1A0D13] border-t border-white/10",
+    "transition-transform duration-300 ease-in-out",
+    visible ? "translate-y-0" : "translate-y-full",
+  ].join(" ");
+
+  const buttonClass =
+    "block w-full text-center rounded-full bg-wine text-cream text-sm font-medium py-3.5 tap-target hover:bg-wine-dark transition-colors";
+
   return (
-    <div
-      aria-hidden={!visible}
-      className={[
-        // Only visible on mobile
-        "md:hidden",
-        "fixed bottom-0 left-0 right-0 z-50",
-        "px-4 py-3",
-        "bg-[#1A0D13] border-t border-white/10",
-        "transition-transform duration-300 ease-in-out",
-        visible ? "translate-y-0" : "translate-y-full",
-      ].join(" ")}
-    >
-      <button
-        onClick={handleClick}
-        className="w-full rounded-full bg-wine text-cream text-sm font-medium py-3.5 tap-target hover:bg-wine-dark transition-colors"
-      >
-        Get Your Free Missed Call Audit
-      </button>
+    <div aria-hidden={!visible} className={wrapperClass}>
+      {href ? (
+        <Link
+          href={href}
+          className={buttonClass}
+          data-event="audit_cta_click"
+          data-source-page={sourcePage}
+          data-source-section={sourceSection}
+          onClick={() =>
+            trackAuditCtaClick(sourcePage, sourceSection, {
+              destination: href,
+              cta_label: label,
+            })
+          }
+        >
+          {label}
+        </Link>
+      ) : (
+        <button onClick={handleFormScroll} className={buttonClass}>
+          {label}
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/features.tsx
+++ b/src/components/features.tsx
@@ -10,7 +10,7 @@ interface StatCard {
 }
 
 const defaultStats: StatCard[] = [
-  { value: "$960", label: "Revenue", detail: "recovered in 14 days" },
+  { value: "$2,560", label: "Revenue", detail: "recovered in 30 days" },
   { value: "40+", label: "Reviews", detail: "Google reviews in 6 weeks" },
   { value: "<1", label: "No-shows", detail: "per week, down from 4" },
   { value: "14d", label: "Live", detail: "to get the system running" },

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -4,7 +4,6 @@ import { Logo } from "./logo";
 export function Footer() {
   const pages = [
     { title: "Home", href: "/" },
-    { title: "Predictive Customer Intelligence", href: "/predictive-customer-intelligence" },
     { title: "Systems", href: "/systems" },
     { title: "Pricing", href: "/pricing" },
     { title: "ROI Calculator", href: "/roi" },
@@ -19,14 +18,6 @@ export function Footer() {
     { title: "Noell Care", href: "/noell-care" },
     { title: "For Service Businesses", href: "/for-service-businesses" },
     { title: "Upgrade Your AI Tool", href: "/upgrade" },
-  ];
-
-  const b2bProducts = [
-    { title: "Noell Inbound", href: "/noell-inbound" },
-    { title: "Noell Pipeline", href: "/noell-pipeline" },
-    { title: "Noell Account", href: "/noell-account" },
-    { title: "For B2B & SaaS", href: "/for-b2b" },
-    { title: "Predictive Intelligence", href: "/predictive-customer-intelligence" },
   ];
 
   const legal = [
@@ -44,7 +35,7 @@ export function Footer() {
           <div className="flex items-start flex-col max-w-sm">
             <Logo />
             <h2 className="font-serif text-xl md:text-2xl font-medium text-cream mt-6 leading-snug">
-              AI-powered operations for service businesses and B2B teams. Built, installed, and managed end-to-end.
+              AI-powered operations for service businesses. Built, installed, and managed end-to-end.
             </h2>
             {/* Review badge */}
             <div className="mt-6 flex items-center gap-3 rounded-xl border border-white/10 bg-[#271520] px-4 py-3">
@@ -68,7 +59,7 @@ export function Footer() {
             </div>
           </div>
 
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-8 md:gap-12">
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-8 md:gap-12">
             <div className="space-y-5">
               <h3 className="text-[11px] uppercase tracking-widest text-muted-strong">
                 Pages
@@ -107,24 +98,6 @@ export function Footer() {
 
             <div className="space-y-5">
               <h3 className="text-[11px] uppercase tracking-widest text-muted-strong">
-                B2B & SaaS
-              </h3>
-              <ul className="space-y-3">
-                {b2bProducts.map((item, idx) => (
-                  <li key={idx}>
-                    <Link
-                      href={item.href}
-                      className="text-sm text-cream/70 hover:text-cream inline-flex items-center tap-target"
-                    >
-                      {item.title}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-            <div className="space-y-5">
-              <h3 className="text-[11px] uppercase tracking-widest text-muted-strong">
                 Legal
               </h3>
               <ul className="space-y-3">
@@ -145,10 +118,10 @@ export function Footer() {
 
         <div className="flex flex-col md:flex-row justify-between items-center pt-12 mt-12 border-t border-white/10 gap-3">
           <p className="text-xs text-muted-strong">
-            &copy; {new Date().getFullYear()} Ops by Noell. Quiet operations for service businesses and B2B teams.
+            &copy; {new Date().getFullYear()} Ops by Noell. Quiet operations for service businesses.
           </p>
           <p className="text-xs text-muted-strong">
-            Built for both tracks. Managed end-to-end.
+            Done for you. Managed end-to-end.
           </p>
         </div>
         <div className="pt-6 mt-6 border-t border-white/10/60">

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -158,7 +158,7 @@ export function Hero({
           initial={false}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.4, delay: 0.6 }}
-          className="relative z-20 mx-auto mt-3 max-w-xl px-4 text-center text-sm text-cream/80"
+          className="relative z-20 mx-auto mt-6 md:mt-8 max-w-xl px-4 text-center text-sm text-cream/80 leading-relaxed"
         >
           {footnote}
         </motion.p>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -40,7 +40,7 @@ export function Hero({
   body?: string;
   footnote?: string;
   primaryCta?: { label: string; href: string };
-  secondaryCta?: { label: string; href: string };
+  secondaryCta?: { label: string; href: string } | null;
   mockScreen?: React.ReactNode;
   showProofBar?: boolean;
   priceSignal?: React.ReactNode;
@@ -181,15 +181,17 @@ export function Hero({
         >
           {primaryCta.label}
         </Button>
-        <Button
-          href={secondaryCta.href}
-          variant="secondary"
-          className="w-full sm:w-auto h-12 px-7"
-          data-source-page={sourcePage}
-          data-source-section={sourceSection}
-        >
-          {secondaryCta.label}
-        </Button>
+        {secondaryCta && (
+          <Button
+            href={secondaryCta.href}
+            variant="secondary"
+            className="w-full sm:w-auto h-12 px-7"
+            data-source-page={sourcePage}
+            data-source-section={sourceSection}
+          >
+            {secondaryCta.label}
+          </Button>
+        )}
       </motion.div>
 
       {priceSignal && (
@@ -320,8 +322,8 @@ function DefaultMockScreen() {
           </span>
         </div>
         <div className="mt-2 bg-[#301A26] rounded-lg p-2 text-[11px] text-cream/80 leading-snug">
-          "Thanks for reaching out. A few quick questions to confirm we are the
-          right fit, what does your current setup look like?"
+          &ldquo;Thanks for reaching out. A few quick questions to confirm we are the
+          right fit, what does your current setup look like?&rdquo;
         </div>
       </div>
 
@@ -330,8 +332,8 @@ function DefaultMockScreen() {
         <p className="text-[10px] uppercase tracking-widest text-cream/70 font-medium">
           Revenue recovered
         </p>
-        <p className="font-serif text-3xl font-bold text-cream mt-0.5">$4,200</p>
-        <p className="text-[11px] text-cream/60">from 6 missed inquiries · 30 days</p>
+        <p className="font-serif text-3xl font-bold text-cream mt-0.5">$2,560</p>
+        <p className="text-[11px] text-cream/60">from recovered missed calls · 30 days</p>
       </div>
 
       {/* Meeting confirmed card */}

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -28,7 +28,7 @@ export function Hero({
   showProofBar = true,
   priceSignal,
   headlineLine2Smaller = false,
-  clipHalo = false,
+  softHalo = false,
   sourcePage = "home",
   sourceSection = "hero",
 }: {
@@ -46,9 +46,9 @@ export function Hero({
   showProofBar?: boolean;
   priceSignal?: React.ReactNode;
   headlineLine2Smaller?: boolean;
-  /** Contain the decorative ring halo to the mockup area so it never bleeds
-      up across the hero copy. */
-  clipHalo?: boolean;
+  /** Soften the decorative ring outlines (ambient glow + animation stay) so
+      they don't slice across hero copy that sits over the arc. */
+  softHalo?: boolean;
   sourcePage?: SourcePage;
   sourceSection?: SourceSection;
 }) {
@@ -224,7 +224,7 @@ export function Hero({
         >
           <IphoneMockup>{mockScreen ?? <DefaultMockScreen />}</IphoneMockup>
         </motion.div>
-        <BackgroundShape variant={variant} clip={clipHalo} />
+        <BackgroundShape variant={variant} soft={softHalo} />
       </div>
     </div>
   );
@@ -232,12 +232,12 @@ export function Hero({
 
 function BackgroundShape({
   variant = "wine",
-  clip = false,
+  soft = false,
 }: {
   variant?: "wine" | "lilac" | "sage";
-  /** Clip the decorative rings to the mockup area so they never bleed up
-      across the hero text (used where the copy sits over the ring arc). */
-  clip?: boolean;
+  /** Soften the bright ring outlines (keeping the ambient glow + animation)
+      so the rings don't slice across hero copy that sits over the arc. */
+  soft?: boolean;
 }) {
   const isMobile = useMediaQuery("(max-width: 768px)");
   const sizes = isMobile
@@ -259,18 +259,19 @@ function BackgroundShape({
         : "rgba(251,240,235,0.8)";
 
   return (
-    <div
-      className={cn(
-        "absolute inset-0 z-0 flex items-center justify-center",
-        clip && "overflow-hidden"
-      )}
-    >
+    <div className="absolute inset-0 z-0 flex items-center justify-center">
       <div
-        className="absolute z-0 rounded-full border border-white/30"
+        className={cn(
+          "absolute z-0 rounded-full border",
+          soft ? "border-white/10" : "border-white/30"
+        )}
         style={{ width: outer, height: outer }}
       />
       <motion.div
-        className="absolute z-0 rounded-full border border-white"
+        className={cn(
+          "absolute z-0 rounded-full border",
+          soft ? "border-white/20" : "border-white"
+        )}
         style={{
           width: middle,
           height: middle,

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -28,6 +28,7 @@ export function Hero({
   showProofBar = true,
   priceSignal,
   headlineLine2Smaller = false,
+  clipHalo = false,
   sourcePage = "home",
   sourceSection = "hero",
 }: {
@@ -45,6 +46,9 @@ export function Hero({
   showProofBar?: boolean;
   priceSignal?: React.ReactNode;
   headlineLine2Smaller?: boolean;
+  /** Contain the decorative ring halo to the mockup area so it never bleeds
+      up across the hero copy. */
+  clipHalo?: boolean;
   sourcePage?: SourcePage;
   sourceSection?: SourceSection;
 }) {
@@ -220,13 +224,21 @@ export function Hero({
         >
           <IphoneMockup>{mockScreen ?? <DefaultMockScreen />}</IphoneMockup>
         </motion.div>
-        <BackgroundShape variant={variant} />
+        <BackgroundShape variant={variant} clip={clipHalo} />
       </div>
     </div>
   );
 }
 
-function BackgroundShape({ variant = "wine" }: { variant?: "wine" | "lilac" | "sage" }) {
+function BackgroundShape({
+  variant = "wine",
+  clip = false,
+}: {
+  variant?: "wine" | "lilac" | "sage";
+  /** Clip the decorative rings to the mockup area so they never bleed up
+      across the hero text (used where the copy sits over the ring arc). */
+  clip?: boolean;
+}) {
   const isMobile = useMediaQuery("(max-width: 768px)");
   const sizes = isMobile
     ? { outer: 800, middle: 600, inner: 400 }
@@ -247,7 +259,12 @@ function BackgroundShape({ variant = "wine" }: { variant?: "wine" | "lilac" | "s
         : "rgba(251,240,235,0.8)";
 
   return (
-    <div className="absolute inset-0 z-0 flex items-center justify-center">
+    <div
+      className={cn(
+        "absolute inset-0 z-0 flex items-center justify-center",
+        clip && "overflow-hidden"
+      )}
+    >
       <div
         className="absolute z-0 rounded-full border border-white/30"
         style={{ width: outer, height: outer }}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -351,9 +351,9 @@ const DesktopNav = ({ visible }: NavbarProps) => {
           About
         </Link>
       </div>
-      {/* Primary CTA */}
+      {/* Primary CTA — appears once the user scrolls past the hero */}
       <AnimatePresence mode="popLayout" initial={false}>
-        {!visible && (
+        {visible && (
           <motion.div
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0, transition: { duration: 0.2 } }}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -18,10 +18,6 @@ import { useMediaQuery } from "@/hooks/use-media-query";
 const SYSTEMS_LINKS = [
   { name: "Systems Overview", href: "/systems", description: "The full operations platform" },
   { name: "Agents", href: "/agents", description: "Noell Support, Front Desk & Care" },
-  { name: "Predictive Intelligence", href: "/predictive-customer-intelligence", description: "Signals before revenue leaves" },
-  { name: "Noell Inbound", href: "/noell-inbound", description: "B2B lead qualification" },
-  { name: "Noell Pipeline", href: "/noell-pipeline", description: "B2B sales operations" },
-  { name: "Noell Account", href: "/noell-account", description: "B2B account management" },
 ];
 // ─── Platform dropdown links ───────────────────────────────────────────────────
 const PLATFORM_LINKS = [
@@ -29,12 +25,6 @@ const PLATFORM_LINKS = [
     name: "Lead Intelligence Dashboard",
     href: "/platform/lead-intelligence",
     description: "Live leads, conversations, and conversion funnel",
-    external: false,
-  },
-  {
-    name: "B2B Pipeline Dashboard",
-    href: "/platform/b2b-pipeline",
-    description: "Deal stages, ICP scores, and pipeline value",
     external: false,
   },
   {
@@ -126,18 +116,6 @@ const DesktopNav = ({ visible }: NavbarProps) => {
           )}
         >
           For Service Businesses
-        </Link>
-        {/* For B2B & SaaS — accent only when it is the current page */}
-        <Link
-          href="/for-b2b"
-          className={cn(
-            "px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors",
-            isActive("/for-b2b")
-              ? "text-[#C45A2A]"
-              : "text-cream/80 hover:text-cream hover:bg-wine/10"
-          )}
-        >
-          For B2B &amp; SaaS
         </Link>
         {/* Systems dropdown */}
         <div
@@ -462,19 +440,6 @@ const MobileNav = ({ visible }: NavbarProps) => {
               )}
             >
               For Service Businesses
-            </Link>
-            {/* For B2B & SaaS — accent only when it is the current page */}
-            <Link
-              href="/for-b2b"
-              onClick={() => setOpen(false)}
-              className={cn(
-                "w-full px-3 py-2.5 rounded-xl transition-colors text-sm font-medium",
-                isActive("/for-b2b")
-                  ? "text-[#C45A2A]"
-                  : "text-cream/90 hover:text-cream hover:bg-wine/10"
-              )}
-            >
-              For B2B &amp; SaaS
             </Link>
             <div className="w-full h-px bg-white/8 my-1" />
             {/* Systems accordion */}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { cn } from "@/lib/utils";
-import { IconMenu2, IconX } from "@tabler/icons-react";
+import { IconMenu2, IconX, IconChevronDown } from "@tabler/icons-react";
 import {
   motion,
   AnimatePresence,
@@ -14,6 +14,12 @@ import { Button } from "./button";
 import { Logo } from "./logo";
 import { trackAuditCtaClick } from "@/lib/analytics";
 import { useMediaQuery } from "@/hooks/use-media-query";
+// ─── Resources dropdown links ──────────────────────────────────────────────────
+const RESOURCES_LINKS = [
+  { name: "Case Studies", href: "/case-studies", description: "Real results from real clients" },
+  { name: "Compare", href: "/compare", description: "How we stack up against alternatives" },
+  { name: "ROI Calculator", href: "/roi", description: "Estimate your missed revenue" },
+];
 interface NavbarProps {
   visible: boolean;
 }
@@ -50,6 +56,7 @@ export const Navbar = () => {
 };
 // ─── Desktop nav ────────────────────────────────────────────────────────────
 const DesktopNav = ({ visible }: NavbarProps) => {
+  const [resourcesOpen, setResourcesOpen] = useState(false);
   const isActive = useIsActivePath();
   // Below 2xl the full item row plus the CTA button needs more of the
   // viewport, otherwise nav items collide with the button around 1450px.
@@ -88,6 +95,59 @@ const DesktopNav = ({ visible }: NavbarProps) => {
         >
           For Service Businesses
         </Link>
+        {/* Resources dropdown */}
+        <div
+          className="relative"
+          onMouseEnter={() => setResourcesOpen(true)}
+          onMouseLeave={() => setResourcesOpen(false)}
+        >
+          <button
+            type="button"
+            onClick={() => setResourcesOpen((v) => !v)}
+            className={cn(
+              "flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium transition-colors",
+              resourcesOpen
+                ? "text-wine bg-wine/15"
+                : "text-cream/80 hover:text-cream hover:bg-wine/10"
+            )}
+          >
+            Resources
+            <IconChevronDown
+              size={13}
+              className={cn(
+                "transition-transform duration-200",
+                resourcesOpen ? "rotate-180" : "rotate-0"
+              )}
+            />
+          </button>
+          <AnimatePresence>
+            {resourcesOpen && (
+              <motion.div
+                initial={{ opacity: 0, y: 8, scale: 0.97 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: 8, scale: 0.97 }}
+                transition={{ duration: 0.18, ease: "easeOut" }}
+                className="absolute top-full left-1/2 -translate-x-1/2 mt-3 w-72 rounded-2xl border border-white/10 bg-[#1F1219]/98 backdrop-blur-xl shadow-[0_20px_40px_-10px_rgba(28,25,23,0.12)] p-2 z-50"
+              >
+                {RESOURCES_LINKS.map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    onClick={() => setResourcesOpen(false)}
+                    className="flex flex-col px-3.5 py-2.5 rounded-xl hover:bg-wine/10 transition-colors group"
+                  >
+                    <span className="text-sm font-medium text-cream group-hover:text-wine transition-colors">
+                      {link.name}
+                    </span>
+                    <span className="text-[11px] text-cream/55 mt-0.5">
+                      {link.description}
+                    </span>
+                  </Link>
+                ))}
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
         {/* Pricing */}
         <Link
           href="/pricing"
@@ -145,6 +205,7 @@ const DesktopNav = ({ visible }: NavbarProps) => {
 // ─── Mobile nav ────────────────────────────────────────────────────────────
 const MobileNav = ({ visible }: NavbarProps) => {
   const [open, setOpen] = useState(false);
+  const [resourcesOpen, setResourcesOpen] = useState(false);
   const isActive = useIsActivePath();
   return (
     <motion.div
@@ -217,6 +278,50 @@ const MobileNav = ({ visible }: NavbarProps) => {
             >
               For Service Businesses
             </Link>
+            {/* Resources accordion */}
+            <div className="w-full">
+              <button
+                type="button"
+                onClick={() => setResourcesOpen((v) => !v)}
+                className="w-full flex items-center justify-between px-3 py-2.5 rounded-xl text-cream/90 hover:bg-wine/10 transition-colors text-sm font-medium"
+              >
+                Resources
+                <IconChevronDown
+                  size={14}
+                  className={cn(
+                    "transition-transform duration-200",
+                    resourcesOpen ? "rotate-180" : "rotate-0"
+                  )}
+                />
+              </button>
+              <AnimatePresence>
+                {resourcesOpen && (
+                  <motion.div
+                    initial={{ opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: "auto" }}
+                    exit={{ opacity: 0, height: 0 }}
+                    transition={{ duration: 0.18 }}
+                    className="overflow-hidden pl-3"
+                  >
+                    {RESOURCES_LINKS.map((link) => (
+                      <Link
+                        key={link.href}
+                        href={link.href}
+                        onClick={() => setOpen(false)}
+                        className="flex flex-col px-3 py-2 rounded-xl hover:bg-wine/10 transition-colors"
+                      >
+                        <span className="text-sm text-cream/85">
+                          {link.name}
+                        </span>
+                        <span className="text-[11px] text-cream/50">
+                          {link.description}
+                        </span>
+                      </Link>
+                    ))}
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
             {/* Pricing */}
             <Link
               href="/pricing"

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { cn } from "@/lib/utils";
-import { IconMenu2, IconX, IconChevronDown } from "@tabler/icons-react";
+import { IconMenu2, IconX } from "@tabler/icons-react";
 import {
   motion,
   AnimatePresence,
@@ -14,33 +14,6 @@ import { Button } from "./button";
 import { Logo } from "./logo";
 import { trackAuditCtaClick } from "@/lib/analytics";
 import { useMediaQuery } from "@/hooks/use-media-query";
-// ─── Systems dropdown links ───────────────────────────────────────────────────
-const SYSTEMS_LINKS = [
-  { name: "Systems Overview", href: "/systems", description: "The full operations platform" },
-  { name: "Agents", href: "/agents", description: "Noell Support, Front Desk & Care" },
-];
-// ─── Platform dropdown links ───────────────────────────────────────────────────
-const PLATFORM_LINKS = [
-  {
-    name: "Lead Intelligence Dashboard",
-    href: "/platform/lead-intelligence",
-    description: "Live leads, conversations, and conversion funnel",
-    external: false,
-  },
-  {
-    name: "ROI Calculator",
-    href: "/roi",
-    description: "Estimate your missed revenue",
-    external: false,
-  },
-];
-// ─── Resources dropdown links ──────────────────────────────────────────────────
-const RESOURCES_LINKS = [
-  { name: "Case Studies", href: "/case-studies", description: "Real results from real clients" },
-  { name: "Compare", href: "/compare", description: "How we stack up against alternatives" },
-  { name: "ROI Calculator", href: "/roi", description: "Estimate your missed revenue" },
-];
-type DropdownKey = "systems" | "platform" | "resources" | null;
 interface NavbarProps {
   visible: boolean;
 }
@@ -77,14 +50,12 @@ export const Navbar = () => {
 };
 // ─── Desktop nav ────────────────────────────────────────────────────────────
 const DesktopNav = ({ visible }: NavbarProps) => {
-  const [openDropdown, setOpenDropdown] = useState<DropdownKey>(null);
   const isActive = useIsActivePath();
   // Below 2xl the full item row plus the CTA button needs more of the
   // viewport, otherwise nav items collide with the button around 1450px.
   const isWide = useMediaQuery("(min-width: 1536px)");
   return (
     <motion.div
-      onMouseLeave={() => setOpenDropdown(null)}
       animate={{
         width: visible ? (isWide ? "70%" : "85%") : (isWide ? "88%" : "96%"),
         backgroundColor: visible
@@ -117,193 +88,6 @@ const DesktopNav = ({ visible }: NavbarProps) => {
         >
           For Service Businesses
         </Link>
-        {/* Systems dropdown */}
-        <div
-          className="relative"
-          onMouseEnter={() => setOpenDropdown("systems")}
-        >
-          <button
-            type="button"
-            onClick={() =>
-              setOpenDropdown(openDropdown === "systems" ? null : "systems")
-            }
-            className={cn(
-              "flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium transition-colors",
-              openDropdown === "systems"
-                ? "text-wine bg-wine/15"
-                : "text-cream/80 hover:text-cream hover:bg-wine/10"
-            )}
-          >
-            Systems
-            <IconChevronDown
-              size={13}
-              className={cn(
-                "transition-transform duration-200",
-                openDropdown === "systems" ? "rotate-180" : "rotate-0"
-              )}
-            />
-          </button>
-          <AnimatePresence>
-            {openDropdown === "systems" && (
-              <motion.div
-                initial={{ opacity: 0, y: 8, scale: 0.97 }}
-                animate={{ opacity: 1, y: 0, scale: 1 }}
-                exit={{ opacity: 0, y: 8, scale: 0.97 }}
-                transition={{ duration: 0.18, ease: "easeOut" }}
-                onMouseLeave={() => setOpenDropdown(null)}
-                className="absolute top-full left-1/2 -translate-x-1/2 mt-3 w-72 rounded-2xl border border-white/10 bg-[#1F1219]/98 backdrop-blur-xl shadow-[0_20px_40px_-10px_rgba(28,25,23,0.12)] p-2 z-50"
-              >
-                {SYSTEMS_LINKS.map((link) => (
-                  <Link
-                    key={link.href}
-                    href={link.href}
-                    onClick={() => setOpenDropdown(null)}
-                    className="flex flex-col px-3.5 py-2.5 rounded-xl hover:bg-wine/10 transition-colors group"
-                  >
-                    <span className="text-sm font-medium text-cream group-hover:text-wine transition-colors">
-                      {link.name}
-                    </span>
-                    <span className="text-[11px] text-cream/55 mt-0.5">
-                      {link.description}
-                    </span>
-                  </Link>
-                ))}
-              </motion.div>
-            )}
-          </AnimatePresence>
-        </div>
-        {/* Platform dropdown */}
-        <div
-          className="relative"
-          onMouseEnter={() => setOpenDropdown("platform")}
-        >
-          <button
-            type="button"
-            onClick={() =>
-              setOpenDropdown(openDropdown === "platform" ? null : "platform")
-            }
-            className={cn(
-              "flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium transition-colors",
-              openDropdown === "platform"
-                ? "text-wine bg-wine/15"
-                : "text-cream/80 hover:text-cream hover:bg-wine/10"
-            )}
-          >
-            Platform
-            <IconChevronDown
-              size={13}
-              className={cn(
-                "transition-transform duration-200",
-                openDropdown === "platform" ? "rotate-180" : "rotate-0"
-              )}
-            />
-          </button>
-          <AnimatePresence>
-            {openDropdown === "platform" && (
-              <motion.div
-                initial={{ opacity: 0, y: 8, scale: 0.97 }}
-                animate={{ opacity: 1, y: 0, scale: 1 }}
-                exit={{ opacity: 0, y: 8, scale: 0.97 }}
-                transition={{ duration: 0.18, ease: "easeOut" }}
-                onMouseLeave={() => setOpenDropdown(null)}
-                className="absolute top-full left-1/2 -translate-x-1/2 mt-3 w-80 rounded-2xl border border-white/10 bg-[#1F1219]/98 backdrop-blur-xl shadow-[0_20px_40px_-10px_rgba(28,25,23,0.12)] p-2 z-50"
-              >
-                <p className="px-3.5 pt-1.5 pb-2 text-[10px] uppercase tracking-[0.2em] text-cream/40 font-medium">
-                  Platform previews
-                </p>
-                {PLATFORM_LINKS.map((link) => (
-                  link.external ? (
-                    <a
-                      key={link.href}
-                      href={link.href}
-                      target="_blank"
-                      rel="noopener noreferrer nofollow"
-                      onClick={() => setOpenDropdown(null)}
-                      className="flex flex-col px-3.5 py-2.5 rounded-xl hover:bg-wine/10 transition-colors group"
-                    >
-                      <span className="text-sm font-medium text-cream group-hover:text-wine transition-colors flex items-center gap-1.5">
-                        {link.name}
-                        <span className="text-[9px] uppercase tracking-wider bg-wine/10 text-wine px-1.5 py-0.5 rounded-full font-semibold">Live</span>
-                      </span>
-                      <span className="text-[11px] text-cream/55 mt-0.5">
-                        {link.description}
-                      </span>
-                    </a>
-                  ) : (
-                    <Link
-                      key={link.href}
-                      href={link.href}
-                      onClick={() => setOpenDropdown(null)}
-                      className="flex flex-col px-3.5 py-2.5 rounded-xl hover:bg-wine/10 transition-colors group"
-                    >
-                      <span className="text-sm font-medium text-cream group-hover:text-wine transition-colors">
-                        {link.name}
-                      </span>
-                      <span className="text-[11px] text-cream/55 mt-0.5">
-                        {link.description}
-                      </span>
-                    </Link>
-                  )
-                ))}
-              </motion.div>
-            )}
-          </AnimatePresence>
-        </div>
-        {/* Resources dropdown */}
-        <div
-          className="relative"
-          onMouseEnter={() => setOpenDropdown("resources")}
-        >
-          <button
-            type="button"
-            onClick={() =>
-              setOpenDropdown(openDropdown === "resources" ? null : "resources")
-            }
-            className={cn(
-              "flex items-center gap-1 px-3 py-1.5 rounded-full text-sm font-medium transition-colors",
-              openDropdown === "resources"
-                ? "text-wine bg-wine/15"
-                : "text-cream/80 hover:text-cream hover:bg-wine/10"
-            )}
-          >
-            Resources
-            <IconChevronDown
-              size={13}
-              className={cn(
-                "transition-transform duration-200",
-                openDropdown === "resources" ? "rotate-180" : "rotate-0"
-              )}
-            />
-          </button>
-          <AnimatePresence>
-            {openDropdown === "resources" && (
-              <motion.div
-                initial={{ opacity: 0, y: 8, scale: 0.97 }}
-                animate={{ opacity: 1, y: 0, scale: 1 }}
-                exit={{ opacity: 0, y: 8, scale: 0.97 }}
-                transition={{ duration: 0.18, ease: "easeOut" }}
-                onMouseLeave={() => setOpenDropdown(null)}
-                className="absolute top-full left-1/2 -translate-x-1/2 mt-3 w-72 rounded-2xl border border-white/10 bg-[#1F1219]/98 backdrop-blur-xl shadow-[0_20px_40px_-10px_rgba(28,25,23,0.12)] p-2 z-50"
-              >
-                {RESOURCES_LINKS.map((link) => (
-                  <Link
-                    key={link.href}
-                    href={link.href}
-                    onClick={() => setOpenDropdown(null)}
-                    className="flex flex-col px-3.5 py-2.5 rounded-xl hover:bg-wine/10 transition-colors group"
-                  >
-                    <span className="text-sm font-medium text-cream group-hover:text-wine transition-colors">
-                      {link.name}
-                    </span>
-                    <span className="text-[11px] text-cream/55 mt-0.5">
-                      {link.description}
-                    </span>
-                  </Link>
-                ))}
-              </motion.div>
-            )}
-          </AnimatePresence>
-        </div>
         {/* Pricing */}
         <Link
           href="/pricing"
@@ -361,11 +145,7 @@ const DesktopNav = ({ visible }: NavbarProps) => {
 // ─── Mobile nav ────────────────────────────────────────────────────────────
 const MobileNav = ({ visible }: NavbarProps) => {
   const [open, setOpen] = useState(false);
-  const [openSection, setOpenSection] = useState<DropdownKey>(null);
   const isActive = useIsActivePath();
-  const toggleSection = (key: "systems" | "platform" | "resources") => {
-    setOpenSection((prev) => (prev === key ? null : key));
-  };
   return (
     <motion.div
       animate={{
@@ -424,11 +204,7 @@ const MobileNav = ({ visible }: NavbarProps) => {
             aria-label="Mobile navigation"
             className="flex rounded-2xl absolute top-16 backdrop-blur-xl bg-[#1F1219]/95 inset-x-0 z-50 flex-col items-start justify-start gap-1 w-full px-4 py-4 shadow-lg border border-white/10/40"
           >
-            {/* Track separator label */}
-            <p className="w-full px-3 pt-1 pb-0.5 text-[10px] uppercase tracking-[0.2em] text-cream/35 font-medium">
-              Who we help
-            </p>
-            {/* For Service Businesses — primary track */}
+            {/* For Service Businesses */}
             <Link
               href="/for-service-businesses"
               onClick={() => setOpen(false)}
@@ -441,158 +217,6 @@ const MobileNav = ({ visible }: NavbarProps) => {
             >
               For Service Businesses
             </Link>
-            <div className="w-full h-px bg-white/8 my-1" />
-            {/* Systems accordion */}
-            <div className="w-full">
-              <button
-                type="button"
-                onClick={() => toggleSection("systems")}
-                className="w-full flex items-center justify-between px-3 py-2.5 rounded-xl text-cream/90 hover:bg-wine/10 transition-colors text-sm font-medium"
-              >
-                Systems
-                <IconChevronDown
-                  size={14}
-                  className={cn(
-                    "transition-transform duration-200",
-                    openSection === "systems" ? "rotate-180" : "rotate-0"
-                  )}
-                />
-              </button>
-              <AnimatePresence>
-                {openSection === "systems" && (
-                  <motion.div
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: "auto" }}
-                    exit={{ opacity: 0, height: 0 }}
-                    transition={{ duration: 0.18 }}
-                    className="overflow-hidden pl-3"
-                  >
-                    {SYSTEMS_LINKS.map((link) => (
-                      <Link
-                        key={link.href}
-                        href={link.href}
-                        onClick={() => setOpen(false)}
-                        className="flex flex-col px-3 py-2 rounded-xl hover:bg-wine/10 transition-colors"
-                      >
-                        <span className="text-sm text-cream/85">
-                          {link.name}
-                        </span>
-                        <span className="text-[11px] text-cream/50">
-                          {link.description}
-                        </span>
-                      </Link>
-                    ))}
-                  </motion.div>
-                )}
-              </AnimatePresence>
-            </div>
-            {/* Platform accordion */}
-            <div className="w-full">
-              <button
-                type="button"
-                onClick={() => toggleSection("platform")}
-                className="w-full flex items-center justify-between px-3 py-2.5 rounded-xl text-cream/90 hover:bg-wine/10 transition-colors text-sm font-medium"
-              >
-                Platform
-                <IconChevronDown
-                  size={14}
-                  className={cn(
-                    "transition-transform duration-200",
-                    openSection === "platform" ? "rotate-180" : "rotate-0"
-                  )}
-                />
-              </button>
-              <AnimatePresence>
-                {openSection === "platform" && (
-                  <motion.div
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: "auto" }}
-                    exit={{ opacity: 0, height: 0 }}
-                    transition={{ duration: 0.18 }}
-                    className="overflow-hidden pl-3"
-                  >
-                    {PLATFORM_LINKS.map((link) => (
-                      link.external ? (
-                        <a
-                          key={link.href}
-                          href={link.href}
-                          target="_blank"
-                          rel="noopener noreferrer nofollow"
-                          onClick={() => setOpen(false)}
-                          className="flex flex-col px-3 py-2 rounded-xl hover:bg-wine/10 transition-colors"
-                        >
-                          <span className="text-sm text-cream/85 flex items-center gap-1.5">
-                            {link.name}
-                            <span className="text-[9px] uppercase tracking-wider bg-wine/10 text-wine px-1.5 py-0.5 rounded-full font-semibold">Live</span>
-                          </span>
-                          <span className="text-[11px] text-cream/50">
-                            {link.description}
-                          </span>
-                        </a>
-                      ) : (
-                        <Link
-                          key={link.href}
-                          href={link.href}
-                          onClick={() => setOpen(false)}
-                          className="flex flex-col px-3 py-2 rounded-xl hover:bg-wine/10 transition-colors"
-                        >
-                          <span className="text-sm text-cream/85">
-                            {link.name}
-                          </span>
-                          <span className="text-[11px] text-cream/50">
-                            {link.description}
-                          </span>
-                        </Link>
-                      )
-                    ))}
-                  </motion.div>
-                )}
-              </AnimatePresence>
-            </div>
-            {/* Resources accordion */}
-            <div className="w-full">
-              <button
-                type="button"
-                onClick={() => toggleSection("resources")}
-                className="w-full flex items-center justify-between px-3 py-2.5 rounded-xl text-cream/90 hover:bg-wine/10 transition-colors text-sm font-medium"
-              >
-                Resources
-                <IconChevronDown
-                  size={14}
-                  className={cn(
-                    "transition-transform duration-200",
-                    openSection === "resources" ? "rotate-180" : "rotate-0"
-                  )}
-                />
-              </button>
-              <AnimatePresence>
-                {openSection === "resources" && (
-                  <motion.div
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: "auto" }}
-                    exit={{ opacity: 0, height: 0 }}
-                    transition={{ duration: 0.18 }}
-                    className="overflow-hidden pl-3"
-                  >
-                    {RESOURCES_LINKS.map((link) => (
-                      <Link
-                        key={link.href}
-                        href={link.href}
-                        onClick={() => setOpen(false)}
-                        className="flex flex-col px-3 py-2 rounded-xl hover:bg-wine/10 transition-colors"
-                      >
-                        <span className="text-sm text-cream/85">
-                          {link.name}
-                        </span>
-                        <span className="text-[11px] text-cream/50">
-                          {link.description}
-                        </span>
-                      </Link>
-                    ))}
-                  </motion.div>
-                )}
-              </AnimatePresence>
-            </div>
             {/* Pricing */}
             <Link
               href="/pricing"

--- a/src/components/proof-bar.tsx
+++ b/src/components/proof-bar.tsx
@@ -18,7 +18,7 @@ const recoveryScenes: RecoveryRow[][] = [
   [
     { time: "09:14", action: "missed-call-recovery", sep: "·", result: "triggered" },
     { time: "09:14", action: "auto-reply sent", sep: "·", result: "lead engaged" },
-    { time: "09:17", action: "appointment confirmed", sep: "·", result: "$960 recovered" },
+    { time: "09:17", action: "appointment confirmed", sep: "·", result: "$2,560 recovered" },
   ],
   [
     { time: "14:22", action: "web-chat opened", sep: "·", result: "qualified" },

--- a/src/components/revenue-calculator.tsx
+++ b/src/components/revenue-calculator.tsx
@@ -334,7 +334,7 @@ export function RevenueCalculator() {
           {/* Assumption note */}
           <p className="text-[11px] text-cream/50 leading-relaxed mb-6">
             Model assumes +21.5% booking conversion lift and 67.5% no-show reduction (midpoints of verified ranges).
-            Healing Hands by Santa saw 75% no-show reduction and $960 recovered in 14 days.
+            Healing Hands by Santa saw 75% no-show reduction and $2,560 recovered in 30 days.
             Your results depend on lead volume, timing, and existing workflow.
           </p>
 

--- a/src/components/santa-proof-block.tsx
+++ b/src/components/santa-proof-block.tsx
@@ -29,8 +29,8 @@ export function SantaProofBlock({ className }: SantaProofBlockProps) {
             <p className="text-[11px] text-cream/70 mt-1 uppercase tracking-wide">missed calls<br/>recovered</p>
           </div>
           <div className="text-center">
-            <p className="font-serif text-3xl md:text-4xl font-semibold text-wine">$960</p>
-            <p className="text-[11px] text-cream/70 mt-1 uppercase tracking-wide">recovered<br/>in 14 days</p>
+            <p className="font-serif text-3xl md:text-4xl font-semibold text-wine">$2,560</p>
+            <p className="text-[11px] text-cream/70 mt-1 uppercase tracking-wide">recovered<br/>in 30 days</p>
           </div>
           <div className="text-center">
             <p className="font-serif text-3xl md:text-4xl font-semibold text-wine">75%</p>

--- a/src/components/systems.tsx
+++ b/src/components/systems.tsx
@@ -5,42 +5,34 @@ import { IconBolt, IconPhoneCall, IconHeartHandshake } from "@tabler/icons-react
 
 interface AgentCard {
   title: string;
-  handle: string;
-  eyebrow: string;
+  slug: string;
   description: string;
-  uptime: string;
   href: string;
   icon: React.ReactNode;
 }
 
 const agents: AgentCard[] = [
   {
-    title: "Noell Support",
-    handle: "@noell_support",
-    eyebrow: "New prospect intake",
+    title: "Answers your phone",
+    slug: "front-desk",
     description:
-      "Website chat, lead qualification, contact capture, and triage to booking or your team.",
-    uptime: "status: online / 24/7",
-    href: "/noell-support",
-    icon: <IconBolt size={22} />,
-  },
-  {
-    title: "Noell Front Desk",
-    handle: "@noell_frontdesk",
-    eyebrow: "Operations layer",
-    description:
-      "Calls, scheduling, reminders, confirmations, reschedules, review capture, reactivation, and everything a receptionist handles.",
-    uptime: "status: online / runs during hours",
+      "Picks up every call, day or night. Books the appointment, answers the common questions, and never sends a new client to voicemail.",
     href: "/noell-front-desk",
     icon: <IconPhoneCall size={22} />,
   },
   {
-    title: "Noell Care",
-    handle: "@noell_care",
-    eyebrow: "Existing client support",
+    title: "Texts back missed calls",
+    slug: "support",
     description:
-      "Rebooking, service questions, account help, and support for clients already in your system. Keeps your front desk clear for new business.",
-    uptime: "status: online / existing clients",
+      "The moment a call goes unanswered, it texts the caller back within seconds with real open times, so they book with you instead of the next business on Google.",
+    href: "/noell-support",
+    icon: <IconBolt size={22} />,
+  },
+  {
+    title: "Follows up and fills cancellations",
+    slug: "care",
+    description:
+      "Reminds clients so they actually show up, reactivates the ones who drifted, and fills last-minute cancellations from your existing client list.",
     href: "/noell-care",
     icon: <IconHeartHandshake size={22} />,
   },
@@ -51,22 +43,19 @@ export function Systems() {
     <section id="systems" className="w-full py-20 md:py-28 px-4">
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-14 max-w-3xl mx-auto">
-          <div className="flex items-center justify-center gap-2 mb-4">
-            <span className="inline-block w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
-            <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-muted-strong">
-              the noell system / agent roster
-            </p>
-          </div>
+          <p className="text-[11px] uppercase tracking-[0.28em] text-muted-strong mb-4">
+            What the system does for you
+          </p>
           <h2 className="font-serif text-3xl md:text-5xl font-semibold text-cream leading-tight">
-            Three agents. One system.{" "}
+            Three jobs, handled.{" "}
             <span className="italic bg-gradient-to-b from-wine to-wine-light bg-clip-text text-transparent">
               Zero setup on your end.
             </span>
           </h2>
           <p className="mt-5 text-cream/75 max-w-2xl mx-auto leading-relaxed">
-            Your leads get qualified instantly. Your phone gets answered. Your
-            clients get taken care of. All running in the background while you
-            work. Start with the layer you need. Expand when you are ready.
+            Your phone gets answered. Missed calls get texted back. Your clients
+            get followed up with. All running in the background while you work.
+            Start with the part you need. Add more when you are ready.
           </p>
         </div>
 
@@ -78,7 +67,7 @@ export function Systems() {
               data-event="systems_grid_click"
               data-source-page="home"
               data-source-section="systems_grid"
-              data-agent={agent.handle.replace(/^@/, "")}
+              data-agent={agent.slug}
               className={cn(
                 "group relative rounded-[22px] border border-wine/20 bg-[#271520] shadow-[0_0_0_1px_rgba(139,42,66,0.10),0_8px_32px_rgba(139,42,66,0.06)]",
                 "p-7 md:p-8 transition-all duration-200",
@@ -86,33 +75,16 @@ export function Systems() {
                 "hover:-translate-y-1 hover:shadow-[0px_44px_24px_0px_rgba(28,25,23,0.06),0px_18px_18px_0px_rgba(28,25,23,0.08),0px_6px_10px_0px_rgba(28,25,23,0.06)]"
               )}
             >
-              <div className="flex items-center justify-between mb-6">
-                <div className="w-12 h-12 rounded-xl bg-wine/10 text-wine flex items-center justify-center">
-                  {agent.icon}
-                </div>
-                <div className="flex items-center gap-1.5">
-                  <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
-                  <span className="text-[10px] font-mono text-cream/70">
-                    0{index + 1}
-                  </span>
-                </div>
+              <div className="w-12 h-12 rounded-xl bg-wine/10 text-wine flex items-center justify-center mb-6">
+                {agent.icon}
               </div>
-              <p className="text-[11px] uppercase tracking-[0.2em] text-cream/60 mb-1">
-                {agent.eyebrow}
-              </p>
-              <h3 className="font-serif text-2xl font-semibold text-cream mb-1">
+              <h3 className="font-serif text-2xl font-semibold text-cream mb-3">
                 {agent.title}
               </h3>
-              <p className="font-mono text-[10px] text-cream/70 mb-3">
-                {agent.handle}
-              </p>
               <p className="text-sm text-cream/80 leading-relaxed">
                 {agent.description}
               </p>
-              <div className="mt-6 pt-4 border-t border-white/10 flex items-center justify-between">
-                <p className="font-mono text-[10px] uppercase tracking-widest text-cream/60">
-                  {agent.uptime}
-                </p>
+              <div className="mt-6 pt-4 border-t border-white/10 flex items-center justify-end">
                 <p className="text-xs text-[#C45A2A] font-medium group-hover:text-[#D96B38] transition-colors">
                   Learn more &rarr;
                 </p>

--- a/src/components/upgrade-page-client.tsx
+++ b/src/components/upgrade-page-client.tsx
@@ -140,7 +140,7 @@ const TESTIMONIALS = [
     quote: "I used to dread Mondays because there would always be gaps I didn't expect. Now I open my calendar and it's just full. The reminders go out and people show up. I don't think about it anymore.",
     author: "Santa E.",
     role: "Licensed Massage Therapist · Laguna Niguel, CA",
-    result: "$960 recovered in 14 days",
+    result: "$2,560 recovered in 30 days",
   },
   {
     quote: "We tried Rosie first. It was fine for answering calls but we couldn't get it to connect to our booking software the way we needed. Ops by Noell had it wired in a week and we haven't touched it since.",

--- a/src/components/vertical-case-study.tsx
+++ b/src/components/vertical-case-study.tsx
@@ -66,7 +66,7 @@ export function VerticalCaseStudyPlaceholder({ vertical }: PlaceholderProps) {
         </div>
         <div className="flex gap-8 flex-wrap">
           <div>
-            <div className="font-serif text-2xl text-cream">$960</div>
+            <div className="font-serif text-2xl text-cream">$2,560</div>
             <div className="text-xs uppercase tracking-wider text-cream/70">
               Recovered in first month
             </div>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -105,7 +105,8 @@ export type SourceSection =
   | "offer"
   | "final"
   | "calculator_results"
-  | "calculator_lead_form";
+  | "calculator_lead_form"
+  | "sticky_mobile";
 
 /**
  * The canonical conversion events. Narrow set on purpose — each has a


### PR DESCRIPTION
Implements the new hero and conversion fixes on the service-business landing experience (homepage `/`), the destination for the cold-email campaign to dental/med-spa/salon owners. **B2B pages were not restructured.**

## What changed

**1. Hero copy (`src/app/page.tsx`, `src/components/hero.tsx`)**
- Eyebrow → "For local practices and solo operators who can't catch every call"
- Headline → "While you're with a client, who's picking up?"
- Sub-headline → the new "We build and run an AI front desk… recovered $2,560 in 30 days. Done for you. Live in 14 days."
- Three-question agitation line below the sub-headline ("Who's answering the phone? Who's following up on every missed call? Who's there after you close?")
- CTA microcopy → "Free. No pitch. If we can't find recoverable revenue, we'll tell you."
- Hero proof bar turned **on**

**2. Removed fabricated number** — hero mockup `$4,200 / 6 missed inquiries` → real `$2,560 / recovered missed calls · 30 days`.

**3. Single CTA** — removed the secondary "See How It Works → /systems" hero CTA. `Hero` now accepts `secondaryCta={null}`.

**4. Stripped B2B from the service path** — removed the "Two types of business" audience split (incl. Predictive Customer Intelligence / Platform / ICP copy), and the B2B mentions in the homepage FAQ and service schema. Renamed the three Systems agents to plain outcomes ("Answers your phone," "Texts back missed calls," "Follows up and fills cancellations") and dropped the `@handle` / `status:online` / monospace styling.

**5. Persistent CTAs (`navbar.tsx`, `book-sticky-mobile-cta.tsx`)** — desktop navbar book button now appears **on** scroll (was: disappeared on scroll). Sticky mobile bar generalized with an `href` mode and wired onto the homepage; added a `sticky_mobile` analytics source section.

**6. Figure consistency** — `$960 / 14 days` → `$2,560 / 30 days` across all rendered service pages and components (case study, proof blocks, ROI/revenue copy, pricing/book/thank-you proof, verticals/massage, compare, features, llms.txt). The case study keeps `$1,060 in the first 14 days` as a secondary milestone. The install timeline "Live in 14 days" was preserved everywhere.

**7. Booking conversion tracking** — `trackBookingConfirmed` and its `/book/thanks` + postMessage wiring are unchanged and intact.

## Notes / decisions for review
- **B2B page exception:** the B2B `predictive-customer-intelligence` page still says `$960 / 14 days` (two spots). Left untouched per "do not touch the B2B pages" — flag if you want it updated for consistency.
- **`4 missed calls` stat** is kept next to `$2,560 / 30 days` on the homepage/proof blocks (the 4 calls were the first-14-day count; more came in days 15–30). No call counts were invented.
- Pre-existing `react/no-unescaped-entities` lint debt exists across the site (unrelated quote lines); I only fixed the one instance inside `hero.tsx` that I was touching. No new lint errors introduced.

https://claude.ai/code/session_01T4JrPL6dJFTmi8trrjGYCo

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4JrPL6dJFTmi8trrjGYCo)_