### PR TITLE
Prototype: refined mobile hero (star trust badge + text-back visual)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { Hero } from "@/components/hero";
 import { BookingCalendarEmbed } from "@/components/booking-calendar-embed";
 import { StickyMobileBookCta } from "@/components/book-sticky-mobile-cta";
+import { TextbackCard } from "@/components/textback-card";
 import { Systems } from "@/components/systems";
 import { FAQ, type FaqItem } from "@/components/faq";
 import { JsonLd } from "@/components/json-ld";
@@ -84,7 +85,8 @@ export default function Home() {
         headlineLine2Smaller={false}
         body="We build and run an AI front desk that answers and follows up on every call, day or night. Done for you. Live in 14 days."
         footnote=""
-        proofBadge="$2,560 recovered in 30 days · Laguna Niguel"
+        proofBadge="$2,560 recovered in 30 days for a Laguna Niguel practice"
+        mobileVisual={<TextbackCard />}
         primaryCta={{ label: "Get Your Free Missed Call Audit", href: "/book" }}
         secondaryCta={null}
         showProofBar={true}

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -32,6 +32,7 @@ export function Hero({
   proofBadge,
   pinnedProof = false,
   calmMobile = false,
+  mobileVisual,
   sourcePage = "home",
   sourceSection = "hero",
 }: {
@@ -59,6 +60,8 @@ export function Hero({
   /** On mobile, hide the proof bar, phone mockup, and background decor for a
       calm, centered single-column hero (desktop unchanged). */
   calmMobile?: boolean;
+  /** A single clean visual shown only on mobile (e.g. a text-back card). */
+  mobileVisual?: React.ReactNode;
   sourcePage?: SourcePage;
   sourceSection?: SourceSection;
 }) {
@@ -159,9 +162,15 @@ export function Hero({
       </div>
 
       {proofBadge && (
-        <div className="md:hidden relative z-20 mb-5 mt-1 flex justify-center px-4">
-          <span className="inline-flex items-center gap-2 rounded-full border border-wine/40 bg-wine/15 px-3.5 py-1.5 text-[13px] font-medium text-cream text-center">
-            <span className="w-1.5 h-1.5 rounded-full bg-[#C45A2A] flex-shrink-0" />
+        <div className="md:hidden relative z-20 mb-6 mt-1 flex flex-col items-center gap-2 px-4">
+          <div className="flex items-center gap-1" aria-hidden="true">
+            {[0, 1, 2, 3, 4].map((s) => (
+              <svg key={s} className="w-4 h-4 text-[#E0A43B]" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+              </svg>
+            ))}
+          </div>
+          <span className="text-[13px] font-medium text-cream/90 text-center leading-snug">
             {proofBadge}
           </span>
         </div>
@@ -220,6 +229,12 @@ export function Hero({
       {priceSignal && (
         <div className="relative z-20 -mt-1 mb-8 text-center text-sm text-cream/70 px-4">
           {priceSignal}
+        </div>
+      )}
+
+      {mobileVisual && (
+        <div className="md:hidden relative z-20 w-full px-4 mb-10">
+          {mobileVisual}
         </div>
       )}
 

--- a/src/components/textback-card.tsx
+++ b/src/components/textback-card.tsx
@@ -1,0 +1,40 @@
+/**
+ * A single clean "missed call → instant text-back → booked" visual for the
+ * mobile hero. One calm card (not the multi-card mockup), on-message with the
+ * missed-call recovery story.
+ */
+export function TextbackCard() {
+  return (
+    <div className="mx-auto w-full max-w-sm rounded-3xl border border-white/10 bg-[#241019]/90 backdrop-blur-sm p-4 shadow-[0_12px_40px_-12px_rgba(0,0,0,0.5)]">
+      <div className="flex items-center justify-between mb-3">
+        <span className="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-wider text-cream/55">
+          <span className="w-1.5 h-1.5 rounded-full bg-[#C45A2A]" />
+          Missed call · new client
+        </span>
+        <span className="text-[11px] text-cream/40">9:14 AM</span>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="self-start max-w-[82%] rounded-2xl rounded-bl-md bg-[#3a2230] px-3.5 py-2 text-[13px] leading-snug text-cream/90">
+          Hi, are you taking new clients?
+        </div>
+        <div className="self-end max-w-[88%] rounded-2xl rounded-br-md bg-gradient-to-b from-[#8B2A42] to-[#6B2D3E] px-3.5 py-2 text-[13px] leading-snug text-cream">
+          Hi! Sorry we missed you — I can get you in Tue 2pm or Wed 10am. Which
+          works?
+        </div>
+        <div className="self-start max-w-[82%] rounded-2xl rounded-bl-md bg-[#3a2230] px-3.5 py-2 text-[13px] leading-snug text-cream/90">
+          Tuesday 2pm, thank you!
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center gap-2 border-t border-white/10 pt-3">
+        <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full bg-[#C45A2A] text-[10px] font-bold text-white">
+          ✓
+        </span>
+        <span className="text-[12px] font-medium text-[#E0A43B]">
+          Booked in under a minute — while you were with a client.
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**Prototype for review — not for merge yet.** A mobile-only hero refresh toward a more premium, competitor-grade feel, based on the mobile-UX benchmark.

## What's in it
- **Refined trust badge:** replaces the plain proof pill with a **5-star rating + the named local result** ("$2,560 recovered in 30 days for a Laguna Niguel practice"). Star/rating badges are the most common mobile trust device in this category (Rosie, Dialpad, Podium, etc.).
- **One clean hero visual:** a "missed call → instant text-back → booked" message card (`mobileVisual` prop + new `TextbackCard`), so the hero has a visual instead of being all text — without the old multi-card clutter.
- Desktop is unchanged; everything is gated to mobile.

## Not included (need input)
- **Click-to-call/text:** there's no public phone number in the codebase (only internal Twilio numbers), so I didn't wire it. Give me a number and I'll add a "Call/Text us" option by the booking CTA.
- **Light theme:** kept the dark brand for this pass. The biggest open question from the benchmark is dark-vs-light — happy to mock a light hero next for contrast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4JrPL6dJFTmi8trrjGYCo)_