### PR TITLE
Update stale PCI figure to $2,560/30 days; resurface Predictive Intelligence for service businesses

### DIFF
--- a/src/app/predictive-customer-intelligence/page.tsx
+++ b/src/app/predictive-customer-intelligence/page.tsx
@@ -770,7 +770,7 @@ export default function PredictiveCustomerIntelligencePage() {
         headlineLine2Accent="gap."
         headlineLine2Smaller
         body="Ops by Noell watches your leads, clients, rebooking patterns, and service history for revenue signals your booking software does not surface. When a signal fires, the right recovery action is queued for your agents."
-        footnote="The same system recovered $960 in 14 days for a solo massage practice in Orange County."
+        footnote="The same system recovered $2,560 in 30 days for a solo massage practice in Orange County."
         primaryCta={{ label: "Get Your Free Missed Call Audit", href: "/book" }}
         secondaryCta={{ label: "See a Sample Signal", href: "#sample-signal" }}
         showProofBar={false}
@@ -806,7 +806,7 @@ export default function PredictiveCustomerIntelligencePage() {
         eyebrow="Proof"
         headlineStart="The first proof came from a"
         headlineAccent="solo practice."
-        body="Healing Hands by Santa recovered $960 in 14 days after Ops by Noell caught missed-call and booking-flow leakage. The next step is turning that same recovery logic into Missed Call Audits for every service business vertical we serve."
+        body="Healing Hands by Santa recovered $2,560 in 30 days after Ops by Noell caught missed-call and booking-flow leakage. The next step is turning that same recovery logic into Missed Call Audits for every service business vertical we serve."
         ctaLabel="Get your Missed Call Audit"
         sourcePage={SOURCE_PAGE}
         sourceSection="proof"

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -16,6 +16,7 @@ export function Footer() {
     { title: "Noell Support", href: "/noell-support" },
     { title: "Noell Front Desk", href: "/noell-front-desk" },
     { title: "Noell Care", href: "/noell-care" },
+    { title: "Predictive Customer Intelligence", href: "/predictive-customer-intelligence" },
     { title: "For Service Businesses", href: "/for-service-businesses" },
     { title: "Upgrade Your AI Tool", href: "/upgrade" },
   ];

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -16,6 +16,7 @@ import { trackAuditCtaClick } from "@/lib/analytics";
 import { useMediaQuery } from "@/hooks/use-media-query";
 // ─── Resources dropdown links ──────────────────────────────────────────────────
 const RESOURCES_LINKS = [
+  { name: "Predictive Intelligence", href: "/predictive-customer-intelligence", description: "Spot clients before they ghost" },
   { name: "Case Studies", href: "/case-studies", description: "Real results from real clients" },
   { name: "Compare", href: "/compare", description: "How we stack up against alternatives" },
   { name: "ROI Calculator", href: "/roi", description: "Estimate your missed revenue" },


### PR DESCRIPTION
Follow-up to #96.

The Predictive Customer Intelligence page is **already framed for service businesses** — its metadata says "Predictive client intelligence for service businesses," its proof is the Santa massage practice, and its case scenario is client re-activation (not B2B). It shouldn't have been treated as B2B-only / hidden.

## Changes
- **Figure consistency:** updated the two stale `$960 / 14 days` references on the PCI page to the site-wide `$2,560 / 30 days`. There is now **no `$960` left anywhere on the site**.
- **Resurface PCI for the service audience:**
  - Added **Predictive Intelligence** to the nav **Resources** dropdown ("Spot clients before they ghost") — desktop + mobile.
  - Added **Predictive Customer Intelligence** back to the footer **Service Track** column.

## Verified
- PCI page renders (HTTP 200, no error boundary) and shows `$2,560`, no `$960`.
- Resources dropdown shows Predictive Intelligence; site-wide `$960` grep is empty.
- Lint clean on all three changed files.

No B2B page content/structure was restructured — only the figure and discoverability links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4JrPL6dJFTmi8trrjGYCo)_